### PR TITLE
Change byte streams to raise EndOfStream

### DIFF
--- a/docs/networking.rst
+++ b/docs/networking.rst
@@ -13,6 +13,10 @@ Currently AnyIO offers the following networking functionality:
 
 More exotic forms of networking such as raw sockets and SCTP are currently not supported.
 
+.. warning:: Unlike the standard BSD sockets interface and most other networking libraries, AnyIO
+    (from 2.0 onwards) signals the end of any stream by raising the
+    :exc:`~anyio.exceptions.EndOfStream` exception instead of returning an empty bytes object.
+
 Working with TCP sockets
 ------------------------
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -19,7 +19,7 @@ from .. import (
 from ..abc import IPSockAddrType, SockAddrType
 from ..exceptions import (
     ExceptionGroup as BaseExceptionGroup, ClosedResourceError, BusyResourceError, WouldBlock,
-    BrokenResourceError)
+    BrokenResourceError, EndOfStream)
 from .._utils import ResourceGuard
 
 if sys.version_info >= (3, 7):
@@ -622,7 +622,7 @@ class SocketStream(abc.SocketStream):
                 elif self._protocol.exception:
                     raise BrokenResourceError from self._protocol.exception
                 else:
-                    return b''
+                    raise EndOfStream
 
             if len(chunk) > max_bytes:
                 # Split the oversized chunk

--- a/src/anyio/abc/streams.py
+++ b/src/anyio/abc/streams.py
@@ -111,10 +111,9 @@ class ByteReceiveStream(AsyncResource):
         return self
 
     async def __anext__(self) -> bytes:
-        data = await self.receive()
-        if data:
-            return data
-        else:
+        try:
+            return await self.receive()
+        except EndOfStream:
             raise StopAsyncIteration
 
     @abstractmethod
@@ -124,6 +123,7 @@ class ByteReceiveStream(AsyncResource):
 
         :param max_bytes: maximum number of bytes to receive
         :return: the received bytes
+        :raises EndOfStream: if this stream has been closed from the other end
         """
 
 

--- a/src/anyio/streams/buffered.py
+++ b/src/anyio/streams/buffered.py
@@ -36,11 +36,7 @@ class BufferedByteReceiveStream(ByteReceiveStream):
         else:
             # With a bytes-oriented object stream, we need to handle any surplus bytes we get from
             # the receive() call
-            try:
-                chunk = await self.receive_stream.receive()
-            except EndOfStream:
-                return b''
-
+            chunk = await self.receive_stream.receive()
             if len(chunk) > max_bytes:
                 # Save the surplus bytes in the buffer
                 self._buffer.extend(chunk[max_bytes:])
@@ -70,11 +66,8 @@ class BufferedByteReceiveStream(ByteReceiveStream):
                     chunk = await self.receive_stream.receive(remaining)
                 else:
                     chunk = await self.receive_stream.receive()
-            except EndOfStream:
-                chunk = b''
-
-            if not chunk:
-                raise IncompleteRead
+            except EndOfStream as exc:
+                raise IncompleteRead from exc
 
             self._buffer.extend(chunk)
 
@@ -109,11 +102,8 @@ class BufferedByteReceiveStream(ByteReceiveStream):
             # Read more data into the buffer from the socket
             try:
                 data = await self.receive_stream.receive()
-            except EndOfStream:
-                data = b''
-
-            if not data:
-                raise IncompleteRead
+            except EndOfStream as exc:
+                raise IncompleteRead from exc
 
             # Move the offset forward and add the new data to the buffer
             offset = max(len(self._buffer) - delimiter_size + 1, 0)

--- a/src/anyio/streams/text.py
+++ b/src/anyio/streams/text.py
@@ -5,7 +5,6 @@ from typing import Callable, Tuple
 from ..abc import (
     AnyByteReceiveStream, ObjectReceiveStream, ObjectSendStream, AnyByteSendStream, ObjectStream)
 from ..abc.streams import AnyByteStream
-from ..exceptions import EndOfStream
 
 
 @dataclass
@@ -37,9 +36,6 @@ class TextReceiveStream(ObjectReceiveStream[str]):
     async def receive(self) -> str:
         while True:
             chunk = await self.transport_stream.receive()
-            if not chunk:
-                raise EndOfStream
-
             decoded = self._decoder.decode(chunk)
             if decoded:
                 return decoded

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -61,7 +61,8 @@ class TestTLSStream:
                                            ssl_context=client_context)
             msg1 = await wrapper.receive()
             stream, msg2 = await wrapper.unwrap()
-            msg2 += await stream.receive()
+            if msg2 != b'unencrypted':
+                msg2 += await stream.receive()
 
         server_thread.join()
         server_sock.close()


### PR DESCRIPTION
Byte streams will not return an empty bytes object on EOF, but raise `EndOfStream` instead.

Closes #128.