### PR TITLE
trio / pytest: Don't kill the test loop on exceptions

### DIFF
--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -674,6 +674,8 @@ class TestRunner(abc.TestRunner):
     async def _call_func(self, func, args, kwargs):
         try:
             retval = await func(*args, **kwargs)
+        except Exception as exc:
+            self._result_queue.append(Error(exc))
         except BaseException as exc:
             self._result_queue.append(Error(exc))
             raise


### PR DESCRIPTION
"Normal" Exceptions must not propagate to Trio.
    

Otherwise there's a race condition:
* main task [starts Trio and] queues an async call

  * Trio handles the call and steps through the call, or rather tells the main task to do so

* one of the steps in question raises an exception
* the exception is queued for the main task to process,
  but also re-raised and thus propagated to Trio

  * the Trio task starts shutting itself down

* main task reads the exception from the queue
* main task processes the exception and starts calling finalizers
* one of the finalizers calls into Trio (_nursery is still set)
* main task waits on the _call_queue

  * Trio calls the finalizer which clears _nursery
  * the Trio thread ends

* main task hangs indefinitely.
