### PR TITLE
Correct TaskGroup.__aexit__ types

### DIFF
--- a/anyio/abc.py
+++ b/anyio/abc.py
@@ -240,8 +240,9 @@ class TaskGroup(metaclass=ABCMeta):
         """Enter the task group context and allow starting new tasks."""
 
     @abstractmethod
-    async def __aexit__(self, exc_type: Type[BaseException], exc_val: BaseException,
-                        exc_tb: TracebackType) -> Optional[bool]:
+    async def __aexit__(self, exc_type: Optional[Type[BaseException]],
+                        exc_val: Optional[BaseException],
+                        exc_tb: Optional[TracebackType]) -> Optional[bool]:
         """Exit the task group context waiting for all tasks to finish."""
 
 


### PR DESCRIPTION
Recently I've noticed that ``__aexit__()`` argument types are ``Optional``s (https://mypy.readthedocs.io/en/latest/protocols.html#context-manager-protocols) so I propose this change.
It seems that I've missed this detail when I submitted my previous pull request adding type information to ``TaskGroup.__aexit__()`` method, sorry for that, and thank you very much for your work!