### PR TITLE
Made the pytest plugin more flexible about the backend

### DIFF
--- a/anyio/pytest_plugin.py
+++ b/anyio/pytest_plugin.py
@@ -85,7 +85,7 @@ def pytest_pyfunc_call(pyfuncitem):
     try:
         backend = pyfuncitem.callspec.getparam('anyio_backend')
     except (AttributeError, ValueError):
-        return False
+        return None
 
     if backend:
         if hasattr(pyfuncitem.obj, 'hypothesis'):

--- a/anyio/pytest_plugin.py
+++ b/anyio/pytest_plugin.py
@@ -20,7 +20,6 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.hookimpl(hookwrapper=True)
 def pytest_fixture_setup(fixturedef, request):
     def wrapper(*args, **kwargs):
         backend = kwargs['anyio_backend']
@@ -54,8 +53,6 @@ def pytest_fixture_setup(fixturedef, request):
             strip_backend = True
 
         fixturedef.func = wrapper
-
-    yield
 
 
 @pytest.hookimpl(trylast=True)

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -63,29 +63,19 @@ For example, to run your test suite against the curio and trio backends:
 
     pytest --anyio-backends=curio,trio
 
-If you need more precise control over which backend(s) you want to run particular tests on,
-you can pass the ``backend`` argument to ``@pytest.mark.anyio``. For example, if you need to run
-a particular test only on asyncio, you can do this::
+Behind the scenes, any function that uses the ``@pytest.mark.anyio`` marker gets parametrized by
+the plugin to use the ``anyio_backend`` fixture. One alternative is to do this parametrization on
+your own::
 
-    @pytest.mark.anyio(backend='asyncio')
-    async def test_on_asyncio_only():
+    @pytest.mark.parametrize('anyio_backend', ['asyncio'])
+    async def test_on_asyncio_only(anyio_backend):
         ...
 
-To run a test on more than one explicitly specified backends, you can do it like this::
+Or you can write a simple fixture by the same name that provides the back-end name::
 
-    @pytest.mark.anyio(backend=['asyncio', 'trio'])
-    async def test_on_asyncio_and_trio():
-        ...
-
-Or even like this::
-
-    @pytest.mark.parametrize('some_argument', [
-        pytest.param('value 1', marks=[pytest.mark.anyio(backend='trio')]),
-        pytest.param('value 2', marks=[pytest.mark.anyio(backend='curio')]),
-        pytest.param('third value', marks=[pytest.mark.anyio(backend='asyncio')])
-    ])
-    async def test_on_asyncio_and_trio(some_argument):
-        ...
+    @pytest.fixture(params=['asyncio'])
+    def anyio_backend(request):
+        return request.param
 
 Using AnyIO from regular tests
 ------------------------------

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -63,6 +63,30 @@ For example, to run your test suite against the curio and trio backends:
 
     pytest --anyio-backends=curio,trio
 
+If you need more precise control over which backend(s) you want to run particular tests on,
+you can pass the ``backend`` argument to ``@pytest.mark.anyio``. For example, if you need to run
+a particular test only on asyncio, you can do this::
+
+    @pytest.mark.anyio(backend='asyncio')
+    async def test_on_asyncio_only():
+        ...
+
+To run a test on more than one explicitly specified backends, you can do it like this::
+
+    @pytest.mark.anyio(backend=['asyncio', 'trio'])
+    async def test_on_asyncio_and_trio():
+        ...
+
+Or even like this::
+
+    @pytest.mark.parametrize('some_argument', [
+        pytest.param('value 1', marks=[pytest.mark.anyio(backend='trio')]),
+        pytest.param('value 2', marks=[pytest.mark.anyio(backend='curio')]),
+        pytest.param('third value', marks=[pytest.mark.anyio(backend='asyncio')])
+    ])
+    async def test_on_asyncio_and_trio(some_argument):
+        ...
+
 Using AnyIO from regular tests
 ------------------------------
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added the ``backend`` argument to ``@pytest.mark.anyio`` for fine grained control over which
+  backend(s) to use with each test
+- Allowed regular functions to be marked with ``@pytest.mark.anyio``
 - Fixed ``CancelledError`` leaking from a cancel scope on asyncio if the task previously received a
   cancellation exception
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,9 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Added the ``backend`` argument to ``@pytest.mark.anyio`` for fine grained control over which
-  backend(s) to use with each test
-- Allowed regular functions to be marked with ``@pytest.mark.anyio``
+- Made it possible to assert fine grained control over which AnyIO backends are being used with
+  each test
 - Fixed ``CancelledError`` leaking from a cancel scope on asyncio if the task previously received a
   cancellation exception
 

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -7,3 +7,9 @@ from hypothesis.strategies import just
 @given(x=just(1))
 async def test_hypothesis_wrapper(x):
     assert isinstance(x, int)
+
+
+@pytest.mark.anyio
+@given(x=just(1))
+def test_hypothesis_wrapper_regular(x):
+    assert isinstance(x, int)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,4 +1,5 @@
 import pytest
+import sniffio
 from async_generator import async_generator, yield_
 
 from anyio import sleep
@@ -26,3 +27,27 @@ async def test_fixture(async_fixture):
 @pytest.mark.anyio
 async def test_asyncgen_fixture(asyncgen_fixture):
     assert asyncgen_fixture == 'foo'
+
+
+@pytest.mark.anyio(backend='asyncio')
+async def test_explicit_backend(anyio_backend):
+    assert anyio_backend == 'asyncio'
+
+
+@pytest.mark.anyio(backend='asyncio')
+def test_explicit_backend_regular_function(anyio_backend):
+    assert anyio_backend == 'asyncio'
+
+
+@pytest.mark.parametrize('backend', [
+    pytest.param('trio', marks=[pytest.mark.anyio(backend='trio')]),
+    pytest.param('curio', marks=[pytest.mark.anyio(backend='curio')]),
+    pytest.param('asyncio', marks=[pytest.mark.anyio(backend='asyncio')])
+])
+async def test_multiple_explicit_backend_params(backend):
+    assert backend == sniffio.current_async_library()
+
+
+@pytest.mark.anyio(backend=['asyncio', 'trio'])
+async def test_multiple_explicit_backends():
+    pass

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -29,25 +29,28 @@ async def test_asyncgen_fixture(asyncgen_fixture):
     assert asyncgen_fixture == 'foo'
 
 
-@pytest.mark.anyio(backend='asyncio')
+@pytest.mark.parametrize('anyio_backend', ['asyncio'])
 async def test_explicit_backend(anyio_backend):
     assert anyio_backend == 'asyncio'
+    assert sniffio.current_async_library() == 'asyncio'
 
 
-@pytest.mark.anyio(backend='asyncio')
+@pytest.mark.parametrize('anyio_backend', ['asyncio'])
 def test_explicit_backend_regular_function(anyio_backend):
     assert anyio_backend == 'asyncio'
 
 
-@pytest.mark.parametrize('backend', [
-    pytest.param('trio', marks=[pytest.mark.anyio(backend='trio')]),
-    pytest.param('curio', marks=[pytest.mark.anyio(backend='curio')]),
-    pytest.param('asyncio', marks=[pytest.mark.anyio(backend='asyncio')])
-])
-async def test_multiple_explicit_backend_params(backend):
-    assert backend == sniffio.current_async_library()
+@pytest.mark.parametrize('anyio_backend', ['trio', 'curio', 'asyncio'])
+async def test_multiple_explicit_backend_params(anyio_backend):
+    assert anyio_backend in ('trio', 'curio', 'asyncio')
+    assert anyio_backend == sniffio.current_async_library()
 
 
-@pytest.mark.anyio(backend=['asyncio', 'trio'])
-async def test_multiple_explicit_backends():
-    pass
+class TestAnyIOBackendsFixture:
+    @pytest.fixture(params=['asyncio', 'trio'])
+    def anyio_backend(self, request):
+        return request.param
+
+    async def test_anyio_backend_fixture(self, anyio_backend):
+        assert anyio_backend in ('asyncio', 'trio')
+        assert anyio_backend == sniffio.current_async_library()


### PR DESCRIPTION
This change makes it possible to specify on a per-test basis which backend(s) it should run against.