### PR TITLE
Added support for RunVars

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -164,6 +164,8 @@ Low level operations
 .. autofunction:: anyio.lowlevel.checkpoint_if_cancelled
 .. autofunction:: anyio.lowlevel.cancel_shielded_checkpoint
 
+.. autoclass:: anyio.abc.RunVar
+
 Compatibility
 -------------
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -58,8 +58,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``Semaphore.acquire_nowait()`` methods
 - Added the ``statistics()`` method to ``Event``, ``Lock``, ``Condition``, ``Semaphore``,
   ``CapacityLimiter``, ``MemoryObjectReceiveStream`` and ``MemoryObjectSendStream``
-- Added the ``anyio.lowlevel`` module containing the ``checkpoint()``,
-  ``checkpoint_if_cancelled()`` and ``cancel_shielded_checkpoint()`` functions
+- Added the ``anyio.lowlevel`` module containing:
+
+  * The ``checkpoint()`` function
+  * The ``checkpoint_if_cancelled()`` function
+  * The ``cancel_shielded_checkpoint()`` function
+  * The ``RunVar()`` class
 - Changed ``CancelScope.deadline`` to be writable
 - ``Lock`` and ``Condition`` can now only be released by the task that acquired them. This behavior
   is now consistent on all backends whereas previously only Trio enforced this.

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -29,6 +29,7 @@ from .._core._exceptions import WouldBlock
 from .._core._sockets import GetAddrInfoReturnType, convert_ipv6_sockaddr
 from .._core._synchronization import ResourceGuard
 from ..abc import IPSockAddrType, UDPPacketType
+from ..lowlevel import RunVar
 
 if sys.version_info >= (3, 8):
     get_coro = asyncio.Task.get_coro
@@ -129,6 +130,11 @@ def get_callable_name(func: Callable) -> str:
 #
 # Event loop
 #
+
+_run_vars = WeakKeyDictionary()  # type: WeakKeyDictionary[asyncio.AbstractEventLoop, Any]
+
+current_token = get_running_loop
+
 
 def _task_started(task: asyncio.Task) -> bool:
     """Return ``True`` if the task has been started and has not finished."""
@@ -739,9 +745,6 @@ async def open_process(command, *, shell: bool, stdin: int, stdout: int, stderr:
 # Sockets and networking
 #
 
-_read_events: Dict[socket.SocketType, asyncio.Event] = {}
-_write_events: Dict[socket.SocketType, asyncio.Event] = {}
-
 
 class StreamProtocol(asyncio.Protocol):
     read_queue: Deque[bytes]
@@ -1297,18 +1300,28 @@ async def getnameinfo(sockaddr: IPSockAddrType, flags: int = 0) -> Tuple[str, st
     return cast(Tuple[str, str], result)
 
 
+_read_events: RunVar[Dict[Any, asyncio.Event]] = RunVar('read_events')
+_write_events: RunVar[Dict[Any, asyncio.Event]] = RunVar('write_events')
+
+
 async def wait_socket_readable(sock: socket.SocketType) -> None:
     await checkpoint()
-    if _read_events.get(sock):
+    try:
+        read_events = _read_events.get()
+    except LookupError:
+        read_events = {}
+        _read_events.set(read_events)
+
+    if read_events.get(sock):
         raise BusyResourceError('reading from') from None
 
     loop = get_running_loop()
-    event = _read_events[sock] = asyncio.Event()
-    get_running_loop().add_reader(sock, event.set)
+    event = read_events[sock] = asyncio.Event()
+    loop.add_reader(sock, event.set)
     try:
         await event.wait()
     finally:
-        if _read_events.pop(sock, None) is not None:
+        if read_events.pop(sock, None) is not None:
             loop.remove_reader(sock)
             readable = True
         else:
@@ -1320,16 +1333,22 @@ async def wait_socket_readable(sock: socket.SocketType) -> None:
 
 async def wait_socket_writable(sock: socket.SocketType) -> None:
     await checkpoint()
-    if _write_events.get(sock):
+    try:
+        write_events = _write_events.get()
+    except LookupError:
+        write_events = {}
+        _write_events.set(write_events)
+
+    if write_events.get(sock):
         raise BusyResourceError('writing to') from None
 
     loop = get_running_loop()
-    event = _write_events[sock] = asyncio.Event()
+    event = write_events[sock] = asyncio.Event()
     loop.add_writer(sock.fileno(), event.set)
     try:
         await event.wait()
     finally:
-        if _write_events.pop(sock, None) is not None:
+        if write_events.pop(sock, None) is not None:
             loop.remove_writer(sock)
             writable = True
         else:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -39,6 +39,8 @@ T_SockAddr = TypeVar('T_SockAddr', str, IPSockAddrType)
 #
 
 run = trio.run
+current_token = trio.lowlevel.current_trio_token
+RunVar = trio.lowlevel.RunVar
 
 
 #

--- a/src/anyio/abc/_threads.py
+++ b/src/anyio/abc/_threads.py
@@ -8,8 +8,6 @@ from typing import (
     Any, AsyncContextManager, Callable, ContextManager, Coroutine, Dict, Optional, Tuple, Type,
     TypeVar, cast, overload)
 
-from .._core._synchronization import create_event
-from .._core._tasks import open_cancel_scope
 from ..abc import Event
 from ._tasks import TaskStatus
 
@@ -29,6 +27,8 @@ class _BlockingAsyncContextManager(AbstractContextManager):
         self._portal = portal
 
     async def run_async_cm(self):
+        from .._core._synchronization import create_event
+
         try:
             self._exit_event = create_event()
             value = await self._async_cm.__aenter__()
@@ -112,6 +112,8 @@ class BlockingPortal(metaclass=ABCMeta):
 
     async def _call_func(self, func: Callable, args: tuple, kwargs: Dict[str, Any],
                          future: Future) -> None:
+        from .._core._tasks import open_cancel_scope
+
         def callback(f: Future):
             if f.cancelled():
                 self.call(scope.cancel)

--- a/src/anyio/lowlevel.py
+++ b/src/anyio/lowlevel.py
@@ -1,4 +1,10 @@
+from typing import Any, Dict, Generic, Set, TypeVar, Union, cast
+from weakref import WeakKeyDictionary
+
 from ._core._eventloop import get_asynclib
+
+T = TypeVar('T')
+D = TypeVar('D')
 
 
 async def checkpoint() -> None:
@@ -41,3 +47,100 @@ async def cancel_shielded_checkpoint() -> None:
 
     """
     await get_asynclib().cancel_shielded_checkpoint()
+
+
+def current_token() -> object:
+    """Return a backend specific token object that can be used to get back to the event loop."""
+    return get_asynclib().current_token()
+
+
+_run_vars = WeakKeyDictionary()  # type: WeakKeyDictionary[Any, Dict[str, Any]]
+_token_wrappers: Dict[Any, '_TokenWrapper'] = {}
+
+
+class _TokenWrapper:
+    __slots__ = '_token', '__weakref__'
+
+    def __init__(self, token):
+        self._token = token
+
+    def __eq__(self, other):
+        return self._token is other._token
+
+    def __hash__(self):
+        return hash(self._token)
+
+
+class RunvarToken:
+    __slots__ = '_var', '_value', '_redeemed'
+
+    def __init__(self, var: 'RunVar', value):
+        self._var = var
+        self._value = value
+        self._redeemed = False
+
+
+class RunVar(Generic[T]):
+    """Like a :class:`~contextvars.ContextVar`, expect scoped to the running event loop."""
+    __slots__ = '_name', '_default'
+
+    NO_VALUE_SET = object()
+
+    _token_wrappers: Set[_TokenWrapper] = set()
+
+    def __init__(self, name: str, default: Union[T, object] = NO_VALUE_SET):
+        self._name = name
+        self._default = default
+
+    @property
+    def _current_vars(self) -> Dict[str, T]:
+        token = current_token()
+        while True:
+            try:
+                return _run_vars[token]
+            except TypeError:
+                # Happens when token isn't weak referable (TrioToken).
+                # This workaround does mean that some memory will leak on Trio until the problem
+                # is fixed on their end.
+                token = _TokenWrapper(token)
+                self._token_wrappers.add(token)
+            except KeyError:
+                run_vars = _run_vars[token] = {}
+                return run_vars
+
+    def get(self, default: Union[T, object] = NO_VALUE_SET) -> T:
+        try:
+            return self._current_vars[self._name]
+        except KeyError:
+            if default is not RunVar.NO_VALUE_SET:
+                return cast(T, default)
+            elif self._default is not RunVar.NO_VALUE_SET:
+                return cast(T, self._default)
+
+        raise LookupError(f'Run variable "{self._name}" has no value and no default set')
+
+    def set(self, value: T) -> RunvarToken:
+        current_vars = self._current_vars
+        token = RunvarToken(self, current_vars.get(self._name, RunVar.NO_VALUE_SET))
+        current_vars[self._name] = value
+        return token
+
+    def reset(self, token: RunvarToken) -> None:
+        if token._var is not self:
+            raise ValueError('This token does not belong to this RunVar')
+
+        if token._redeemed:
+            raise ValueError('This token has already been used')
+
+        if token._value is RunVar.NO_VALUE_SET:
+            try:
+                del self._current_vars[self._name]
+            except KeyError:
+                pass
+        else:
+            self._current_vars[self._name] = token._value
+
+        token._redeemed = True
+
+    def __repr__(self):
+        return f'<RunVar name={self._name!r}>'


### PR DESCRIPTION
Another feature towards feature parity with trio.

Note that on trio, this will gradually leak memory on multiple invocations of `trio.run()` or `anyio.run(backend='trio')` until the next version (post 0.18.0) is released.