### PR TITLE
Harmonize default task names across backends

### DIFF
--- a/anyio/_backends/_asyncio.py
+++ b/anyio/_backends/_asyncio.py
@@ -55,6 +55,12 @@ except ImportError:
 _native_task_names = hasattr(asyncio.Task, 'get_name')
 
 
+def get_callable_name(func: Callable) -> str:
+    module = getattr(func, '__module__', None)
+    qualname = getattr(func, '__qualname__', None)
+    return '.'.join([x for x in (module, qualname) if x])
+
+
 #
 # Event loop
 #
@@ -94,7 +100,13 @@ def run(func: Callable[..., T_Retval], *args, debug: bool = False, use_uvloop: b
     exception = retval = None
     loop = asyncio.get_event_loop()
     loop.set_debug(debug)
-    loop.run_until_complete(wrapper())
+    task = loop.create_task(wrapper())
+    task_state = TaskState(None, get_callable_name(func), None)
+    _task_states[task] = task_state
+    if _native_task_names:
+        task.set_name(task_state.name)
+
+    loop.run_until_complete(task)
     if exception is not None:
         raise exception
     else:
@@ -409,6 +421,7 @@ class TaskGroup:
         if not self._active:
             raise RuntimeError('This task group is not active; no new tasks can be spawned.')
 
+        name = name or get_callable_name(func)
         if _native_task_names is None:
             task = create_task(self._run_wrapped_task(func, args), name=name)  # type: ignore
         else:

--- a/anyio/_backends/_trio.py
+++ b/anyio/_backends/_trio.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional, List, Type, Union
 import trio.from_thread
 from async_generator import async_generator, yield_, asynccontextmanager, aclosing
 from trio.to_thread import run_sync
+
 from .. import abc, claim_worker_thread, T_Retval, TaskInfo
 from ..exceptions import (
     ExceptionGroup as BaseExceptionGroup, ClosedResourceError, ResourceBusyError, WouldBlock)
@@ -17,6 +18,8 @@ except ImportError:
     from trio.hazmat import wait_readable, wait_writable, notify_closing
 else:
     from trio.lowlevel import wait_readable, wait_writable, notify_closing
+
+
 #
 # Event loop
 #

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 **UNRELEASED**
 
 - Fixed ``fail.after(0)`` not raising a timeout error on asyncio and curio
+- Harmonized the default task names across all backends
 
 **1.3.1**
 


### PR DESCRIPTION
This ensures that, in absence of explicitly given task names, the default task names match across the different backends.