### PR TITLE
Made start_blocking_portal() a context manager

### DIFF
--- a/docs/threads.rst
+++ b/docs/threads.rst
@@ -63,14 +63,6 @@ One way to do this is to start a new event loop with a portal, using
     from anyio import start_blocking_portal
 
 
-    portal = start_blocking_portal(backend='trio')
-    portal.call(...)
-
-    # At the end of your application, stop the portal
-    portal.stop_from_external_thread()
-
-Or, you can use it as a context manager if that suits your use case::
-
     with start_blocking_portal(backend='trio') as portal:
         portal.call(...)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - **BACKWARDS INCOMPATIBLE** Submodules under ``anyio.abc.`` have been made private (use only
   ``anyio.abc`` from now on).
+- **BACKWARDS INCOMPATIBLE** ``start_blocking_portal()`` must now be used as a context manager (it
+  no longer returns a BlockingPortal, but a context manager that yields one)
+- **BACKWARDS INCOMPATIBLE** Removed the ``BlockingPortal.stop_from_external_thread()`` method
+  (do ``portal.call(portal.stop)`` instead now)
 - Dropped Curio as a backend (see the :doc:`FAQ <faq>` as for why)
 - Added the ``run_sync_from_thread()`` function
 - Fixed ``TLSStream.send_eof()`` raising ``ValueError`` instead of the expected

--- a/src/anyio/_core/_threads.py
+++ b/src/anyio/_core/_threads.py
@@ -97,6 +97,9 @@ def start_blocking_portal(
     :param backend_options: backend options
     :return: a context manager that yields a blocking portal
 
+    .. versionchanged:: 3.0
+        Usage as a context manager is now required.
+
     """
     async def run_portal():
         async with create_blocking_portal() as portal_:

--- a/src/anyio/_core/_threads.py
+++ b/src/anyio/_core/_threads.py
@@ -124,5 +124,5 @@ def start_blocking_portal(
                 raise
 
             portal.call(portal.stop, False)
-        else:
-            run_future.result()
+
+        run_future.result()

--- a/src/anyio/abc/_threads.py
+++ b/src/anyio/abc/_threads.py
@@ -75,12 +75,6 @@ class BlockingPortal(metaclass=ABCMeta):
         await self.stop()
         return await self._task_group.__aexit__(exc_type, exc_val, exc_tb)
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.call(self.stop, exc_type is not None)
-
     async def sleep_until_stopped(self) -> None:
         """Sleep until :meth:`stop` is called."""
         await self._stop_event.wait()
@@ -100,18 +94,6 @@ class BlockingPortal(metaclass=ABCMeta):
         await self._stop_event.set()
         if cancel_remaining:
             await self._task_group.cancel_scope.cancel()
-
-    def stop_from_external_thread(self, cancel_remaining: bool = False) -> None:
-        """
-        Signal the portal to stop and wait for the event loop thread to finish.
-
-        :param cancel_remaining: ``True`` to cancel all the remaining tasks, ``False`` to let them
-            finish before returning
-
-        """
-        thread = self.call(threading.current_thread)
-        self.call(self.stop, cancel_remaining)
-        thread.join()
 
     async def _call_func(self, func: Callable, args: tuple, future: Future) -> None:
         def callback(f: Future):

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -306,6 +306,13 @@ class TestBlockingPortal:
         assert isinstance(thread_id, int)
         assert thread_id != threading.get_ident()
 
+    def test_start_with_nonexistent_backend(self):
+        with pytest.raises(LookupError) as exc:
+            with start_blocking_portal('foo'):
+                pass
+
+        exc.match('No such backend: foo')
+
     def test_call_stopped_portal(self, anyio_backend_name, anyio_backend_options):
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
             pass

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -296,29 +296,20 @@ class TestBlockingPortal:
             exc = pytest.raises(RuntimeError, portal.call, threading.get_ident)
             exc.match('This method cannot be called from the event loop thread')
 
-    @pytest.mark.parametrize('use_contextmanager', [False, True],
-                             ids=['contextmanager', 'startstop'])
-    def test_start_with_new_event_loop(self, anyio_backend_name, anyio_backend_options,
-                                       use_contextmanager):
+    def test_start_with_new_event_loop(self, anyio_backend_name, anyio_backend_options):
         async def async_get_thread_id():
             return threading.get_ident()
 
-        if use_contextmanager:
-            with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
-                thread_id = portal.call(async_get_thread_id)
-        else:
-            portal = start_blocking_portal(anyio_backend_name, anyio_backend_options)
-            try:
-                thread_id = portal.call(async_get_thread_id)
-            finally:
-                portal.call(portal.stop)
+        with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
+            thread_id = portal.call(async_get_thread_id)
 
         assert isinstance(thread_id, int)
         assert thread_id != threading.get_ident()
 
     def test_call_stopped_portal(self, anyio_backend_name, anyio_backend_options):
-        portal = start_blocking_portal(anyio_backend_name, anyio_backend_options)
-        portal.call(portal.stop)
+        with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
+            pass
+
         pytest.raises(RuntimeError, portal.call, threading.get_ident).\
             match('This portal is not running')
 


### PR DESCRIPTION
* Ensures that the thread is joined when exiting
* Eliminates a potentially confusing regular context manager from BlockingPortal