### PR TITLE
Cancel a new scope when its parent is already cancelled.

### DIFF
--- a/anyio/_backends/asyncio.py
+++ b/anyio/_backends/asyncio.py
@@ -402,6 +402,9 @@ class TaskGroup:
         task = current_task()
         try:
             await func(*args)
+        except CancelledError as exc:
+            await self.cancel_scope.cancel(exc.args[0])
+            raise
         except BaseException:
             await self.cancel_scope.cancel()
             raise

--- a/anyio/_backends/asyncio.py
+++ b/anyio/_backends/asyncio.py
@@ -249,11 +249,11 @@ class CancelScope:
         for child in self._children:
             child._sub_cancel(real_scope)
 
-    def _sub_cancel(self, scope):
+    def _sub_cancel(self, real_scope):
         if self.shield or self._cancel_called:
             return
 
-        self._cancel_called = scope
+        self._cancel_called = real_scope
 
         for task in self._tasks:
             if task._coro.cr_await is not None and not task._coro.cr_running:
@@ -264,7 +264,7 @@ class CancelScope:
                     task.cancel()
 
         for child in self._children:
-            child._sub_cancel(scope)
+            child._sub_cancel(real_scope)
 
     @property
     def deadline(self) -> float:

--- a/anyio/_backends/asyncio.py
+++ b/anyio/_backends/asyncio.py
@@ -198,6 +198,10 @@ class CancelScope:
             self._timeout_task = get_running_loop().create_task(timeout())
 
         self._active = True
+
+        if self._parent_scope is not None:
+            if self._parent_scope. _cancel_called and not self._shield:
+                await self.cancel()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/anyio/_backends/asyncio.py
+++ b/anyio/_backends/asyncio.py
@@ -218,24 +218,23 @@ class CancelScope:
             self._parent_scope._children.remove(self)
         set_cancel_scope(host_task, self._parent_scope)
 
-        if self._cancel_called:
-            self._cancel_called = id(self._cancel_called)  # avoid reference loops
-
         if isinstance(exc_val, asyncio.CancelledError):
             if self._timeout_expired:
                 return True
-            elif self._cancel_called in {id(self), self}:
+            elif self._cancel_called == id(self):
                 # This scope was directly cancelled
                 return True
         elif isinstance(exc_val, CancelledError):
-            return exc_val.args[0] is self
+            return exc_val.cause == id(self)
 
     async def cancel(self, real_scope=None):
         if self._cancel_called:
             return
 
         if real_scope is None:
-            real_scope = self
+            real_scope = id(self)
+        elif type(real_scope) is not int:
+            real_scope = id(real_scope)
         self._cancel_called = real_scope
 
         # Cancel any contained tasks
@@ -273,7 +272,7 @@ class CancelScope:
 
     @property
     def cancel_called(self) -> bool:
-        return self._cancel_called in {id(self), self}
+        return self._cancel_called == id(self)
 
     @property
     def shield(self) -> bool:
@@ -403,7 +402,7 @@ class TaskGroup:
         try:
             await func(*args)
         except CancelledError as exc:
-            await self.cancel_scope.cancel(exc.args[0])
+            await self.cancel_scope.cancel(exc.cause)
             raise
         except BaseException:
             await self.cancel_scope.cancel()

--- a/anyio/_backends/asyncio.py
+++ b/anyio/_backends/asyncio.py
@@ -224,8 +224,8 @@ class CancelScope:
         if isinstance(exc_val, asyncio.CancelledError):
             if self._timeout_expired:
                 return True
-            elif self._cancel_called:
-                # This scope was directly(?) cancelled
+            elif self._cancel_called in {id(self), self}:
+                # This scope was directly cancelled
                 return True
         elif isinstance(exc_val, CancelledError):
             return exc_val.args[0] is self

--- a/anyio/_backends/asyncio.py
+++ b/anyio/_backends/asyncio.py
@@ -166,17 +166,18 @@ async def sleep(delay: float) -> None:
 
 class CancelScope:
     __slots__ = ('_deadline', '_shield', '_parent_scope', '_cancel_called', '_active',
-                 '_timeout_task', '_tasks', '_timeout_expired')
+                 '_timeout_task', '_tasks', '_timeout_expired', '_children')
 
     def __init__(self, deadline: float = math.inf, shield: bool = False):
         self._deadline = deadline
         self._shield = shield
         self._parent_scope = None
-        self._cancel_called = False
+        self._cancel_called = None
         self._active = False
         self._timeout_task = None
         self._tasks = set()  # type: Set[asyncio.Task]
         self._timeout_expired = False
+        self._children = set()  # type: Set[CancelScope]
 
     async def __aenter__(self):
         async def timeout():
@@ -191,6 +192,8 @@ class CancelScope:
 
         host_task = current_task()
         self._parent_scope = get_cancel_scope(host_task)
+        if self._parent_scope is not None:
+            self._parent_scope._children.add(self)
         self._tasks.add(host_task)
         set_cancel_scope(host_task, self)
 
@@ -200,8 +203,8 @@ class CancelScope:
         self._active = True
 
         if self._parent_scope is not None:
-            if self._parent_scope. _cancel_called and not self._shield:
-                await self.cancel()
+            if self._parent_scope._cancel_called and not self._shield:
+                await self.cancel(self._parent_scope._cancel_called)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
@@ -211,20 +214,29 @@ class CancelScope:
 
         host_task = current_task()
         self._tasks.remove(host_task)
+        if self._parent_scope is not None:
+            self._parent_scope._children.remove(self)
         set_cancel_scope(host_task, self._parent_scope)
+
+        if self._cancel_called:
+            self._cancel_called = id(self._cancel_called)  # avoid reference loops
 
         if isinstance(exc_val, asyncio.CancelledError):
             if self._timeout_expired:
                 return True
             elif self._cancel_called:
-                # This scope was directly cancelled
+                # This scope was directly(?) cancelled
                 return True
+        elif isinstance(exc_val, CancelledError):
+            return exc_val.args[0] is self
 
-    async def cancel(self):
+    async def cancel(self, real_scope=None):
         if self._cancel_called:
             return
 
-        self._cancel_called = True
+        if real_scope is None:
+            real_scope = self
+        self._cancel_called = real_scope
 
         # Cancel any contained tasks
         for task in self._tasks:
@@ -235,13 +247,33 @@ class CancelScope:
                 if scope is self or not scope.shield:
                     task.cancel()
 
+        for child in self._children:
+            child._sub_cancel(real_scope)
+
+    def _sub_cancel(self, scope):
+        if self.shield or self._cancel_called:
+            return
+
+        self._cancel_called = scope
+
+        for task in self._tasks:
+            if task._coro.cr_await is not None and not task._coro.cr_running:
+                # Cancel the task directly, but only if it's blocked and isn't within a shielded
+                # scope
+                scope = get_cancel_scope(task)
+                if scope is self or not scope.shield:
+                    task.cancel()
+
+        for child in self._children:
+            child._sub_cancel(scope)
+
     @property
     def deadline(self) -> float:
         return self._deadline
 
     @property
     def cancel_called(self) -> bool:
-        return self._cancel_called
+        return self._cancel_called in {id(self), self}
 
     @property
     def shield(self) -> bool:
@@ -273,8 +305,10 @@ def set_cancel_scope(task: asyncio.Task, scope: Optional[CancelScope]):
 def check_cancelled():
     task = current_task()
     cancel_scope = get_cancel_scope(task)
-    if cancel_scope is not None and not cancel_scope._shield and cancel_scope._cancel_called:
-        raise CancelledError
+    if cancel_scope is None:
+        return
+    if not cancel_scope._shield and cancel_scope._cancel_called:
+        raise CancelledError(cancel_scope._cancel_called)
 
 
 def open_cancel_scope(deadline: float = math.inf, shield: bool = False) -> CancelScope:
@@ -286,7 +320,10 @@ def open_cancel_scope(deadline: float = math.inf, shield: bool = False) -> Cance
 async def fail_after(delay: float, shield: bool):
     deadline = get_running_loop().time() + delay
     async with CancelScope(deadline, shield) as scope:
-        await yield_(scope)
+        try:
+            await yield_(scope)
+        except asyncio.CancelledError:
+            raise CancelledError(scope._cancel_called)
 
     if scope._timeout_expired:
         raise TimeoutError
@@ -297,7 +334,10 @@ async def fail_after(delay: float, shield: bool):
 async def move_on_after(delay: float, shield: bool):
     deadline = get_running_loop().time() + delay
     async with CancelScope(deadline=deadline, shield=shield) as scope:
-        await yield_(scope)
+        try:
+            await yield_(scope)
+        except asyncio.CancelledError:
+            raise CancelledError(scope._cancel_called)
 
 
 async def current_effective_deadline():

--- a/anyio/_backends/curio.py
+++ b/anyio/_backends/curio.py
@@ -136,11 +136,11 @@ class CancelScope:
         for child in list(self._children):
             await child._sub_cancel(real_scope)
 
-    async def _sub_cancel(self, scope):
+    async def _sub_cancel(self, real_scope):
         if self.shield or self._cancel_called:
             return
 
-        self._cancel_called = scope
+        self._cancel_called = real_scope
 
         for task in list(self._tasks):
             if task.coro.cr_await is not None and not task.coro.cr_running:
@@ -151,7 +151,7 @@ class CancelScope:
                     await task.cancel()
 
         for child in self._children:
-            await child._sub_cancel(scope)
+            await child._sub_cancel(real_scope)
 
     @property
     def deadline(self) -> float:

--- a/anyio/_backends/curio.py
+++ b/anyio/_backends/curio.py
@@ -111,8 +111,8 @@ class CancelScope:
         if isinstance(exc_val, curio.TaskCancelled):
             if self._timeout_expired:
                 return True
-            elif self._cancel_called:
-                # This scope was directly(?) cancelled
+            elif self._cancel_called in {id(self), self}:
+                # This scope was directly cancelled
                 return True
         elif isinstance(exc_val, CancelledError):
             return exc_val.args[0] is self

--- a/anyio/_backends/curio.py
+++ b/anyio/_backends/curio.py
@@ -285,6 +285,9 @@ class TaskGroup:
         task = await curio.current_task()
         try:
             await func(*args)
+        except CancelledError as exc:
+            await self.cancel_scope.cancel(exc.args[0])
+            raise
         except BaseException:
             await self.cancel_scope.cancel()
             raise

--- a/anyio/_backends/curio.py
+++ b/anyio/_backends/curio.py
@@ -84,6 +84,10 @@ class CancelScope:
         if self._deadline != math.inf:
             self._timeout_task = await curio.spawn(timeout)
 
+        if self._parent_scope is not None:
+            if self._parent_scope._cancel_called and not self._shield:
+                await self.cancel()
+
         self._active = True
         return self
 

--- a/anyio/exceptions.py
+++ b/anyio/exceptions.py
@@ -27,6 +27,10 @@ class ExceptionGroup(Exception):
 
 class CancelledError(Exception):
     """Raised when the enclosing cancel scope has been cancelled."""
+    def __init__(self, cause=None):
+        if type(cause) is not int:
+            cause = id(cause)
+        self.cause = cause
 
 
 class IncompleteRead(Exception):

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -285,6 +285,27 @@ async def test_nested_move_on_after():
 
 
 @pytest.mark.anyio
+async def test_fail_in_taskgroup():
+    bad = False
+    async def check():
+        task_status.started()
+        async with anyio.fail_after(1):
+            await anyio.sleep(1)
+        nonlocal bad
+        bad = True
+
+    try:
+        async with create_task_group() as tg:
+            await tg.start(check)
+            await anyio.sleep(0.1)
+            await tg.cancel_scope.cancel()
+            raise RuntimeError("Owch")
+    except Exception:
+        pass
+    assert not bad
+
+
+@pytest.mark.anyio
 async def test_shielding():
     async def cancel_when_ready():
         await wait_all_tasks_blocked()

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -287,8 +287,8 @@ async def test_nested_move_on_after():
 @pytest.mark.anyio
 async def test_fail_in_taskgroup():
     bad = False
+
     async def check():
-        task_status.started()
         async with fail_after(1):
             await sleep(1)
         nonlocal bad

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -367,7 +367,7 @@ async def test_exception_cancels_siblings():
 @pytest.mark.anyio
 async def test_cancelled_parent():
     async def child():
-        async with open_cancel_scope() as sc:
+        async with open_cancel_scope():
             await sleep(1)
         raise RuntimeError("This should not be printed")
 
@@ -379,6 +379,5 @@ async def test_cancelled_parent():
         pass
 
     async with create_task_group() as tg:
-        await tg.spawn(parent,tg)
+        await tg.spawn(parent, tg)
         await tg.cancel_scope.cancel()
-

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -381,3 +381,16 @@ async def test_cancelled_parent():
     async with create_task_group() as tg:
         await tg.spawn(parent, tg)
         await tg.cancel_scope.cancel()
+
+
+@pytest.mark.anyio
+async def test_cancelled_parent_scope():
+    async with open_cancel_scope() as scope:
+        async with open_cancel_scope() as sc2:
+            try:
+                await scope.cancel()
+                await sleep(2)
+            except BaseException:
+                await sc2.cancel()
+                raise
+        raise RuntimeError("This should not be printed")

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -289,15 +289,15 @@ async def test_fail_in_taskgroup():
     bad = False
     async def check():
         task_status.started()
-        async with anyio.fail_after(1):
-            await anyio.sleep(1)
+        async with fail_after(1):
+            await sleep(1)
         nonlocal bad
         bad = True
 
     try:
         async with create_task_group() as tg:
             await tg.start(check)
-            await anyio.sleep(0.1)
+            await sleep(0.1)
             await tg.cancel_scope.cancel()
             raise RuntimeError("Owch")
     except Exception:


### PR DESCRIPTION
Fixes #51.