### PR TITLE
Fix UnboundLocalError in asyncio's run_sync_in_worker_thread

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -522,6 +522,7 @@ async def run_sync_in_worker_thread(
     await limiter.acquire_on_behalf_of(task)
     thread = Thread(target=thread_worker, daemon=True)
     thread.start()
+    exception = None
     async with CancelScope(shield=not cancellable):
         try:
             retval, exception = await queue.get()


### PR DESCRIPTION
I got an exception like this:
```pytb
Traceback (most recent call last):
  File "/home/user/code/language/python/3/bots/bridges/adhesive/.venv/lib/python3.8/site-packages/telethon/client/updates.py", line 443, in _dispatch_update
    await callback(event)
  File "/home/user/code/language/python/3/bots/bridges/adhesive/adhesive/telegram_bot.py", line 45, in convert
    await event.respond(await converter(event.client, event.client.signal_client, *pack_info))
  File "/home/user/code/language/python/3/bots/bridges/adhesive/adhesive/glue.py", line 56, in convert_to_signal
    await tg.spawn(add_tg_sticker, tg_client, stickers, i, tg_sticker)
  File "/home/user/code/language/python/3/bots/bridges/adhesive/.venv/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 438, in __aexit__
    raise exceptions[0]
  File "/home/user/code/language/python/3/bots/bridges/adhesive/.venv/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 466, in _run_wrapped_task
    await func(*args)
  File "/home/user/code/language/python/3/bots/bridges/adhesive/adhesive/glue.py", line 81, in add_tg_sticker
    image_data = await convert_tgs_to_webp(data)
  File "/home/user/code/language/python/3/bots/bridges/adhesive/adhesive/glue.py", line 108, in convert_tgs_to_webp
    await anyio.run_sync_in_worker_thread(export_apng, anim, apng, limiter=THREAD_LIMITER)
  File "/home/user/code/language/python/3/bots/bridges/adhesive/.venv/lib/python3.8/site-packages/anyio/_core/_threads.py", line 28, in run_sync_in_worker_thread
    return await get_asynclib().run_sync_in_worker_thread(func, *args, cancellable=cancellable,
  File "/home/user/code/language/python/3/bots/bridges/adhesive/.venv/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 531, in run_sync_in_worker_thread
    if exception is not None:
UnboundLocalError: local variable 'exception' referenced before assignment
```

This PR fixes that.