### PR TITLE
Fix KeyError when entering and exiting the same cancel scope in different tasks

### DIFF
--- a/anyio/_backends/_asyncio.py
+++ b/anyio/_backends/_asyncio.py
@@ -20,79 +20,9 @@ from ..exceptions import ExceptionGroup, ClosedResourceError, ResourceBusyError,
 from .._networking import BaseSocket
 
 try:
-    from asyncio import run as native_run, create_task, get_running_loop, current_task, all_tasks
+    from asyncio import create_task, get_running_loop, current_task, all_tasks
 except ImportError:
     _T = TypeVar('_T')
-
-    # Snatched from the standard library
-    def native_run(main: Awaitable[_T], *, debug: bool = False) -> _T:
-        """Run a coroutine.
-
-        This function runs the passed coroutine, taking care of
-        managing the asyncio event loop and finalizing asynchronous
-        generators.
-
-        This function cannot be called when another asyncio event loop is
-        running in the same thread.
-
-        If debug is True, the event loop will be run in debug mode.
-
-        This function always creates a new event loop and closes it at the end.
-        It should be used as a main entry point for asyncio programs, and should
-        ideally only be called once.
-
-        Example:
-
-            async def main():
-                await asyncio.sleep(1)
-                print('hello')
-
-            asyncio.run(main())
-        """
-        from asyncio import events, coroutines
-
-        if events._get_running_loop() is not None:
-            raise RuntimeError(
-                "asyncio.run() cannot be called from a running event loop")
-
-        if not coroutines.iscoroutine(main):
-            raise ValueError("a coroutine was expected, got {!r}".format(main))
-
-        loop = events.new_event_loop()
-        try:
-            events.set_event_loop(loop)
-            loop.set_debug(debug)
-            return loop.run_until_complete(main)
-        finally:
-            try:
-                _cancel_all_tasks(loop)
-                loop.run_until_complete(loop.shutdown_asyncgens())
-            finally:
-                events.set_event_loop(None)  # type: ignore
-                loop.close()
-
-    def _cancel_all_tasks(loop):
-        from asyncio import gather
-
-        to_cancel = all_tasks(loop)
-        if not to_cancel:
-            return
-
-        for task in to_cancel:
-            task.cancel()
-
-        loop.run_until_complete(
-            gather(*to_cancel, loop=loop, return_exceptions=True))
-
-        for task in to_cancel:
-            if task.cancelled():
-                continue
-            if task.exception() is not None:
-                loop.call_exception_handler({
-                    'message': 'unhandled exception during asyncio.run() shutdown',
-                    'exception': task.exception(),
-                    'task': task,
-                })
 
     def create_task(coro: Union[Generator[Any, None, _T], Awaitable[_T]]) -> asyncio.Task:
         return get_running_loop().create_task(coro)

--- a/anyio/_backends/_asyncio.py
+++ b/anyio/_backends/_asyncio.py
@@ -404,7 +404,6 @@ class TaskGroup:
                 self._exceptions.append(exc_val)
 
         while self.cancel_scope._tasks:
-            print('waiting for %d tasks' % len(self.cancel_scope._tasks))
             await asyncio.wait(self.cancel_scope._tasks)
 
         self._active = False

--- a/anyio/_backends/_asyncio.py
+++ b/anyio/_backends/_asyncio.py
@@ -149,6 +149,10 @@ def run(func: Callable[..., T_Retval], *args, debug: bool = False, use_uvloop: b
     if policy is not None:
         asyncio.set_event_loop_policy(policy)
 
+    # We use loop.run_until_complete() instead of asyncio.run() because the latter cancels all
+    # tasks and shuts down all async generators, making it unsuitable for things like pytest
+    # fixtures which require one run() call for setup, one for the actual test and one for
+    # teardown.
     exception = retval = None
     loop = asyncio.get_event_loop()
     loop.set_debug(debug)

--- a/anyio/_backends/_curio.py
+++ b/anyio/_backends/_curio.py
@@ -106,7 +106,7 @@ class CancelScope:
         if self._timeout_task:
             await self._timeout_task.cancel(blocking=False)
 
-        self._tasks.discard(self._host_task)
+        self._tasks.remove(self._host_task)
         host_task_state = _task_states.get(self._host_task)
         if host_task_state is not None and host_task_state.cancel_scope is self:
             host_task_state.cancel_scope = self._parent_scope

--- a/anyio/_backends/_trio.py
+++ b/anyio/_backends/_trio.py
@@ -2,24 +2,13 @@ from typing import Callable, Optional, List
 
 import trio.hazmat
 from async_generator import async_generator, yield_, asynccontextmanager, aclosing
+from trio.to_thread import run_sync
+from trio.from_thread import run as run_async_from_thread
+from trio.hazmat import wait_readable, wait_writable, notify_closing
 
-from .._networking import BaseSocket
 from .. import abc, claim_worker_thread, T_Retval, _local, TaskInfo
 from ..exceptions import ExceptionGroup, ClosedResourceError, ResourceBusyError, WouldBlock
-
-try:
-    # Trio >= 0.12
-    from trio.to_thread import run_sync
-    from trio.from_thread import run as run_async_from_thread
-    from trio.hazmat import wait_readable, wait_writable, notify_closing
-except ImportError:
-    # Trio < 0.12
-    from trio import run_sync_in_worker_thread as run_sync
-    from trio.hazmat import (
-        wait_socket_readable as wait_readable, wait_socket_writable as wait_writable,
-        notify_socket_close as notify_closing
-    )
-    run_async_from_thread = None
+from .._networking import BaseSocket
 
 #
 # Event loop

--- a/anyio/pytest_plugin.py
+++ b/anyio/pytest_plugin.py
@@ -61,13 +61,15 @@ def pytest_fixture_setup(fixturedef, request):
 def pytest_generate_tests(metafunc):
     marker = metafunc.definition.get_closest_marker('anyio')
     if marker:
+        metafunc.fixturenames.append('anyio_backend')
+
+    if 'anyio_backend' in metafunc.fixturenames:
         backends = metafunc.config.getoption('anyio_backends')
         if backends == 'all':
             backends = BACKENDS
         else:
             backends = backends.replace(' ', '').split(',')
 
-        metafunc.fixturenames.append('anyio_backend')
         metafunc.parametrize('anyio_backend', backends, scope='session')
 
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -62,3 +62,13 @@ For example, to run your test suite against the curio and trio backends:
 .. code-block:: bash
 
     pytest --anyio-backends=curio,trio
+
+Using AnyIO from regular tests
+------------------------------
+
+In rare cases, you may need to have tests that run against whatever backends you have chosen to
+work with. For this, you can add the ``anyio_backend`` parameter to your test. It will be filled
+in with the name of each of the selected backends in turn::
+
+    def test_something(anyio_backend):
+        assert anyio_backend in ('asyncio', 'curio', 'trio')

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added the possibility to parametrize regular pytest test functions against the selected list of
   backends
+- Fixed ``KeyError`` on asyncio and curio where entering and exiting a cancel scope happens in
+  different tasks
 
 **1.1.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -9,6 +9,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   backends
 - Fixed ``KeyError`` on asyncio and curio where entering and exiting a cancel scope happens in
   different tasks
+- Dropped support for trio v0.11
 
 **1.1.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,11 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Added the possibility to parametrize regular pytest test functions against the selected list of
+  backends
+
 **1.1.0**
 
 - Added the ``lock`` parameter to ``anyio.create_condition()`` (PR by Matthias Urlichs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ test =
     hypothesis >= 4.0
     pytest >= 3.7.2
     uvloop; platform_python_implementation == 'CPython' and platform_system != 'Windows' and python_version < '3.8'
-trio = trio >= 0.11
+trio = trio >= 0.12
 curio = curio >= 0.9
 doc =
     sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 minversion = 3.3.0
-envlist = py35, py36, py37, py38, pypy3, trio011, flake8, mypy
+envlist = py35, py36, py37, py38, pypy3, flake8, mypy
 skip_missing_interpreters = true
 isolated_build = true
 
@@ -14,11 +14,6 @@ commands = coverage run -m pytest {posargs}
 extras = test
     curio
     trio
-
-[testenv:trio011]
-basepython = python3.5
-commands = coverage run -m pytest --anyio-backends=trio {posargs}
-deps = trio == 0.11
 
 [testenv:flake8]
 basepython = python3.5


### PR DESCRIPTION
This should fix the most obvious problems with running tasks in asynchronous pytest fixtures.
Trio v0.11 could not handle this either so I dropped support for it.

Fixes #74.