### PR TITLE
Add asynchronous context manager methods to task group base class

### DIFF
--- a/anyio/abc.py
+++ b/anyio/abc.py
@@ -2,9 +2,9 @@ from abc import ABCMeta, abstractmethod
 from io import SEEK_SET
 from ipaddress import IPv4Address, IPv6Address
 from ssl import SSLContext
+from types import TracebackType
 from typing import (
     Callable, TypeVar, Optional, Tuple, Union, AsyncIterable, Dict, List, Coroutine, Type)
-from types import TracebackType
 
 T_Retval = TypeVar('T_Retval')
 IPAddressType = Union[str, IPv4Address, IPv6Address]
@@ -144,16 +144,12 @@ class TaskGroup(metaclass=ABCMeta):
 
     @abstractmethod
     async def __aenter__(self) -> 'TaskGroup':
-        """
-        Enter the task group context and allow starting new tasks
-        """
+        """Enter the task group context and allow starting new tasks."""
 
     @abstractmethod
     async def __aexit__(self, exc_type: Type[BaseException], exc_val: BaseException,
                         exc_tb: TracebackType) -> Optional[bool]:
-        """
-        Exit the task group context waiting for all tasks to finish
-        """
+        """Exit the task group context waiting for all tasks to finish."""
 
 
 class CancelScope(metaclass=ABCMeta):

--- a/anyio/abc.py
+++ b/anyio/abc.py
@@ -2,7 +2,19 @@ from abc import ABCMeta, abstractmethod
 from io import SEEK_SET
 from ipaddress import IPv4Address, IPv6Address
 from ssl import SSLContext
-from typing import Callable, TypeVar, Optional, Tuple, Union, AsyncIterable, Dict, List, Coroutine
+from typing import (
+    Callable,
+    TypeVar,
+    Optional,
+    Tuple,
+    Union,
+    AsyncIterable,
+    Dict,
+    List,
+    Coroutine,
+    Type,
+)
+from types import TracebackType
 
 T_Retval = TypeVar('T_Retval')
 IPAddressType = Union[str, IPv4Address, IPv6Address]
@@ -138,6 +150,22 @@ class TaskGroup(metaclass=ABCMeta):
         :param func: a coroutine function
         :param args: positional arguments to call the function with
         :param name: name of the task, for the purposes of introspection and debugging
+        """
+
+    @abstractmethod
+    async def __aenter__(self) -> 'TaskGroup':
+        """
+        Enter the task group context and allow starting new tasks
+        """
+
+    async def __aexit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
+    ) -> Optional[bool]:
+        """
+        Exit the task group context waiting for all tasks to finish
         """
 
 

--- a/anyio/abc.py
+++ b/anyio/abc.py
@@ -148,6 +148,7 @@ class TaskGroup(metaclass=ABCMeta):
         Enter the task group context and allow starting new tasks
         """
 
+    @abstractmethod
     async def __aexit__(self, exc_type: Type[BaseException], exc_val: BaseException,
                         exc_tb: TracebackType) -> Optional[bool]:
         """

--- a/anyio/abc.py
+++ b/anyio/abc.py
@@ -3,17 +3,7 @@ from io import SEEK_SET
 from ipaddress import IPv4Address, IPv6Address
 from ssl import SSLContext
 from typing import (
-    Callable,
-    TypeVar,
-    Optional,
-    Tuple,
-    Union,
-    AsyncIterable,
-    Dict,
-    List,
-    Coroutine,
-    Type,
-)
+    Callable, TypeVar, Optional, Tuple, Union, AsyncIterable, Dict, List, Coroutine, Type)
 from types import TracebackType
 
 T_Retval = TypeVar('T_Retval')
@@ -158,12 +148,8 @@ class TaskGroup(metaclass=ABCMeta):
         Enter the task group context and allow starting new tasks
         """
 
-    async def __aexit__(
-        self,
-        exc_type: Type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
-    ) -> Optional[bool]:
+    async def __aexit__(self, exc_type: Type[BaseException], exc_val: BaseException,
+                        exc_tb: TracebackType) -> Optional[bool]:
         """
         Exit the task group context waiting for all tasks to finish
         """


### PR DESCRIPTION
It's better for ``TaskGroup`` base class to define methos of asynchronous context manager -- ``__aexit__()`` and ``__aenter__()`` -- because otherwise ``mypy`` can't know that objects returned from ``anyio.create_task_group()`` may be used in ``async with`` statement.

Closes: #63