### PR TITLE
Implement worker processes

### DIFF
--- a/.github/workflows/codeqa-test.yml
+++ b/.github/workflows/codeqa-test.yml
@@ -29,6 +29,7 @@ jobs:
 
   test:
     needs: [lint]
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -14,7 +14,8 @@ __all__ = ('maybe_async', 'maybe_async_cm', 'run', 'sleep', 'current_time', 'get
            'wait_all_tasks_blocked', 'run_sync_in_worker_thread', 'run_async_from_thread',
            'run_sync_from_thread', 'current_default_worker_thread_limiter',
            'create_blocking_portal', 'start_blocking_portal', 'typed_attribute',
-           'TypedAttributeSet', 'TypedAttributeProvider')
+           'TypedAttributeSet', 'TypedAttributeProvider', 'run_sync_in_worker_process',
+           'current_default_worker_process_limiter', 'BrokenWorkerError')
 
 from ._core._compat import maybe_async, maybe_async_cm
 from ._core._eventloop import current_time, get_all_backends, get_cancelled_exc_class, run, sleep
@@ -40,6 +41,8 @@ from ._core._threads import (
     create_blocking_portal, current_default_worker_thread_limiter, run_async_from_thread,
     run_sync_from_thread, run_sync_in_worker_thread, start_blocking_portal)
 from ._core._typedattr import TypedAttributeProvider, TypedAttributeSet, typed_attribute
+from ._core._workers import (
+    BrokenWorkerError, current_default_worker_process_limiter, run_sync_in_worker_process)
 from .abc._synchronization import CapacityLimiterStatistics, EventStatistics
 
 # Re-export imports so they look like they live directly in this package

--- a/src/anyio/_core/_workers.py
+++ b/src/anyio/_core/_workers.py
@@ -201,7 +201,8 @@ class WorkerProc:
                 self._proc.terminate()
 
     async def wait(self):
-        await run_sync_in_worker_thread(self._proc.join)
+        while self._proc.is_alive():
+            await run_sync_in_worker_thread(self._proc.join, 1, cancellable=True)
 
 
 class PypyWorkerProc(WorkerProc):

--- a/src/anyio/_core/_workers.py
+++ b/src/anyio/_core/_workers.py
@@ -1,0 +1,306 @@
+import os
+import platform
+import threading
+import traceback
+from collections import deque
+from itertools import count
+from multiprocessing import get_context
+from threading import BrokenBarrierError
+from typing import Callable, Optional, TypeVar
+
+from ..abc import CapacityLimiter
+from ._eventloop import get_asynclib
+from ._lowlevel import checkpoint
+from ._synchronization import create_capacity_limiter
+from ._tasks import create_task_group, open_cancel_scope
+from ._threads import run_sync_in_worker_thread
+
+T_Retval = TypeVar('T_Retval')
+
+
+# Code to embed a traceback in a remote exception.  This is borrowed
+# straight from multiprocessing.pool.  Copied here to avoid possible
+# confusion when reading the traceback message (it will identify itself
+# as originating from curio as opposed to multiprocessing.pool).
+
+class RemoteTraceback(Exception):
+
+    def __init__(self, tb):
+        self.tb = tb
+
+    def __str__(self):
+        return self.tb
+
+
+class ExceptionWithTraceback:
+
+    def __init__(self, exc, tb):
+        tb = traceback.format_exception(type(exc), exc, tb)
+        tb = ''.join(tb)
+        self.exc = exc
+        self.tb = '\n"""\n%s"""' % tb
+
+    def __reduce__(self):
+        return rebuild_exc, (self.exc, self.tb)
+
+
+def rebuild_exc(exc, tb):
+    exc.__cause__ = RemoteTraceback(tb)
+    return exc
+
+
+class BrokenWorkerError(RuntimeError):
+    """Raised when a worker process fails or dies unexpectedly.
+
+    This error is not typically encountered in normal use, and indicates a severe
+    failure of either anyio or the code that was executing in the worker.
+    """
+
+    pass
+
+
+DEFAULT_LIMIT = os.cpu_count() or 2
+_limiter_local = threading.local()
+_limiter_local.limiters = {}
+
+
+def current_default_worker_process_limiter() -> CapacityLimiter:
+    """
+    Return the capacity limiter that is used by default to limit the number of concurrent
+    processes. Defaults to the value returned by os.cpu_count()
+
+    :return: a capacity limiter object
+
+    """
+
+    try:
+        return _limiter_local.limiters[get_asynclib()]
+    except KeyError:
+        limiter = _limiter_local.limiters[get_asynclib()] = create_capacity_limiter(DEFAULT_LIMIT)
+        return limiter
+
+
+# How long a process will idle waiting for new work before gives up and exits.
+# This should be longer than a thread timeout proportionately to startup time.
+IDLE_TIMEOUT = 60 * 10
+
+_proc_counter = count()
+
+
+class WorkerProc:
+    def __init__(self, mp_context=get_context("spawn")):
+        # It is almost possible to synchronize on the pipe alone but on Pypy
+        # the _send_pipe doesn't raise the correct error on death. Anyway,
+        # this Barrier strategy is more obvious to understand.
+        self._barrier = mp_context.Barrier(2)
+        child_recv_pipe, self._send_pipe = mp_context.Pipe(duplex=False)
+        self._recv_pipe, child_send_pipe = mp_context.Pipe(duplex=False)
+        self._proc = mp_context.Process(
+            target=self._work,
+            args=(self._barrier, child_recv_pipe, child_send_pipe),
+            name=f"trio-parallel worker process {next(_proc_counter)}",
+            daemon=True,
+        )
+        # keep our own state flag for quick checks
+        self._started = False
+
+    @staticmethod
+    def _work(barrier, recv_pipe, send_pipe):  # pragma: no cover
+
+        import inspect
+
+        def coroutine_checker(fn, args):
+            ret = fn(*args)
+            if inspect.iscoroutine(ret):
+                # Manually close coroutine to avoid RuntimeWarnings
+                ret.close()
+                raise TypeError(
+                    "Worker expected a sync function, but {!r} appears "
+                    "to be asynchronous".format(getattr(fn, "__qualname__", fn))
+                )
+
+            return ret
+
+        while True:
+            try:
+                # Return value is party #, not whether awoken within timeout
+                barrier.wait(timeout=IDLE_TIMEOUT)
+            except BrokenBarrierError:
+                # Timeout waiting for job, so we can exit.
+                return
+            # We got a job, and we are "woken"
+            fn, args = recv_pipe.recv()
+            # Send the result to the main process and go back to idling
+            try:
+                result = coroutine_checker(fn, args)
+            except BaseException as err:
+                send_pipe.send((ExceptionWithTraceback(err, err.__traceback__), True))
+            else:
+                send_pipe.send((result, False))
+
+            del fn
+            del args
+            del result
+
+    def _communicate_job(self, sync_fn, args):
+        self._send_pipe.send((sync_fn, args))
+        return self._recv_pipe.recv()
+
+    async def run_sync(self, sync_fn, *args):
+        # Neither this nor the child process should be waiting at this point
+        assert not self._barrier.n_waiting, "Must first wake_up() the worker"
+        try:
+            # NOTE: upon cancellation the worker must be killed to free the thread
+            outcome, error = await run_sync_in_worker_thread(
+                self._communicate_job, sync_fn, args, cancellable=True)
+        except EOFError:
+            # Likely the worker died while we were waiting on a pipe
+            self.kill()  # NOTE: must reap zombie child elsewhere
+            raise BrokenWorkerError(f"{self._proc} died unexpectedly")
+        except BaseException:
+            # Cancellation or other unknown errors leave the process in an
+            # unknown state, so there is no choice but to kill.
+            self.kill()  # NOTE: must reap zombie child elsewhere
+            raise
+        else:
+            if error:
+                raise outcome
+            else:
+                return outcome
+
+    def is_alive(self):
+        # if the proc is alive, there is a race condition where it could be
+        # dying, but the the barrier should be broken at that time. This
+        # call reaps zombie children on Unix.
+        return self._proc.is_alive()
+
+    def wake_up(self, timeout=None):
+        if not self._started:
+            self._proc.start()
+            self._started = True
+        try:
+            self._barrier.wait(timeout)
+        except BrokenBarrierError:
+            # raise our own flavor of exception and reap child
+            if self._proc.is_alive():  # pragma: no cover - rare race condition
+                self.kill()
+                self._proc.join(1)  # this will block for ms, but it should be rare
+                assert not self._proc.is_alive(), f"{self._proc} alive after failed wakeup"
+            raise BrokenWorkerError(f"{self._proc} died unexpectedly") from None
+
+    def kill(self):
+        # race condition: if we kill while the proc has the underlying
+        # semaphore, we can deadlock it, so make sure we hold it.
+        with self._barrier._cond:
+            self._barrier.abort()
+            try:
+                self._proc.kill()
+            except AttributeError:
+                # cpython 3.6 has an edge case where if this process holds
+                # the semaphore, a wait can timeout and raise an OSError.
+                self._proc.terminate()
+
+    async def wait(self):
+        await run_sync_in_worker_thread(self._proc.join)
+
+
+class PypyWorkerProc(WorkerProc):
+    async def run_sync(self, sync_fn, *args):
+        async with create_task_group() as group:
+            group.spawn(self.child_monitor)
+            result = await super().run_sync(sync_fn, *args)
+            group.cancel_scope.cancel()
+        return result
+
+    async def child_monitor(self):
+        # If this worker dies, raise a catchable error...
+        await self.wait()
+        # but not if another error or cancel is incoming, those take priority!
+        await checkpoint()
+        raise BrokenWorkerError(f"{self._proc} died unexpectedly")
+
+
+class WorkerCache:
+    def __init__(self):
+        # The cache is a deque rather than dict here since processes can't remove
+        # themselves anyways, so we don't need O(1) lookups
+        self._cache = deque()
+        # NOTE: avoid thread races between runs by only interacting with
+        # self._cache via thread-atomic actions like append, pop, del
+
+    def prune(self):
+        # take advantage of the oldest proc being on the left to
+        # keep iteration O(dead workers)
+        try:
+            while True:
+                proc = self._cache.popleft()
+                if proc.is_alive():
+                    self._cache.appendleft(proc)
+                    return
+        except IndexError:
+            # Thread safety: it's necessary to end the iteration using this error
+            # when the cache is empty, as opposed to `while self._cache`.
+            pass
+
+    def push(self, proc):
+        self._cache.append(proc)
+
+    def pop(self):
+        # Get live, WOKEN worker process or raise IndexError
+        while True:
+            proc = self._cache.pop()
+            try:
+                proc.wake_up(0)
+            except BrokenWorkerError:
+                # proc must have died in the cache, just try again
+                continue
+            else:
+                return proc
+
+    def __len__(self):
+        return len(self._cache)
+
+
+WORKER_CACHE = WorkerCache()
+
+
+async def run_sync_in_worker_process(
+        func: Callable[..., T_Retval], *args, cancellable: bool = False,
+        limiter: Optional[CapacityLimiter] = None) -> T_Retval:
+    """
+    Call the given function with the given arguments in a worker processs.
+
+    If the ``cancellable`` option is enabled and the task waiting for its completion is cancelled,
+    the process will be terminated with SIGKILL/TerminateProcess.
+
+    :param func: a callable
+    :param args: positional arguments for the callable
+    :param cancellable: ``True`` to allow cancellation of the operation
+    :param limiter: capacity limiter to use to limit the total amount of processes running
+        (if omitted, the default limiter is used)
+    :return: an awaitable that yields the return value of the function.
+
+    """
+
+    if limiter is None:
+        limiter = current_default_worker_process_limiter()
+
+    async with limiter:
+        await checkpoint()
+        WORKER_CACHE.prune()
+
+        try:
+            proc = WORKER_CACHE.pop()
+        except IndexError:
+            if platform.python_implementation() == "PyPy":
+                proc = PypyWorkerProc()
+            else:
+                proc = WorkerProc()
+            await run_sync_in_worker_thread(proc.wake_up)
+
+        try:
+            with open_cancel_scope(shield=not cancellable):
+                return await proc.run_sync(func, *args)
+        finally:
+            if proc.is_alive():
+                WORKER_CACHE.push(proc)

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,0 +1,238 @@
+import multiprocessing
+import os
+
+import pytest
+
+import anyio
+from anyio._core._workers import WORKER_CACHE, WorkerProc
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(autouse=True)
+def empty_proc_cache():
+    while True:
+        try:
+            proc = WORKER_CACHE.pop()
+            proc.kill()
+            proc._proc.join()
+        except IndexError:
+            return
+
+
+def _echo_and_pid(x):  # pragma: no cover
+    return (x, os.getpid())
+
+
+def _raise_pid():  # pragma: no cover
+    raise ValueError(os.getpid())
+
+
+async def test_run_in_worker():
+    trio_pid = os.getpid()
+    limiter = anyio.create_capacity_limiter(1)
+
+    x, child_pid = await anyio.run_sync_in_worker_process(_echo_and_pid, 1, limiter=limiter)
+    assert x == 1
+    assert child_pid != trio_pid
+
+    with pytest.raises(ValueError) as excinfo:
+        await anyio.run_sync_in_worker_process(_raise_pid, limiter=limiter)
+    print(excinfo.value.args)
+    assert excinfo.value.args[0] != trio_pid
+
+
+def _block_proc_on_queue(q, ev, done_ev):  # pragma: no cover
+    # Make the process block for a controlled amount of time
+    ev.set()
+    q.get()
+    done_ev.set()
+
+
+async def test_cancellation(capfd):
+    async def child(q, ev, done_ev, cancellable):
+        print("start")
+        try:
+            return await anyio.run_sync_in_worker_process(
+                _block_proc_on_queue, q, ev, done_ev, cancellable=cancellable
+            )
+        finally:
+            print("exit")
+
+    m = multiprocessing.Manager()
+    q = m.Queue()
+    ev = m.Event()
+    done_ev = m.Event()
+
+    # This one can't be cancelled
+    async with anyio.create_task_group() as nursery:
+        nursery.spawn(child, q, ev, done_ev, False)
+        await anyio.run_sync_in_worker_thread(ev.wait, cancellable=True)
+        nursery.cancel_scope.cancel()
+        with anyio.open_cancel_scope(shield=True):
+            await anyio.wait_all_tasks_blocked()
+        # It's still running
+        assert not done_ev.is_set()
+        q.put(None)
+        # Now it exits
+
+    ev = m.Event()
+    done_ev = m.Event()
+    # But if we cancel *before* it enters, the entry is itself a cancellation
+    # point
+    with anyio.open_cancel_scope() as scope:
+        scope.cancel()
+        await child(q, ev, done_ev, False)
+        assert False, 'unreachable'
+    capfd.readouterr()
+
+    ev = m.Event()
+    done_ev = m.Event()
+    # This is truly cancellable by killing the process
+    async with anyio.create_task_group() as nursery:
+        nursery.spawn(child, q, ev, done_ev, True)
+        # Give it a chance to get started. (This is important because
+        # to_thread_run_sync does a checkpoint_if_cancelled before
+        # blocking on the thread, and we don't want to trigger this.)
+        await anyio.wait_all_tasks_blocked()
+        assert capfd.readouterr().out.rstrip() == "start"
+        await anyio.run_sync_in_worker_thread(ev.wait, cancellable=True)
+        # Then cancel it.
+        nursery.cancel_scope.cancel()
+    # The task exited, but the process died
+    assert not done_ev.is_set()
+    assert capfd.readouterr().out.rstrip() == "exit"
+
+
+async def _null_async_fn():  # pragma: no cover
+    pass
+
+
+async def test_raises_on_async_fn():
+    with pytest.raises(TypeError, match="expected a sync function"):
+        await anyio.run_sync_in_worker_process(_null_async_fn)
+
+
+async def test_prune_cache():
+    # take proc's number and kill it for the next test
+    while True:
+        _, pid1 = await anyio.run_sync_in_worker_process(_echo_and_pid, None)
+        try:
+            proc = WORKER_CACHE.pop()
+        except IndexError:  # pragma: no cover
+            # In CI apparently the worker occasionally doesn't make it all the way
+            # to the barrier in time. This is only a slight inefficiency rather
+            # than a bug so for now just work around it with this loop.
+            continue
+        else:
+            break
+    proc.kill()
+    with anyio.fail_after(1):
+        await proc.wait()
+    # put dead proc into the cache (normal code never does this)
+    WORKER_CACHE.push(proc)
+    # dead procs shouldn't pop out
+    with pytest.raises(IndexError):
+        WORKER_CACHE.pop()
+    WORKER_CACHE.push(proc)
+    # should spawn a new worker and remove the dead one
+    _, pid2 = await anyio.run_sync_in_worker_process(_echo_and_pid, None)
+    assert len(WORKER_CACHE) == 1
+    assert pid1 != pid2
+
+
+async def test_large_job():
+    n = 2 ** 20
+    x, _ = await anyio.run_sync_in_worker_process(_echo_and_pid, bytearray(n))
+    assert len(x) == n
+
+
+@pytest.fixture
+async def proc():
+    proc = WorkerProc()
+    await anyio.run_sync_in_worker_thread(proc.wake_up)
+    yield proc
+    with anyio.fail_after(1):
+        await proc.wait()
+
+
+def _never_halts(ev):  # pragma: no cover
+    # important difference from blocking call is cpu usage
+    ev.set()
+    while True:
+        pass
+
+
+async def test_run_sync_cancel_infinite_loop(proc):
+    m = multiprocessing.Manager()
+    ev = m.Event()
+
+    async with anyio.create_task_group() as nursery:
+        nursery.spawn(proc.run_sync, _never_halts, ev)
+        await anyio.run_sync_in_worker_thread(ev.wait, cancellable=True)
+        nursery.cancel_scope.cancel()
+
+
+async def test_run_sync_raises_on_kill(proc):
+    m = multiprocessing.Manager()
+    ev = m.Event()
+
+    with pytest.raises(anyio.BrokenWorkerError):
+        with anyio.move_on_after(10):
+            async with anyio.create_task_group() as nursery:
+                nursery.spawn(proc.run_sync, _never_halts, ev)
+                try:
+                    await anyio.run_sync_in_worker_thread(ev.wait, cancellable=True)
+                finally:
+                    # if something goes wrong, free the thread
+                    ev.set()
+                proc.kill()  # also tests multiple calls to proc.kill
+
+
+def _segfault_out_of_bounds_pointer():  # pragma: no cover
+    # https://wiki.python.org/moin/CrashingPython
+    import ctypes
+
+    i = ctypes.c_char(b"a")
+    j = ctypes.pointer(i)
+    c = 0
+    while True:
+        j[c] = b"a"
+        c += 1
+
+
+async def test_run_sync_raises_on_segfault(proc):
+    # This test was flaky on CI across several platforms and implementations.
+    # I can reproduce it locally if there is some other process using the rest
+    # of the CPU (F@H in this case) although I cannot explain why running this
+    # on a busy machine would change the number of iterations (40-50k) needed
+    # for the OS to notice there is something funny going on with memory access.
+    # The usual symptom was for the segfault to occur, but the process
+    # to fail to raise the error for more than one minute, which would
+    # stall the test runner for 10 minutes.
+    # Here we raise our own failure error before the test runner timeout (55s)
+    # but xfail if we actually have to timeout.
+    try:
+        with anyio.fail_after(55):
+            await proc.run_sync(_segfault_out_of_bounds_pointer)
+    except anyio.BrokenWorkerError:
+        pass
+    except TimeoutError:  # pragma: no cover
+        pytest.xfail("Unable to cause segfault after 55 seconds.")
+    else:  # pragma: no cover
+        pytest.fail("No error was raised on segfault.")
+
+
+async def test_exhaustively_cancel_run_sync(proc):
+    # to test that cancellation does not ever leave a living process behind
+    # currently requires manually targeting all but last checkpoints
+    m = multiprocessing.Manager()
+    ev = m.Event()
+
+    # cancel at job send
+    with anyio.fail_after(1):
+        with anyio.move_on_after(0):
+            await proc.run_sync(_never_halts, ev)
+        await proc.wait()
+
+    # cancel at result recv is tested elsewhere

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -218,7 +218,7 @@ async def test_run_sync_raises_on_segfault(proc):
     except anyio.BrokenWorkerError:
         pass
     except TimeoutError:  # pragma: no cover
-        pytest.xfail("Unable to cause segfault after 55 seconds.")
+        pytest.skip("Unable to cause segfault after 55 seconds.")
     else:  # pragma: no cover
         pytest.fail("No error was raised on segfault.")
 


### PR DESCRIPTION
Closes #219. This is a straightforward transliteration of [`trio-parallel`](https://github.com/richardsheridan/trio-parallel), but using threads to portably do IPC and using a trick from [`curio`](https://github.com/dabeaz/curio/blob/bb4efc43175d454e1a55d415184db3ce0542b34b/curio/workers.py#L25-L53) to avoid depending on `outcome`.