### PR TITLE
Use callbacks instead of coroutine wrappers on Python 3.8+

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -78,6 +78,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   teardown) completes
 - Changed the asyncio ``TaskGroup.spawn()`` method to call the target function immediately before
   spawning the task, for consistency across backends
+- Changed the asyncio ``TaskGroup.spawn()`` method to avoid the use of a coroutine wrapper on
+  Python 3.8+ and added a hint for hiding the wrapper in tracebacks on earlier Pythons (supported
+  by Pytest, Sentry etc.)
 
 **2.2.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -314,7 +314,6 @@ class CancelScope(abc.CancelScope, DeprecatedAsyncContextManager):
                     cancellable_tasks.add(task)
 
         for task in cancellable_tasks:
-            print('cancelling task', id(task))
             task.cancel()
 
         # Schedule another callback if there are still tasks left
@@ -486,18 +485,14 @@ class TaskGroup(abc.TaskGroup):
 
         self._active = False
         if not self.cancel_scope._parent_cancelled():
-            print('task group', id(self), ': parent cancelled, filtering out cancellation errors')
             exceptions = self._filter_cancellation_errors(self._exceptions)
-            print('exceptions left:', exceptions)
         else:
             exceptions = self._exceptions
 
         try:
             if len(exceptions) > 1:
-                print('raising exception group in task group', id(self))
                 raise ExceptionGroup(exceptions)
             elif exceptions and exceptions[0] is not exc_val:
-                print('raising single exception in task group', id(self))
                 raise exceptions[0]
         except BaseException as exc:
             # Clear the context here, as it can only be done in-flight.
@@ -1665,7 +1660,6 @@ class TestRunner(abc.TestRunner):
 
     def call(self, func: Callable[..., Awaitable], *args, **kwargs):
         def exception_handler(loop: asyncio.AbstractEventLoop, context: Dict[str, Any]) -> None:
-            print('unhandled exception:', context['exception'])
             exceptions.append(context['exception'])
 
         exceptions: List[Exception] = []


### PR DESCRIPTION
The asyncio event loop is allergic to BaseExceptions being raised by tasks on Python 3.7 and earlier, so a separate code path is left for these older versions. An effort was also made to hide the coroutine wrapper in tracebacks in frameworks that support it.