### PR TITLE
Refactored the Listener API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -70,8 +70,6 @@ Streams and stream wrappers
 
 .. autofunction:: anyio.create_memory_object_stream
 
-.. autofunction:: anyio.serve_listeners
-
 .. autoclass:: anyio.streams.buffered.BufferedByteReceiveStream
     :members:
 
@@ -79,6 +77,9 @@ Streams and stream wrappers
     :members:
 
 .. autoclass:: anyio.streams.memory.MemoryObjectSendStream
+    :members:
+
+.. autoclass:: anyio.streams.stapled.MultiListener
     :members:
 
 .. autoclass:: anyio.streams.stapled.StapledByteStream

--- a/docs/networking.rst
+++ b/docs/networking.rst
@@ -40,21 +40,21 @@ If you need to establish a TLS session over TCP, you can use :func:`~anyio.conne
 a convenience (instead of wrapping the stream with :meth:`anyio.streams.tls.TLSStream.wrap` after
 a successful connection).
 
-To receive incoming TCP connections, you first create TCP listeners with
-:func:`anyio.create_tcp_listeners` and then pass them to :func:`~anyio.serve_listeners`::
+To receive incoming TCP connections, you first create a TCP listener with
+:func:`anyio.create_tcp_listener` and call :meth:`~anyio.abc.streamsListener.serve` on it::
 
-    from anyio import create_tcp_listeners, serve_listeners, run
+    from anyio import create_tcp_listeners, run
 
 
     async def handle(client):
         async with client:
             name = await client.receive(1024)
-            await client.send_all(b'Hello, %s\n' % name)
+            await client.send(b'Hello, %s\n' % name)
 
 
     async def main():
-        listeners = create_tcp_listeners(local_port=1234)
-        await serve_listeners(handle, listeners)
+        listener = create_tcp_listener(local_port=1234)
+        await listener.serve(handle)
 
     run(main)
 
@@ -76,26 +76,26 @@ This is what the client from the TCP example looks like when converted to use UN
 
     async def main():
         async with await connect_unix('/tmp/mysock') as client:
-            await client.send_all(b'Client\n')
-            response = await client.receive_until(b'\n', 1024)
+            await client.send(b'Client\n')
+            response = await client.receive(1024)
             print(response)
 
     run(main)
 
 And the listener::
 
-    from anyio import create_unix_listener, serve_listeners, run
+    from anyio import create_unix_listener, run
 
 
     async def handle(client):
         async with client:
-            name = await client.receive_until(b'\n', 1024)
-            await client.send_all(b'Hello, %s\n' % name)
+            name = await client.receive(1024)
+            await client.send(b'Hello, %s\n' % name)
 
 
     async def main():
         listener = await create_unix_listener('/tmp/mysock')
-        await serve_listeners(handle, [listener])
+        await listener.serve(handle)
 
     run(main)
 

--- a/src/anyio/_utils.py
+++ b/src/anyio/_utils.py
@@ -39,3 +39,11 @@ def convert_ipv6_sockaddr(sockaddr):
             return sockaddr[:2]
     else:
         return sockaddr
+
+
+class NullAsyncContextManager:
+    async def __aenter__(self):
+        pass
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass

--- a/src/anyio/streams/stapled.py
+++ b/src/anyio/streams/stapled.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, Callable, Any, Optional, Sequence
 
 from ..abc import (
     ByteReceiveStream, ByteStream, ByteSendStream, ObjectStream, ObjectReceiveStream,
-    ObjectSendStream)
+    ObjectSendStream, Listener, TaskGroup)
 
 T_Item = TypeVar('T_Item')
+T_Stream = TypeVar('T_Stream')
 
 
 @dataclass
@@ -58,3 +59,42 @@ class StapledObjectStream(Generic[T_Item], ObjectStream[T_Item]):
     async def aclose(self) -> None:
         await self.send_stream.aclose()
         await self.receive_stream.aclose()
+
+
+@dataclass
+class MultiListener(Generic[T_Stream], Listener[T_Stream]):
+    """
+    Combines multiple listeners into one, serving connections from all of them at once.
+
+    Any MultiListeners in the given collection of listeners will have their listeners moved into
+    this one.
+
+    :param listeners: listeners to serve
+    :type listeners: Sequence[Listener[T_Stream]]
+    """
+
+    listeners: Sequence[Listener[T_Stream]]
+
+    def __post_init__(self):
+        listeners = []
+        for listener in self.listeners:
+            if isinstance(listener, MultiListener):
+                listeners.extend(listener.listeners)
+                del listener.listeners[:]
+            else:
+                listeners.append(listener)
+
+        self.listeners = listeners
+
+    async def serve(self, handler: Callable[[T_Stream], Any],
+                    task_group: Optional[TaskGroup] = None) -> None:
+        from .. import create_task_group
+
+        # There is a mypy bug here
+        async with create_task_group() as tg:  # type: ignore[attr-defined]
+            for listener in self.listeners:
+                await tg.spawn(listener.serve, handler, task_group)
+
+    async def aclose(self) -> None:
+        for listener in self.listeners:
+            await listener.aclose()


### PR DESCRIPTION
This replaces `accept()` with `serve()` which in turn obsoletes `anyio.serve_listeners()` which did not make it into any release.
Among other things, this lets us do the TLS handshake in the newly spawned handler task.

Fixes #125.