### PR TITLE
Capacity limiter improvements

### DIFF
--- a/anyio/__init__.py
+++ b/anyio/__init__.py
@@ -247,6 +247,16 @@ def run_async_from_thread(func: Callable[..., Coroutine[Any, Any, T_Retval]], *a
     return asynclib.run_async_from_thread(func, *args)
 
 
+def current_default_thread_limiter() -> CapacityLimiter:
+    """
+    Return the capacity limiter that is used by default to limit the number of concurrent threads.
+
+    :return: a capacity limiter object
+
+    """
+    return _get_asynclib().current_default_thread_limiter()
+
+
 #
 # Async file I/O
 #

--- a/anyio/_backends/_asyncio.py
+++ b/anyio/_backends/_asyncio.py
@@ -745,6 +745,10 @@ class CapacityLimiter:
             event.set()
 
 
+def current_default_thread_limiter():
+    return _default_thread_limiter
+
+
 _default_thread_limiter = CapacityLimiter(40)
 
 abc.Lock.register(Lock)

--- a/anyio/_backends/_curio.py
+++ b/anyio/_backends/_curio.py
@@ -567,6 +567,10 @@ class CapacityLimiter:
             await event.set()
 
 
+def current_default_thread_limiter():
+    return _default_thread_limiter
+
+
 _default_thread_limiter = CapacityLimiter(40)
 
 abc.Lock.register(Lock)

--- a/anyio/_backends/_curio.py
+++ b/anyio/_backends/_curio.py
@@ -475,13 +475,8 @@ class Queue(curio.Queue):
 
 
 class CapacityLimiter:
-    def __init__(self, total_tokens: int):
-        if not isinstance(total_tokens, int) and not math.isinf(total_tokens):
-            raise TypeError('total_tokens must be an int or math.inf')
-        if total_tokens < 1:
-            raise ValueError('total_tokens must be >= 1')
-
-        self._total_tokens = total_tokens
+    def __init__(self, total_tokens: float):
+        self._set_total_tokens(total_tokens)
         self._borrowers = set()  # type: Set[Any]
         self._wait_queue = OrderedDict()  # type: Dict[Any, curio.Event]
 
@@ -491,9 +486,32 @@ class CapacityLimiter:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.release()
 
+    def _set_total_tokens(self, value: float) -> None:
+        if not isinstance(value, int) and not math.isinf(value):
+            raise TypeError('total_tokens must be an int or math.inf')
+        if value < 1:
+            raise ValueError('total_tokens must be >= 1')
+
+        self._total_tokens = value
+
     @property
     def total_tokens(self) -> float:
         return self._total_tokens
+
+    async def set_total_tokens(self, value: float) -> None:
+        old_value = self._total_tokens
+        self._set_total_tokens(value)
+        events = []
+        for event in self._wait_queue.values():
+            if value <= old_value:
+                break
+
+            if not event.is_set():
+                events.append(event)
+                old_value += 1
+
+        for event in events:
+            await event.set()
 
     @property
     def borrowed_tokens(self) -> int:

--- a/anyio/_backends/_trio.py
+++ b/anyio/_backends/_trio.py
@@ -299,6 +299,9 @@ class CapacityLimiter(abc.CapacityLimiter):
     def total_tokens(self) -> float:
         return self._limiter.total_tokens
 
+    async def set_total_tokens(self, value: float) -> None:
+        self._limiter.total_tokens = value
+
     @property
     def borrowed_tokens(self) -> int:
         return self._limiter.borrowed_tokens

--- a/anyio/abc.py
+++ b/anyio/abc.py
@@ -144,6 +144,17 @@ class CapacityLimiter(metaclass=ABCMeta):
     def total_tokens(self) -> float:
         """The total number of tokens available for borrowing."""
 
+    @abstractmethod
+    async def set_total_tokens(self, value: float) -> None:
+        """
+        Set the total number of tokens.
+
+        If the total number of tokens is increased, the proportionate number of tasks waiting on
+        this limiter will be granted their tokens.
+
+        :param value: the new total number of tokens (>= 1)
+        """
+
     @property
     @abstractmethod
     def borrowed_tokens(self) -> int:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,6 +38,7 @@ Threads
 
 .. autofunction:: anyio.run_in_thread
 .. autofunction:: anyio.run_async_from_thread
+.. autofunction:: anyio.current_default_thread_limiter
 
 Async file I/O
 --------------

--- a/docs/synchronization.rst
+++ b/docs/synchronization.rst
@@ -186,3 +186,6 @@ Example::
                 await tg.spawn(use_resource, num, limiter)
 
     run(main)
+
+To adjust the number of total tokens, you can use the
+:meth:`~anyio.abc.CapacityLimiter.set_total_tokens` method.

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added the possibility to parametrize regular pytest test functions against the selected list of
   backends
+- Added the ``set_total_tokens()`` method to ``CapacityLimiter``
 - Implemented the Happy Eyeballs (:rfc:`6555`) algorithm for ``anyio.connect_tcp()``
 - Fixed ``KeyError`` on asyncio and curio where entering and exiting a cancel scope happens in
   different tasks

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,6 +8,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Added the possibility to parametrize regular pytest test functions against the selected list of
   backends
 - Added the ``set_total_tokens()`` method to ``CapacityLimiter``
+- Added the ``anyio.current_default_thread_limiter()`` function
 - Implemented the Happy Eyeballs (:rfc:`6555`) algorithm for ``anyio.connect_tcp()``
 - Fixed ``KeyError`` on asyncio and curio where entering and exiting a cancel scope happens in
   different tasks

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -2,7 +2,8 @@ import pytest
 
 from anyio import (
     create_lock, create_task_group, create_queue, create_event, create_semaphore, create_condition,
-    open_cancel_scope, wait_all_tasks_blocked, create_capacity_limiter)
+    open_cancel_scope, wait_all_tasks_blocked, create_capacity_limiter,
+    current_default_thread_limiter, CapacityLimiter)
 
 
 class TestLock:
@@ -298,3 +299,9 @@ class TestCapacityLimiter:
             await limiter.set_total_tokens(2)
 
         assert event2.is_set()
+
+    @pytest.mark.anyio
+    async def test_current_default_thread_limiter(self):
+        limiter = current_default_thread_limiter()
+        assert isinstance(limiter, CapacityLimiter)
+        assert limiter.total_tokens == 40


### PR DESCRIPTION
This pull request contains two loosely related features:

1. The addition of the `CapacityLimiter.set_total_tokens()` method
1. The addition of the `anyio.current_default_thread_limiter()` function

I was torn between following trio's example and adding a setter method for the `total_tokens` property (and having to work around curio's limitations) vs adding a coroutine method for setting the property. I opted for the later approach because the curio workaround would have been pretty ugly.