### PR TITLE
Added backwards compatibility code and migration docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -146,6 +146,12 @@ Operating system signals
 
 .. autofunction:: anyio.open_signal_receiver
 
+Compatibility
+-------------
+
+.. autofunction:: anyio.maybe_async
+.. autofunction:: anyio.maybe_async_cm
+
 Testing and debugging
 ---------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ The manual
    signals
    testing
    api
+   migration
    faq
    support
    contributing

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1,6 +1,8 @@
 Migrating from AnyIO 2 to AnyIO 3
 =================================
 
+.. py:currentmodule:: anyio
+
 AnyIO 3 changed several previously asynchronous functions and methods into regular ones for two
 reasons:
 
@@ -9,29 +11,31 @@ reasons:
 
 The following functions and methods were changed:
 
-* ``current_time()``
-* ``current_effective_deadline()``
-* ``CancelScope.cancel()``
-* ``CapacityLimiter.acquire_nowait()``
-* ``CapacityLimiter.acquire_on_behalf_of_nowait()``
-* ``Condition.release()``
-* ``Event.set()``
-* ``get_current_task()``
-* ``get_running_tasks()``
-* ``Lock.release()``
-* ``MemoryObjectReceiveStream.receive_nowait()``
-* ``MemoryObjectSendStream.send_nowait()``
-* ``open_signal_receiver()``
-* ``Semaphore.release()``
-* ``TaskGroup.spawn()``
+* :func:`current_time`
+* :func:`current_effective_deadline`
+* :meth:`CancelScope.cancel() <.abc.CancelScope.cancel>`
+* :meth:`CapacityLimiter.acquire_nowait() <.abc.CapacityLimiter.acquire_nowait>`
+* :meth:`CapacityLimiter.acquire_on_behalf_of_nowait()
+  <.abc.CapacityLimiter.acquire_on_behalf_of_nowait>`
+* :meth:`Condition.release() <.abc.Condition.release>`
+* :meth:`Event.set() <.abc.Event.set>`
+* :func:`get_current_task`
+* :func:`get_running_tasks`
+* :meth:`Lock.release() <.abc.Lock.release>`
+* :meth:`MemoryObjectReceiveStream.receive_nowait()
+  <.streams.memory.MemoryObjectReceiveStream.receive_nowait>`
+* :meth:`MemoryObjectSendStream.send_nowait() <.streams.memory.MemoryObjectSendStream.send_nowait>`
+* :func:`open_signal_receiver`
+* :meth:`Semaphore.release() <.abc.Semaphore.release>`
+* :meth:`TaskGroup.spawn() <.abc.TaskGroup.spawn>`
 
 When migrating to AnyIO 3, simply remove the ``await`` from each call to these.
 
 The following async context managers changed to regular context managers:
 
-* ``fail_after()``
-* ``move_on_after()``
-* ``open_cancel_scope()``
+* :func:`fail_after`
+* :func:`move_on_after`
+* :func:`open_cancel_scope`
 
 When migrating, just change ``async with`` into a plain ``with``.
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1,0 +1,64 @@
+Migrating from AnyIO 2 to AnyIO 3
+=================================
+
+AnyIO 3 changed several previously asynchronous functions and methods into regular ones for two
+reasons:
+
+#. to better serve use cases where synchronous callbacks are used by third party libraries
+#. to better match the API of trio_
+
+The following functions and methods were changed:
+
+* ``current_time()``
+* ``current_effective_deadline()``
+* ``CancelScope.cancel()``
+* ``CapacityLimiter.acquire_nowait()``
+* ``CapacityLimiter.acquire_on_behalf_of_nowait()``
+* ``Condition.release()``
+* ``Event.set()``
+* ``get_current_task()``
+* ``get_running_tasks()``
+* ``Lock.release()``
+* ``MemoryObjectReceiveStream.receive_nowait()``
+* ``MemoryObjectSendStream.send_nowait()``
+* ``open_signal_receiver()``
+* ``Semaphore.release()``
+* ``TaskGroup.spawn()``
+
+When migrating to AnyIO 3, simply remove the ``await`` from each call to these.
+
+The following async context managers changed to regular context managers:
+
+* ``open_cancel_scope()``
+* ``fail_after()``
+* ``move_on_after()``
+
+When migrating, just change ``async with`` into a plain ``with``.
+
+.. _trio: https://github.com/python-trio/trio
+
+Writing libraries compatible with both 2.x and 3.x
+--------------------------------------------------
+
+When you're writing a library that needs to be compatible with both major releases, you will need
+to use the compatibility functions added in AnyIO 2.2: :func:`~maybe_async` and
+:func:`~maybe_async_cm`. These will let you safely use functions/methods and context managers
+(respectively) regardless of which major release is currently installed.
+
+Example 1 – setting an event::
+
+    from anyio.abc import Event
+    from anyio import maybe_async
+
+
+    async def foo(event: Event):
+        await maybe_async(event.set())
+        ...
+
+Example 2 – opening a cancel scope::
+
+    from anyio import open_cancel_scope, maybe_async_cm
+
+    async def foo():
+        async with maybe_async_cm(open_cancel_scope()) as scope:
+            ...

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -29,9 +29,9 @@ When migrating to AnyIO 3, simply remove the ``await`` from each call to these.
 
 The following async context managers changed to regular context managers:
 
-* ``open_cancel_scope()``
 * ``fail_after()``
 * ``move_on_after()``
+* ``open_cancel_scope()``
 
 When migrating, just change ``async with`` into a plain ``with``.
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -45,8 +45,8 @@ Writing libraries compatible with both 2.x and 3.x
 --------------------------------------------------
 
 When you're writing a library that needs to be compatible with both major releases, you will need
-to use the compatibility functions added in AnyIO 2.2: :func:`~maybe_async` and
-:func:`~maybe_async_cm`. These will let you safely use functions/methods and context managers
+to use the compatibility functions added in AnyIO 2.2: :func:`maybe_async` and
+:func:`maybe_async_cm`. These will let you safely use functions/methods and context managers
 (respectively) regardless of which major release is currently installed.
 
 Example 1 – setting an event::

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -25,12 +25,16 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   * ``open_signal_receiver()``
   * ``Semaphore.release()``
   * ``TaskGroup.spawn()``
-- **BACKWARDS INCOMPATIBLE** The following functions now return synchronous context managers
-  instead of asynchronous context managers:
 
-  * ``open_cancel_scope()``
+  Likewise, the following functions now return synchronous context managers instead of asynchronous
+  context managers:
+
   * ``fail_after()``
   * ``move_on_after()``
+  * ``open_cancel_scope()``
+
+  See the :doc:`migration documentation <migration>` for instructions on how to deal with these
+  changes.
 - **BACKWARDS INCOMPATIBLE** The ``CapacityLimiter.set_total_tokens()`` method has been removed in
   exchange of making the ``total_tokens`` property writable
 - **BACKWARDS INCOMPATIBLE** ``start_blocking_portal()`` must now be used as a context manager (it

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -1,19 +1,21 @@
-__all__ = ('run', 'sleep', 'current_time', 'get_all_backends', 'get_cancelled_exc_class',
-           'BrokenResourceError', 'BusyResourceError', 'ClosedResourceError', 'DelimiterNotFound',
-           'EndOfStream', 'ExceptionGroup', 'IncompleteRead', 'TypedAttributeLookupError',
-           'WouldBlock', 'AsyncFile', 'open_file', 'aclose_forcefully', 'open_signal_receiver',
-           'connect_tcp', 'connect_unix', 'create_tcp_listener', 'create_unix_listener',
-           'create_udp_socket', 'create_connected_udp_socket', 'getaddrinfo', 'getnameinfo',
-           'wait_socket_readable', 'wait_socket_writable', 'create_memory_object_stream',
-           'run_process', 'open_process', 'create_lock', 'create_condition', 'create_event',
-           'create_semaphore', 'create_capacity_limiter', 'open_cancel_scope', 'fail_after',
-           'move_on_after', 'current_effective_deadline', 'create_task_group', 'TaskInfo',
-           'get_current_task', 'get_running_tasks', 'wait_all_tasks_blocked',
-           'run_sync_in_worker_thread', 'run_async_from_thread', 'run_sync_from_thread',
+__all__ = ('maybe_async', 'maybe_async_cm', 'run', 'sleep', 'current_time', 'get_all_backends',
+           'get_cancelled_exc_class', 'BrokenResourceError', 'BusyResourceError',
+           'ClosedResourceError', 'DelimiterNotFound', 'EndOfStream', 'ExceptionGroup',
+           'IncompleteRead', 'TypedAttributeLookupError', 'WouldBlock', 'AsyncFile', 'open_file',
+           'aclose_forcefully', 'open_signal_receiver', 'connect_tcp', 'connect_unix',
+           'create_tcp_listener', 'create_unix_listener', 'create_udp_socket',
+           'create_connected_udp_socket', 'getaddrinfo', 'getnameinfo', 'wait_socket_readable',
+           'wait_socket_writable', 'create_memory_object_stream', 'run_process', 'open_process',
+           'create_lock', 'create_condition', 'create_event', 'create_semaphore',
+           'create_capacity_limiter', 'open_cancel_scope', 'fail_after', 'move_on_after',
+           'current_effective_deadline', 'create_task_group', 'TaskInfo', 'get_current_task',
+           'get_running_tasks', 'wait_all_tasks_blocked', 'run_sync_in_worker_thread',
+           'run_async_from_thread', 'run_sync_from_thread',
            'current_default_worker_thread_limiter', 'create_blocking_portal',
            'start_blocking_portal', 'typed_attribute', 'TypedAttributeSet',
            'TypedAttributeProvider')
 
+from ._core._compat import maybe_async, maybe_async_cm
 from ._core._eventloop import current_time, get_all_backends, get_cancelled_exc_class, run, sleep
 from ._core._exceptions import (
     BrokenResourceError, BusyResourceError, ClosedResourceError, DelimiterNotFound, EndOfStream,

--- a/src/anyio/_core/_compat.py
+++ b/src/anyio/_core/_compat.py
@@ -25,7 +25,7 @@ async def maybe_async(__obj):
 
     :return: the result of awaiting on the object if coroutine, or the object itself otherwise
 
-    .. versionadded:: 2.1
+    .. versionadded:: 2.2
 
     """
     if iscoroutine(__obj):
@@ -55,7 +55,7 @@ def maybe_async_cm(cm: Union[ContextManager[T], AsyncContextManager[T]]) -> Asyn
     :param cm: a regular or async context manager
     :return: an async context manager
 
-    .. versionadded:: 2.1
+    .. versionadded:: 2.2
 
     """
     if hasattr(cm, '__aenter__') and hasattr(cm, '__aexit__'):

--- a/src/anyio/_core/_compat.py
+++ b/src/anyio/_core/_compat.py
@@ -1,0 +1,65 @@
+from asyncio import iscoroutine
+from contextlib import AbstractContextManager
+from typing import Any, AsyncContextManager, ContextManager, Coroutine, TypeVar, Union, overload
+
+T = TypeVar('T')
+
+
+@overload
+async def maybe_async(__obj: Coroutine[Any, Any, T]) -> T:
+    ...
+
+
+@overload
+async def maybe_async(__obj: T) -> T:
+    ...
+
+
+async def maybe_async(__obj):
+    """
+    Await on the given object if necessary.
+
+    This function is intended to bridge the gap between AnyIO 2.x and 3.x where some functions and
+    methods were converted from coroutine functions into regular functions.
+
+    :return: the result of awaiting on the object if coroutine, or the object itself otherwise
+
+    .. versionadded:: 2.1
+
+    """
+    if iscoroutine(__obj):
+        return await __obj
+    else:
+        return __obj
+
+
+class _ContextManagerWrapper:
+    def __init__(self, cm: ContextManager[T]):
+        self._cm = cm
+
+    async def __aenter__(self) -> T:
+        return self._cm.__enter__()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+        return self._cm.__exit__(exc_type, exc_val, exc_tb)
+
+
+def maybe_async_cm(cm: Union[ContextManager[T], AsyncContextManager[T]]) -> AsyncContextManager[T]:
+    """
+    Wrap a regular context manager as an async one if necessary.
+
+    This function is intended to bridge the gap between AnyIO 2.x and 3.x where some functions and
+    methods were changed to return regular context managers instead of async ones.
+
+    :param cm: a regular or async context manager
+    :return: an async context manager
+
+    .. versionadded:: 2.1
+
+    """
+    if hasattr(cm, '__aenter__') and hasattr(cm, '__aexit__'):
+        return cm
+    elif isinstance(cm, AbstractContextManager):
+        return _ContextManagerWrapper(cm)
+
+    raise TypeError('Given object is neither a regular or an asynchronous context manager')

--- a/src/anyio/_core/_compat.py
+++ b/src/anyio/_core/_compat.py
@@ -1,6 +1,7 @@
 from asyncio import iscoroutine
 from contextlib import AbstractContextManager
-from typing import Any, AsyncContextManager, ContextManager, Coroutine, TypeVar, Union, overload
+from typing import (
+    Any, AsyncContextManager, ContextManager, Coroutine, Optional, TypeVar, Union, cast, overload)
 
 T = TypeVar('T')
 
@@ -40,7 +41,7 @@ class _ContextManagerWrapper:
     async def __aenter__(self) -> T:
         return self._cm.__enter__()
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> Optional[bool]:
         return self._cm.__exit__(exc_type, exc_val, exc_tb)
 
 
@@ -58,7 +59,7 @@ def maybe_async_cm(cm: Union[ContextManager[T], AsyncContextManager[T]]) -> Asyn
 
     """
     if hasattr(cm, '__aenter__') and hasattr(cm, '__aexit__'):
-        return cm
+        return cast(AsyncContextManager[T], cm)
     elif isinstance(cm, AbstractContextManager):
         return _ContextManagerWrapper(cm)
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,41 @@
+import pytest
+
+from anyio import maybe_async, maybe_async_cm
+
+pytestmark = pytest.mark.anyio
+
+
+def dummy():
+    return 'foo'
+
+
+async def dummy_async():
+    return 'foo'
+
+
+class DummyContextManager:
+    def __enter__(self):
+        return 'foo'
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+class DummyAsyncContextManager:
+    async def __aenter__(self):
+        return 'foo'
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+@pytest.mark.parametrize('function', [dummy, dummy_async], ids=['sync', 'async'])
+async def test_maybe_async(function):
+    assert await maybe_async(function()) == 'foo'
+
+
+@pytest.mark.parametrize('cm', [DummyContextManager(), DummyAsyncContextManager()],
+                         ids=['sync', 'async'])
+async def test_maybe_async_cm(cm):
+    async with maybe_async_cm(cm) as wrapped:
+        assert wrapped == 'foo'


### PR DESCRIPTION
These changes will be backported to the 2.x branch. They allow library authors to write code compatible with both major releases.