### PR TITLE
Forward all exceptions to the caller

### DIFF
--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -497,11 +497,8 @@ class TestRunner(abc.TestRunner):
     async def _call_func(self, func, args, kwargs):
         try:
             retval = await func(*args, **kwargs)
-        except Exception as exc:
-            self._result_queue.append(Error(exc))
         except BaseException as exc:
             self._result_queue.append(Error(exc))
-            raise
         else:
             self._result_queue.append(Value(retval))
 

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -95,3 +95,19 @@ async def test_wait_all_tasks_blocked_asend(anyio_backend):
     await wait_all_tasks_blocked()
     await task
     await agen.aclose()
+
+
+@pytest.fixture
+async def some_feature(request, anyio_backend):
+    yield None
+    await anyio.sleep(0)
+
+
+class TestSkipping:
+    """
+    This test fails with Trio when the guest mode runner sees the
+    cancellation.
+    """
+    async def test_skip_inline(self, some_feature):
+        """Test for github #214"""
+        pytest.skip("Test that skipping works")


### PR DESCRIPTION
Normal practice is to forward `Exception`s to the caller, but to handle
`BaseException`s yourself.

This does not apply here. Trio's guest mode is a special-purpose context
which must not terminate. Thus, we need to forward all exceptions to the
caller.