### PR TITLE
Add network mark to getaddrinfo test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ max_line_length = 99
 addopts = "-rsx --tb=short"
 testpaths = ["tests"]
 filterwarnings = "always"
+markers = [
+    "network",
+]
 
 [tool.coverage.run]
 source = ["anyio"]

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -828,6 +828,7 @@ class TestConnectedUDPSocket:
             await udp.send(b'foo')
 
 
+@pytest.mark.network
 async def test_getaddrinfo():
     # IDNA 2003 gets this wrong
     correct = await getaddrinfo('faß.de', 0)


### PR DESCRIPTION
Calling getaddrinfo in a builder without network access results in an error as
it cannot contact a DNS server. The network marker is used by convention to mark
such tests and allows this test to be skipped.