### PR TITLE
trio: taskgroup.cancel_scope can't yet be native

### DIFF
--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -112,7 +112,7 @@ class TaskGroup(abc.TaskGroup):
     async def __aenter__(self):
         self._active = True
         self._nursery = await self._nursery_manager.__aenter__()
-        self.cancel_scope = self._nursery.cancel_scope
+        self.cancel_scope = CancelScope(self._nursery.cancel_scope)
         return self
 
     async def __aexit__(self, exc_type: Optional[Type[BaseException]],

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -60,6 +60,11 @@ class TestDeprecations:
             with pytest.deprecated_call():
                 await scope.cancel()
 
+    async def test_taskgroup_cancel(self):
+        async with create_task_group() as tg:
+            with pytest.deprecated_call():
+                await tg.cancel_scope.cancel()
+
     async def test_capacitylimiter_acquire_nowait(self):
         limiter = create_capacity_limiter(1)
         with pytest.deprecated_call():


### PR DESCRIPTION
Trio's `cancel` doesn't return a `DeprecatedAwaitable`, which breaks
backwards compatibility.

Closes #243