### PR TITLE
Gracefully handle socket creation failure

### DIFF
--- a/anyio/__init__.py
+++ b/anyio/__init__.py
@@ -325,7 +325,12 @@ async def connect_tcp(
 
     async def try_connect(af: int, addr: str, event: Event):
         nonlocal stream
-        raw_socket = socket.socket(af, socket.SOCK_STREAM)
+        try:
+            raw_socket = socket.socket(af, socket.SOCK_STREAM)
+        except OSError as exc:
+            await event.set()
+            oserrors.append(exc)
+            return
         sock = asynclib.Socket(raw_socket)
         try:
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)


### PR DESCRIPTION
It is possible that the call to create a regular socket fails, even
before you try to do anything with it. In those cases, we should allow
another attempt to succeed.

One way that this can happen is on linux with `ipv6.disable=1` on the
kernel command line. In this case, opening a socket with an IPv6
address family will fail with EAFNOSUPPORT.