### PR TITLE
Add primitives for sync/async coordination

### DIFF
--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -6,10 +6,10 @@ __all__ = ('run', 'sleep', 'current_time', 'get_all_backends', 'get_cancelled_ex
            'create_udp_socket', 'create_connected_udp_socket', 'getaddrinfo', 'getnameinfo',
            'wait_socket_readable', 'wait_socket_writable', 'create_memory_object_stream',
            'run_process', 'open_process', 'create_lock', 'create_condition', 'create_event',
-           'create_semaphore', 'create_capacity_limiter', 'open_cancel_scope', 'fail_after',
-           'move_on_after', 'current_effective_deadline', 'create_task_group', 'TaskInfo',
-           'get_current_task', 'get_running_tasks', 'wait_all_tasks_blocked',
-           'run_sync_in_worker_thread', 'run_async_from_thread',
+           'create_universal_event', 'create_semaphore', 'create_capacity_limiter',
+           'open_cancel_scope', 'fail_after', 'move_on_after', 'current_effective_deadline',
+           'create_task_group', 'TaskInfo', 'get_current_task', 'get_running_tasks',
+           'wait_all_tasks_blocked', 'run_sync_in_worker_thread', 'run_async_from_thread',
            'current_default_worker_thread_limiter', 'create_blocking_portal',
            'start_blocking_portal', 'typed_attribute', 'TypedAttributeSet',
            'TypedAttributeProvider')
@@ -27,7 +27,8 @@ from ._core._sockets import (
 from ._core._streams import create_memory_object_stream
 from ._core._subprocesses import open_process, run_process
 from ._core._synchronization import (
-    create_capacity_limiter, create_condition, create_event, create_lock, create_semaphore)
+    create_capacity_limiter, create_condition, create_event, create_lock, create_semaphore,
+    create_universal_event)
 from ._core._tasks import (
     create_task_group, current_effective_deadline, fail_after, move_on_after, open_cancel_scope)
 from ._core._testing import TaskInfo, get_current_task, get_running_tasks, wait_all_tasks_blocked

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1063,12 +1063,9 @@ class Condition(abc.Condition):
         return await self._condition.wait()
 
 
-class Event(abc.Event):
+class BaseEvent(abc.BaseEvent):
     def __init__(self):
         self._event = asyncio.Event()
-
-    async def set(self):
-        self._event.set()
 
     def is_set(self) -> bool:
         return self._event.is_set()
@@ -1076,6 +1073,16 @@ class Event(abc.Event):
     async def wait(self):
         await checkpoint()
         await self._event.wait()
+
+
+class Event(abc.Event, BaseEvent):
+    async def set(self):
+        self._event.set()
+
+
+class UniversalEvent(abc.UniversalEvent, BaseEvent):
+    def set(self):
+        self._event.set()
 
 
 class Semaphore(abc.Semaphore):

--- a/src/anyio/_backends/_curio.py
+++ b/src/anyio/_backends/_curio.py
@@ -834,6 +834,21 @@ class Event(abc.Event):
         return await self._event.wait()
 
 
+class UniversalEvent(abc.UniversalEvent):
+    def __init__(self):
+        self._event = curio.UniversalEvent()
+
+    def set(self) -> None:
+        self._event.set()
+
+    def is_set(self) -> bool:
+        return self._event.is_set()
+
+    async def wait(self):
+        await checkpoint()
+        return await self._event.wait()
+
+
 class Semaphore(abc.Semaphore):
     def __init__(self, value: int):
         self._semaphore = curio.Semaphore(value)

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -500,18 +500,25 @@ class Lock(abc.Lock):
         self._lock.release()
 
 
-class Event:
+class BaseEvent(abc.BaseEvent):
     def __init__(self):
         self._event = trio.Event()
-
-    async def set(self) -> None:
-        self._event.set()
 
     def is_set(self) -> bool:
         return self._event.is_set()
 
     async def wait(self):
         await self._event.wait()
+
+
+class Event(abc.Event, BaseEvent):
+    async def set(self) -> None:
+        self._event.set()
+
+
+class UniversalEvent(abc.UniversalEvent, BaseEvent):
+    def set(self) -> None:
+        self._event.set()
 
 
 class Condition(abc.Condition):

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -1,4 +1,4 @@
-from ..abc import CapacityLimiter, Condition, Event, Lock, Semaphore
+from ..abc import CapacityLimiter, Condition, Event, Lock, Semaphore, UniversalEvent
 from ._eventloop import get_asynclib
 from ._exceptions import BusyResourceError
 
@@ -32,6 +32,16 @@ def create_event() -> Event:
 
     """
     return get_asynclib().Event()
+
+
+def create_universal_event() -> UniversalEvent:
+    """
+    Create an asynchronous event object that we can set from sync code.
+
+    :return: a universal event object
+
+    """
+    return get_asynclib().UniversalEvent()
 
 
 def create_semaphore(value: int) -> Semaphore:

--- a/src/anyio/abc/__init__.py
+++ b/src/anyio/abc/__init__.py
@@ -3,9 +3,9 @@ __all__ = ('AsyncResource', 'SocketAttribute', 'SocketStream', 'SocketListener',
            'UnreliableObjectStream', 'ObjectReceiveStream', 'ObjectSendStream', 'ObjectStream',
            'ByteReceiveStream', 'ByteSendStream', 'ByteStream', 'AnyUnreliableByteReceiveStream',
            'AnyUnreliableByteSendStream', 'AnyUnreliableByteStream', 'AnyByteReceiveStream',
-           'AnyByteSendStream', 'AnyByteStream', 'Listener', 'Process', 'Event', 'Lock',
-           'Condition', 'Semaphore', 'CapacityLimiter', 'CancelScope', 'TaskGroup', 'TestRunner',
-           'BlockingPortal')
+           'AnyByteSendStream', 'AnyByteStream', 'Listener', 'Process', 'BaseEvent', 'Event',
+           'UniversalEvent', 'Lock', 'Condition', 'Semaphore', 'CapacityLimiter', 'CancelScope',
+           'TaskGroup', 'TestRunner', 'BlockingPortal')
 
 from .resources import AsyncResource
 from .sockets import ConnectedUDPSocket, SocketAttribute, SocketListener, SocketStream, UDPSocket
@@ -15,7 +15,8 @@ from .streams import (
     ByteStream, Listener, ObjectReceiveStream, ObjectSendStream, ObjectStream,
     UnreliableObjectReceiveStream, UnreliableObjectSendStream, UnreliableObjectStream)
 from .subprocesses import Process
-from .synchronization import CapacityLimiter, Condition, Event, Lock, Semaphore
+from .synchronization import (
+    BaseEvent, CapacityLimiter, Condition, Event, Lock, Semaphore, UniversalEvent)
 from .tasks import CancelScope, TaskGroup
 from .testing import TestRunner
 from .threads import BlockingPortal

--- a/src/anyio/abc/synchronization.py
+++ b/src/anyio/abc/synchronization.py
@@ -7,11 +7,7 @@ T_Retval = TypeVar('T_Retval')
 IPAddressType = Union[str, IPv4Address, IPv6Address]
 
 
-class Event(metaclass=ABCMeta):
-    @abstractmethod
-    async def set(self) -> None:
-        """Set the flag, notifying all listeners."""
-
+class BaseEvent(metaclass=ABCMeta):
     @abstractmethod
     def is_set(self) -> bool:
         """Return ``True`` if the flag is set, ``False`` if not."""
@@ -23,6 +19,18 @@ class Event(metaclass=ABCMeta):
 
         If the flag has already been set when this method is called, it returns immediately.
         """
+
+
+class Event(BaseEvent):
+    @abstractmethod
+    async def set(self) -> None:
+        """Set the flag, notifying all listeners."""
+
+
+class UniversalEvent(BaseEvent):
+    @abstractmethod
+    def set(self) -> None:
+        """Set the flag, notifying all listeners."""
 
 
 class Lock(metaclass=ABCMeta):


### PR DESCRIPTION
This pull request comes from the discussion in #167. Let's take this a couple of steps at a time.

So far, I added an `anyio.create_universal_event` function. Said function returns a `UniversalEvent`. A `UniversalEvent` is like a regular `Event` except that it's `set` method is sync:

```python
def set(self) -> None:
    """Set the flag, notifying all listeners."""
```

Behind the scenes, `UniversalEvent` maps as follows:
 * asyncio: `anyio.UniversalEvent` --> `asyncio.Event`
 * trio: `anyio.UniversalEvent` --> `trio.Event`
 * curio: `anyio.UniversalEvent` --> `curio.UniversalEvent`

If you don't like the "universal" term, I'm open to suggestions. I based it on curio's terminology.

I plan to add more commits to this pull request when we agree on the API design.

Let me know what you think so far.