### PR TITLE
skip test if socket.SO_REUSEPORT is unsupported

### DIFF
--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -404,7 +404,7 @@ class TestTCPListener:
 
                 client.close()
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason='Not supported on Windows')
+    @pytest.mark.skipif(not hasattr(socket, "SO_REUSEPORT"), reason='SO_REUSEPORT option not supported')
     async def test_reuse_port(self, family):
         multi1 = await create_tcp_listener(local_host='localhost', family=family, reuse_port=True)
         assert len(multi1.listeners) == 1
@@ -829,7 +829,7 @@ class TestUDPSocket:
                     assert await client.receive() == (b'654321', (host, port))
                     tg.cancel_scope.cancel()
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason='Not supported on Windows')
+    @pytest.mark.skipif(not hasattr(socket, "SO_REUSEPORT"), reason='SO_REUSEPORT option not supported')
     async def test_reuse_port(self, family):
         async with await create_udp_socket(family=family, local_host='localhost',
                                            reuse_port=True) as udp:
@@ -919,7 +919,7 @@ class TestConnectedUDPSocket:
                     assert await udp1.receive() == (b'654321', (host, port))
                     tg.cancel_scope.cancel()
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason='Not supported on Windows')
+    @pytest.mark.skipif(not hasattr(socket, "SO_REUSEPORT"), reason='SO_REUSEPORT option not supported')
     async def test_reuse_port(self, family):
         async with await create_connected_udp_socket(
                 'localhost', 6000, family=family, local_host='localhost', reuse_port=True) as udp:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -404,7 +404,8 @@ class TestTCPListener:
 
                 client.close()
 
-    @pytest.mark.skipif(not hasattr(socket, "SO_REUSEPORT"), reason='SO_REUSEPORT option not supported')
+    @pytest.mark.skipif(not hasattr(socket, "SO_REUSEPORT"),
+                        reason='SO_REUSEPORT option not supported')
     async def test_reuse_port(self, family):
         multi1 = await create_tcp_listener(local_host='localhost', family=family, reuse_port=True)
         assert len(multi1.listeners) == 1
@@ -829,7 +830,8 @@ class TestUDPSocket:
                     assert await client.receive() == (b'654321', (host, port))
                     tg.cancel_scope.cancel()
 
-    @pytest.mark.skipif(not hasattr(socket, "SO_REUSEPORT"), reason='SO_REUSEPORT option not supported')
+    @pytest.mark.skipif(not hasattr(socket, "SO_REUSEPORT"),
+                        reason='SO_REUSEPORT option not supported')
     async def test_reuse_port(self, family):
         async with await create_udp_socket(family=family, local_host='localhost',
                                            reuse_port=True) as udp:
@@ -919,7 +921,8 @@ class TestConnectedUDPSocket:
                     assert await udp1.receive() == (b'654321', (host, port))
                     tg.cancel_scope.cancel()
 
-    @pytest.mark.skipif(not hasattr(socket, "SO_REUSEPORT"), reason='SO_REUSEPORT option not supported')
+    @pytest.mark.skipif(not hasattr(socket, "SO_REUSEPORT"),
+                        reason='SO_REUSEPORT option not supported')
     async def test_reuse_port(self, family):
         async with await create_connected_udp_socket(
                 'localhost', 6000, family=family, local_host='localhost', reuse_port=True) as udp:


### PR DESCRIPTION
# Summary 
Skip some tests is `socket.SO_REUSEPORT` is not supported in the user's python interpreter so that it can be built from source.
## Description
This fixes this test for python built on older kernel versions or python interpreters that do not support `socket.SO_REUSEPORT`. This allows for a more dynamic skip on this test.

Feedback is welcome! 