### PR TITLE
Added blocking portals

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -65,6 +65,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Removed the ``--anyio-backends`` command line option for the pytest plugin. Use the ``-k`` option
   to do ad-hoc filtering, and the ``anyio_backend`` fixture to control which backends you wish to
   run the tests by default.
+- Added support for "blocking portals" which allow running functions in the event loop thread from
+  external threads
 
 **1.4.0**
 

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -19,7 +19,7 @@ from ._utils import convert_ipv6_sockaddr
 from .abc import (
     Lock, Condition, Event, Semaphore, CapacityLimiter, CancelScope, TaskGroup, IPAddressType,
     SocketStream, UDPSocket, ConnectedUDPSocket, IPSockAddrType, SocketListener, Process,
-    AsyncResource)
+    AsyncResource, BlockingPortal)
 from .fileio import AsyncFile
 from .streams.stapled import MultiListener
 from .streams.tls import TLSStream
@@ -282,6 +282,37 @@ def current_default_worker_thread_limiter() -> CapacityLimiter:
 
     """
     return _get_asynclib().current_default_thread_limiter()
+
+
+def create_blocking_portal() -> BlockingPortal:
+    """Create a portal for running functions in the event loop thread."""
+    return _get_asynclib().BlockingPortal()
+
+
+def start_blocking_portal(
+        backend: str = BACKENDS[0],
+        backend_options: Optional[Dict[str, Any]] = None) -> BlockingPortal:
+    """
+    Start a new event loop in a new thread and run a blocking portal in its main task.
+
+    :param backend:
+    :param backend_options:
+    :return: a blocking portal object
+
+    """
+    async def run_portal():
+        nonlocal portal
+        async with create_blocking_portal() as portal:
+            event.set()
+            await portal.sleep_until_stopped()
+
+    portal: Optional[BlockingPortal]
+    event = threading.Event()
+    kwargs = {'func': run_portal, 'backend': backend, 'backend_options': backend_options}
+    thread = threading.Thread(target=run, kwargs=kwargs)
+    thread.start()
+    event.wait()
+    return typing.cast(BlockingPortal, portal)
 
 
 #

--- a/src/anyio/abc/__init__.py
+++ b/src/anyio/abc/__init__.py
@@ -5,7 +5,8 @@ __all__ = ('IPAddressType', 'IPSockAddrType', 'SockAddrType', 'UDPPacketType', '
            'ByteSendStream', 'ByteStream', 'AnyUnreliableByteReceiveStream',
            'AnyUnreliableByteSendStream', 'AnyUnreliableByteStream', 'AnyByteReceiveStream',
            'AnyByteSendStream', 'AnyByteStream', 'Listener', 'Process', 'Event', 'Lock',
-           'Condition', 'Semaphore', 'CapacityLimiter', 'CancelScope', 'TaskGroup', 'TestRunner')
+           'Condition', 'Semaphore', 'CapacityLimiter', 'CancelScope', 'TaskGroup', 'TestRunner',
+           'BlockingPortal')
 
 from .sockets import (
     IPAddressType, IPSockAddrType, SockAddrType, UDPPacketType, SocketStream, SocketListener,
@@ -20,3 +21,4 @@ from .subprocesses import Process
 from .synchronization import Event, Lock, Condition, Semaphore, CapacityLimiter
 from .tasks import CancelScope, TaskGroup
 from .testing import TestRunner
+from .threads import BlockingPortal

--- a/src/anyio/abc/threads.py
+++ b/src/anyio/abc/threads.py
@@ -1,0 +1,96 @@
+import threading
+from abc import ABCMeta, abstractmethod
+from concurrent.futures import Future
+from inspect import iscoroutine
+from typing import TypeVar, Callable
+
+T_Retval = TypeVar('T_Retval')
+
+
+class BlockingPortal(metaclass=ABCMeta):
+    """An object tied that lets external threads run code in an asynchronous event loop."""
+
+    __slots__ = '_task_group', '_event_loop_thread_id', '_stop_event', '_cancelled_exc_class'
+
+    def __init__(self):
+        from .. import create_event, create_task_group, get_cancelled_exc_class
+
+        self._event_loop_thread_id = threading.get_ident()
+        self._stop_event = create_event()
+        self._task_group = create_task_group()
+        self._cancelled_exc_class = get_cancelled_exc_class()
+
+    async def __aenter__(self) -> 'BlockingPortal':
+        await self._task_group.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.stop()
+        return await self._task_group.__aexit__(exc_type, exc_val, exc_tb)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.call(self.stop, exc_type is not None)
+
+    async def sleep_until_stopped(self) -> None:
+        """Sleep until :meth:`stop` is called."""
+        await self._stop_event.wait()
+
+    async def stop(self, cancel_remaining: bool = False) -> None:
+        """
+        Signal the portal to shut down.
+
+        This marks the portal as no longer accepting new calls and exits from
+        :meth:`sleep_until_stopped`.
+
+        :param cancel_remaining: ``True`` to cancel all the remaining tasks, ``False`` to let them
+            finish before returning
+
+        """
+        self._event_loop_thread_id = None
+        await self._stop_event.set()
+        if cancel_remaining:
+            await self._task_group.cancel_scope.cancel()
+
+    def stop_from_external_thread(self, cancel_remaining: bool = False) -> None:
+        thread = self.call(threading.current_thread)
+        self.call(self.stop, cancel_remaining)
+        thread.join()
+
+    async def _call_func(self, func: Callable, args: tuple, future: Future) -> None:
+        try:
+            retval = func(*args)
+            if iscoroutine(retval):
+                future.set_result(await retval)
+            else:
+                future.set_result(retval)
+        except self._cancelled_exc_class:
+            future.cancel()
+        except BaseException as exc:
+            future.set_exception(exc)
+
+    @abstractmethod
+    def _spawn_task_from_thread(self, func: Callable, args: tuple, future: Future) -> None:
+        pass
+
+    def call(self, func: Callable[..., T_Retval], *args) -> T_Retval:
+        """
+        Call the given function in the event loop thread.
+
+        If the callable returns a coroutine object, it is awaited on.
+
+        :param func: any callable
+
+        :raises RuntimeError: if this method is called from within the event loop thread
+
+        """
+        if self._event_loop_thread_id is None:
+            raise RuntimeError('This portal is not running')
+        if self._event_loop_thread_id == threading.get_ident():
+            raise RuntimeError('This method cannot be called from the event loop thread')
+
+        future: Future = Future()
+        self._spawn_task_from_thread(func, args, future)
+        return future.result()


### PR DESCRIPTION
Blocking portals allows one to either:

- launch an event loop in a separate thread and use async APIs from synchronous code
- let synchronous code call async APIs in an existing event loop