### PR TITLE
Add type annotation for `CancelScope.cancel`

### DIFF
--- a/anyio/_backends/_asyncio.py
+++ b/anyio/_backends/_asyncio.py
@@ -216,7 +216,7 @@ class CancelScope:
 
         return False
 
-    async def cancel(self):
+    async def cancel(self) -> None:
         if self._cancel_called:
             return
 

--- a/anyio/_backends/_curio.py
+++ b/anyio/_backends/_curio.py
@@ -157,7 +157,7 @@ class CancelScope:
 
         return False
 
-    async def cancel(self):
+    async def cancel(self) -> None:
         if self._cancel_called:
             return
 

--- a/anyio/_backends/_trio.py
+++ b/anyio/_backends/_trio.py
@@ -51,7 +51,7 @@ class CancelScope:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         return self.__original.__exit__(exc_type, exc_val, exc_tb)
 
-    async def cancel(self):
+    async def cancel(self) -> None:
         self.__original.cancel()
 
     @property

--- a/anyio/abc.py
+++ b/anyio/abc.py
@@ -247,7 +247,7 @@ class TaskGroup(metaclass=ABCMeta):
 
 class CancelScope(metaclass=ABCMeta):
     @abstractmethod
-    async def cancel(self):
+    async def cancel(self) -> None:
         """Cancel this scope immediately."""
 
     @property


### PR DESCRIPTION
Current mypy output:
```
foo.py:218:19: error: Call to untyped function "cancel" of "CancelScope" in typed context  [no-untyped-call]
                await tg.cancel_scope.cancel()
                      ^
```