### PR TITLE
Fix Condition.wait on asyncio and curio

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -640,7 +640,7 @@ class Condition(abc.Condition):
 
     async def wait(self):
         await check_cancelled()
-        return await super().wait()
+        return await self._condition.wait()
 
 
 class Event(abc.Event):

--- a/src/anyio/_backends/_curio.py
+++ b/src/anyio/_backends/_curio.py
@@ -554,7 +554,7 @@ class Condition(abc.Condition):
 
     async def wait(self):
         await check_cancelled()
-        return await super().wait()
+        return await self._condition.wait()
 
 
 class Event(abc.Event):

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -2,7 +2,7 @@ import pytest
 
 from anyio import (
     create_lock, create_task_group, create_event, create_semaphore, create_condition,
-    open_cancel_scope, wait_all_tasks_blocked, create_capacity_limiter, sleep,
+    open_cancel_scope, wait_all_tasks_blocked, create_capacity_limiter,
     current_default_worker_thread_limiter, CapacityLimiter, create_memory_object_stream)
 from anyio.exceptions import EndOfStream, ClosedResourceError, BrokenResourceError, WouldBlock
 
@@ -145,7 +145,7 @@ class TestCondition:
         async with create_task_group() as tg:
             await tg.spawn(task)
             await event.wait()
-            await sleep(0)
+            await wait_all_tasks_blocked()
             await tg.cancel_scope.cancel()
 
         assert task_started

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -2,7 +2,7 @@ import pytest
 
 from anyio import (
     create_lock, create_task_group, create_event, create_semaphore, create_condition,
-    open_cancel_scope, wait_all_tasks_blocked, create_capacity_limiter,
+    open_cancel_scope, wait_all_tasks_blocked, create_capacity_limiter, sleep,
     current_default_worker_thread_limiter, CapacityLimiter, create_memory_object_stream)
 from anyio.exceptions import EndOfStream, ClosedResourceError, BrokenResourceError, WouldBlock
 
@@ -136,19 +136,17 @@ class TestCondition:
             task_started = True
             async with condition:
                 await event.set()
-                await event2.wait()
                 await condition.wait()
                 notified = True
 
         task_started = notified = False
         event = create_event()
-        event2 = create_event()
         condition = create_condition()
         async with create_task_group() as tg:
             await tg.spawn(task)
             await event.wait()
+            await sleep(0)
             await tg.cancel_scope.cancel()
-            await event2.set()
 
         assert task_started
         assert not notified


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/agronholm/anyio/commit/f6987c116a86abbd66451ab44dcb239b683a57c9

`Condition` now inherits from an abstract base class (https://github.com/agronholm/anyio/commit/f6987c116a86abbd66451ab44dcb239b683a57c9#diff-d80f406d80e69d8ad05e4b5fbf988915R614), so the `super()` implementation is a no-op.

The new `test_wait_cancel` fails on master for `asyncio` and `curio`, and passes in this PR.