### PR TITLE
Fixed AssertionError and unnecessary connect delay

### DIFF
--- a/anyio/__init__.py
+++ b/anyio/__init__.py
@@ -347,9 +347,10 @@ async def connect_tcp(
             await sock.close()
             raise
         else:
-            assert stream is None
-            stream = _networking.SocketStream(sock, ssl_context, target_host,
-                                              tls_standard_compatible)
+            if stream is None:
+                stream = _networking.SocketStream(sock, ssl_context, target_host,
+                                                  tls_standard_compatible)
+                await tg.cancel_scope.cancel()
         finally:
             await event.set()
 
@@ -392,10 +393,6 @@ async def connect_tcp(
             await tg.spawn(try_connect, af, addr, event)
             async with move_on_after(happy_eyeballs_delay):
                 await event.wait()
-
-            if stream is not None:
-                await tg.cancel_scope.cancel()
-                break
 
     if stream is None:
         cause = oserrors[0] if len(oserrors) == 1 else asynclib.ExceptionGroup(oserrors)

--- a/anyio/__init__.py
+++ b/anyio/__init__.py
@@ -351,6 +351,8 @@ async def connect_tcp(
                 stream = _networking.SocketStream(sock, ssl_context, target_host,
                                                   tls_standard_compatible)
                 await tg.cancel_scope.cancel()
+            else:
+                raw_socket.close()
         finally:
             await event.set()
 


### PR DESCRIPTION
If an earlier connection attempt succeeds, it should signal that the other attempts should be cancelled. This patch makes the first successful attempt cancel the entire scope immediately to achieve that effect.