### PR TITLE
Fixed fail_after() getting stuck on curio

### DIFF
--- a/anyio/_backends/_curio.py
+++ b/anyio/_backends/_curio.py
@@ -70,7 +70,7 @@ CancelledError = curio.TaskCancelled
 
 class CancelScope:
     __slots__ = ('_deadline', '_shield', '_parent_scope', '_cancel_called', '_active',
-                 '_timeout_task', '_tasks', '_host_task', '_timeout_expired')
+                 '_timeout_task', '_previous_timeout', '_tasks', '_host_task', '_timeout_expired')
 
     def __init__(self, deadline: float = math.inf, shield: bool = False):
         self._deadline = deadline
@@ -79,16 +79,12 @@ class CancelScope:
         self._cancel_called = False
         self._active = False
         self._timeout_task = None
+        self._previous_timeout = None
         self._tasks = set()  # type: Set[curio.Task]
         self._host_task = None  # type: Optional[curio.Task]
         self._timeout_expired = False
 
     async def __aenter__(self):
-        async def timeout():
-            await curio.sleep(self._deadline - await curio.clock())
-            self._timeout_expired = True
-            await self.cancel()
-
         if self._active:
             raise RuntimeError(
                 "Each CancelScope may only be used for a single 'async with' block"
@@ -110,7 +106,7 @@ class CancelScope:
                 self._cancel_called = True
                 self._timeout_expired = True
             else:
-                self._timeout_task = await curio.spawn(timeout)
+                self._previous_timeout = await curio.traps._set_timeout(self._deadline)
 
         self._active = True
         return self
@@ -119,8 +115,14 @@ class CancelScope:
                         exc_val: Optional[BaseException],
                         exc_tb: Optional[TracebackType]) -> Optional[bool]:
         self._active = False
-        if self._timeout_task:
-            await self._timeout_task.cancel(blocking=False)
+        if self._previous_timeout:
+            await curio.traps._unset_timeout(self._previous_timeout)
+
+        if exc_type is curio.errors.TaskTimeout:
+            if self._deadline != math.inf and await curio.clock() >= self._deadline:
+                self._cancel_called = True
+                self._timeout_expired = True
+                exc_val = CancelledError().with_traceback(exc_tb)
 
         self._tasks.remove(self._host_task)
         host_task_state = _task_states.get(self._host_task)
@@ -136,7 +138,10 @@ class CancelScope:
                     # This scope was directly cancelled
                     return True
 
-        return None
+        if exc_val is not None and self._timeout_expired:
+            raise exc_val
+        else:
+            return None
 
     async def _cancel(self):
         # Deliver cancellation to directly contained tasks and nested cancel scopes
@@ -219,7 +224,7 @@ async def fail_after(delay: float, shield: bool):
         await yield_(scope)
 
     if scope._timeout_expired:
-        raise TimeoutError
+        raise TimeoutError from None
 
 
 @asynccontextmanager

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 **UNRELEASED**
 
 - Fixed ``fail.after(0)`` not raising a timeout error on asyncio and curio
+- Fixed ``move_on_after()`` and ``fail_after()`` getting stuck on curio in some cicrumstances
 
 **1.3.1**
 


### PR DESCRIPTION
The curio backend got stuck on fail_after() because the cancellation was not being delivered.