### PR TITLE
Deprecated open_cancel_scope() in favor of CancelScope()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -33,7 +33,7 @@ Timeouts and cancellation
 .. autofunction:: anyio.fail_after
 .. autofunction:: anyio.current_effective_deadline
 
-.. autoclass:: anyio.abc.CancelScope
+.. autoclass:: anyio.CancelScope
 
 Task groups
 -----------

--- a/docs/cancellation.rst
+++ b/docs/cancellation.rst
@@ -57,7 +57,7 @@ The most important such use case is performing shutdown procedures on asynchrono
 
 To accomplish this, open a new cancel scope with the ``shield=True`` argument::
 
-    from anyio import create_task_group, open_cancel_scope, sleep, run
+    from anyio import CancelScope, create_task_group, sleep, run
 
 
     async def external_task():
@@ -68,7 +68,7 @@ To accomplish this, open a new cancel scope with the ``shield=True`` argument::
 
     async def main():
         async with create_task_group() as tg:
-            with open_cancel_scope(shield=True) as scope:
+            with CancelScope(shield=True) as scope:
                 tg.spawn(external_task)
                 tg.cancel_scope.cancel()
                 print('Started sleeping in the host task')

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -65,10 +65,10 @@ Example 1 – setting an event::
 
 Example 2 – opening a cancel scope::
 
-    from anyio import open_cancel_scope, maybe_async_cm
+    from anyio import CancelScope, maybe_async_cm
 
     async def foo():
-        async with maybe_async_cm(open_cancel_scope()) as scope:
+        async with maybe_async_cm(CancelScope()) as scope:
             ...
 
 .. _trio: https://github.com/python-trio/trio

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -34,7 +34,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
   * ``fail_after()``
   * ``move_on_after()``
-  * ``open_cancel_scope()``
+  * ``open_cancel_scope()`` (now just ``CancelScope()``; see below)
   * ``open_signal_receiver()``
 
   See the :doc:`migration documentation <migration>` for instructions on how to deal with these
@@ -46,6 +46,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   * ``create_lock()`` → ``anyio.Lock()``
   * ``create_condition()`` → ``anyio.Condition()``
   * ``create_semaphore()`` → ``anyio.Semaphore()``
+  * ``open_cancel_scope()`` → ``anyio.CancelScope()``
   * ``CapacityLimiter.set_total_tokens()`` → ``limiter.total_tokens = ...``
 - **BACKWARDS INCOMPATIBLE** The ``CapacityLimiter.set_total_tokens()`` method has been removed in
   exchange of making the ``total_tokens`` property writable

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -10,7 +10,7 @@ __all__ = ('maybe_async', 'maybe_async_cm', 'run', 'sleep', 'current_time', 'get
            'ConditionStatistics', 'Event', 'EventStatistics', 'Lock', 'LockStatistics',
            'Semaphore', 'SemaphoreStatistics', 'create_condition', 'create_event',
            'create_semaphore', 'create_capacity_limiter', 'open_cancel_scope', 'fail_after',
-           'move_on_after', 'current_effective_deadline', 'TASK_STATUS_IGNORED',
+           'move_on_after', 'current_effective_deadline', 'TASK_STATUS_IGNORED', 'CancelScope',
            'create_task_group', 'TaskInfo', 'get_current_task', 'get_running_tasks',
            'wait_all_tasks_blocked', 'run_sync_in_worker_thread', 'run_async_from_thread',
            'run_sync_from_thread', 'current_default_worker_thread_limiter',
@@ -35,8 +35,8 @@ from ._core._synchronization import (
     EventStatistics, Lock, LockStatistics, Semaphore, SemaphoreStatistics, create_capacity_limiter,
     create_condition, create_event, create_lock, create_semaphore)
 from ._core._tasks import (
-    TASK_STATUS_IGNORED, create_task_group, current_effective_deadline, fail_after, move_on_after,
-    open_cancel_scope)
+    TASK_STATUS_IGNORED, CancelScope, create_task_group, current_effective_deadline, fail_after,
+    move_on_after, open_cancel_scope)
 from ._core._testing import TaskInfo, get_current_task, get_running_tasks, wait_all_tasks_blocked
 from ._core._threads import (
     create_blocking_portal, current_default_worker_thread_limiter, run_async_from_thread,

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -224,7 +224,7 @@ CancelledError = asyncio.CancelledError
 
 
 class CancelScope(BaseCancelScope, DeprecatedAsyncContextManager):
-    def __new__(cls, *, shield: bool = False, deadline: float = math.inf):
+    def __new__(cls, *, deadline: float = math.inf, shield: bool = False):
         return object.__new__(cls)
 
     def __init__(self, deadline: float = math.inf, shield: bool = False):

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -32,6 +32,7 @@ from .._core._sockets import GetAddrInfoReturnType, convert_ipv6_sockaddr
 from .._core._synchronization import CapacityLimiter as BaseCapacityLimiter
 from .._core._synchronization import Event as BaseEvent
 from .._core._synchronization import ResourceGuard
+from .._core._tasks import CancelScope as BaseCancelScope
 from ..abc import IPSockAddrType, UDPPacketType
 from ..lowlevel import RunVar
 
@@ -222,9 +223,9 @@ sleep = asyncio.sleep
 CancelledError = asyncio.CancelledError
 
 
-class CancelScope(abc.CancelScope, DeprecatedAsyncContextManager):
-    __slots__ = ('_deadline', '_shield', '_parent_scope', '_cancel_called', '_active',
-                 '_timeout_handle', '_tasks', '_host_task', '_timeout_expired')
+class CancelScope(BaseCancelScope, DeprecatedAsyncContextManager):
+    def __new__(cls, *, shield: bool = False, deadline: float = math.inf):
+        return object.__new__(cls)
 
     def __init__(self, deadline: float = math.inf, shield: bool = False):
         self._deadline = deadline

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -23,6 +23,7 @@ from .._core._sockets import convert_ipv6_sockaddr
 from .._core._synchronization import CapacityLimiter as BaseCapacityLimiter
 from .._core._synchronization import Event as BaseEvent
 from .._core._synchronization import ResourceGuard
+from .._core._tasks import CancelScope as BaseCancelScope
 from ..abc import IPSockAddrType, UDPPacketType
 
 try:
@@ -57,7 +58,10 @@ sleep = trio.sleep
 # Timeouts and cancellation
 #
 
-class CancelScope(abc.CancelScope):
+class CancelScope(BaseCancelScope):
+    def __new__(cls, original: Optional[trio.CancelScope] = None, **kwargs):
+        return object.__new__(cls)
+
     def __init__(self, original: Optional[trio.CancelScope] = None, **kwargs):
         self.__original = original or trio.CancelScope(**kwargs)
 

--- a/src/anyio/_core/_resources.py
+++ b/src/anyio/_core/_resources.py
@@ -1,5 +1,5 @@
 from ..abc import AsyncResource
-from ._tasks import open_cancel_scope
+from ._tasks import CancelScope
 
 
 async def aclose_forcefully(resource: AsyncResource) -> None:
@@ -11,6 +11,6 @@ async def aclose_forcefully(resource: AsyncResource) -> None:
     :param resource: the resource to close
 
     """
-    with open_cancel_scope() as scope:
+    with CancelScope() as scope:
         scope.cancel()
         await resource.aclose()

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -8,7 +8,7 @@ from ..lowlevel import checkpoint
 from ._compat import DeprecatedAwaitable
 from ._eventloop import get_asynclib
 from ._exceptions import BusyResourceError, WouldBlock
-from ._tasks import open_cancel_scope
+from ._tasks import CancelScope
 from ._testing import TaskInfo, get_current_task
 
 
@@ -250,7 +250,7 @@ class Condition:
 
             raise
         finally:
-            with open_cancel_scope(shield=True):
+            with CancelScope(shield=True):
                 await self.acquire()
 
     def statistics(self) -> ConditionStatistics:

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -17,7 +17,14 @@ TASK_STATUS_IGNORED = _IgnoredTaskStatus()
 
 
 class CancelScope(DeprecatedAsyncContextManager):
-    def __new__(cls, *, shield: bool = False, deadline: float = math.inf):
+    """
+    Wraps a unit of work that can be made separately cancellable.
+
+    :param deadline: The time (clock value) when this scope is cancelled automatically
+    :param shield: ``True`` to shield the cancel scope from external cancellation
+    """
+
+    def __new__(cls, *, deadline: float = math.inf, shield: bool = False):
         return get_asynclib().CancelScope(shield=shield, deadline=deadline)
 
     def cancel(self) -> DeprecatedAwaitable:
@@ -32,6 +39,10 @@ class CancelScope(DeprecatedAsyncContextManager):
         Will be ``float('inf')`` if no timeout has been set.
 
         """
+        raise NotImplementedError
+
+    @deadline.setter
+    def deadline(self, value: float) -> None:
         raise NotImplementedError
 
     @property

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -1,8 +1,10 @@
 import math
-from typing import Optional
+from types import TracebackType
+from typing import Optional, Type
+from warnings import warn
 
-from ..abc import CancelScope, TaskGroup, TaskStatus
-from ._compat import DeprecatedAsyncContextManager, DeprecatedAwaitableFloat
+from ..abc._tasks import TaskGroup, TaskStatus
+from ._compat import DeprecatedAsyncContextManager, DeprecatedAwaitable, DeprecatedAwaitableFloat
 from ._eventloop import get_asynclib
 
 
@@ -14,6 +16,48 @@ class _IgnoredTaskStatus(TaskStatus):
 TASK_STATUS_IGNORED = _IgnoredTaskStatus()
 
 
+class CancelScope(DeprecatedAsyncContextManager):
+    def __new__(cls, *, shield: bool = False, deadline: float = math.inf):
+        return get_asynclib().CancelScope(shield=shield, deadline=deadline)
+
+    def cancel(self) -> DeprecatedAwaitable:
+        """Cancel this scope immediately."""
+        raise NotImplementedError
+
+    @property
+    def deadline(self) -> float:
+        """
+        The time (clock value) when this scope is cancelled automatically.
+
+        Will be ``float('inf')`` if no timeout has been set.
+
+        """
+        raise NotImplementedError
+
+    @property
+    def cancel_called(self) -> bool:
+        """``True`` if :meth:`cancel` has been called."""
+        raise NotImplementedError
+
+    @property
+    def shield(self) -> bool:
+        """
+        ``True`` if this scope is shielded from external cancellation.
+
+        While a scope is shielded, it will not receive cancellations from outside.
+
+        """
+        raise NotImplementedError
+
+    def __enter__(self):
+        raise NotImplementedError
+
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> Optional[bool]:
+        raise NotImplementedError
+
+
 def open_cancel_scope(*, shield: bool = False) -> CancelScope:
     """
     Open a cancel scope.
@@ -21,7 +65,11 @@ def open_cancel_scope(*, shield: bool = False) -> CancelScope:
     :param shield: ``True`` to shield the cancel scope from external cancellation
     :return: a cancel scope
 
+    .. deprecated:: 3.0
+       Use :class:`~CancelScope` directly.
+
     """
+    warn('open_cancel_scope() is deprecated -- use CancelScope() directly', DeprecationWarning)
     return get_asynclib().CancelScope(shield=shield)
 
 
@@ -83,7 +131,7 @@ def current_effective_deadline() -> DeprecatedAwaitableFloat:
                                     current_effective_deadline)
 
 
-def create_task_group() -> TaskGroup:
+def create_task_group() -> 'TaskGroup':
     """
     Create a task group.
 

--- a/src/anyio/abc/__init__.py
+++ b/src/anyio/abc/__init__.py
@@ -18,13 +18,14 @@ from ._streams import (
     ByteStream, Listener, ObjectReceiveStream, ObjectSendStream, ObjectStream,
     UnreliableObjectReceiveStream, UnreliableObjectSendStream, UnreliableObjectStream)
 from ._subprocesses import Process
-from ._tasks import CancelScope, TaskGroup, TaskStatus
+from ._tasks import TaskGroup, TaskStatus
 from ._testing import TestRunner
 from ._threads import BlockingPortal
 
 # Re-exported here, for backwards compatibility
 # isort: off
 from .._core._synchronization import CapacityLimiter, Condition, Event, Lock, Semaphore
+from .._core._tasks import CancelScope
 
 # Re-export imports so they look like they live directly in this package
 for key, value in list(locals().items()):

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -1,8 +1,12 @@
+import typing
 from abc import ABCMeta, abstractmethod
 from types import TracebackType
 from typing import Callable, Coroutine, Optional, Type, TypeVar
 
-from anyio._core._compat import DeprecatedAsyncContextManager, DeprecatedAwaitable
+from anyio._core._compat import DeprecatedAwaitable
+
+if typing.TYPE_CHECKING:
+    from anyio._core._tasks import CancelScope
 
 T_Retval = TypeVar('T_Retval')
 
@@ -60,42 +64,3 @@ class TaskGroup(metaclass=ABCMeta):
                         exc_val: Optional[BaseException],
                         exc_tb: Optional[TracebackType]) -> Optional[bool]:
         """Exit the task group context waiting for all tasks to finish."""
-
-
-class CancelScope(DeprecatedAsyncContextManager):
-    @abstractmethod
-    def cancel(self) -> DeprecatedAwaitable:
-        """Cancel this scope immediately."""
-
-    @property
-    @abstractmethod
-    def deadline(self) -> float:
-        """
-        The time (clock value) when this scope is cancelled automatically.
-
-        Will be ``float('inf')`` if no timeout has been set.
-        """
-
-    @property
-    @abstractmethod
-    def cancel_called(self) -> bool:
-        """``True`` if :meth:`cancel` has been called."""
-
-    @property
-    @abstractmethod
-    def shield(self) -> bool:
-        """
-        ``True`` if this scope is shielded from external cancellation.
-
-        While a scope is shielded, it will not receive cancellations from outside.
-        """
-
-    @abstractmethod
-    def __enter__(self):
-        pass
-
-    @abstractmethod
-    def __exit__(self, exc_type: Optional[Type[BaseException]],
-                 exc_val: Optional[BaseException],
-                 exc_tb: Optional[TracebackType]) -> Optional[bool]:
-        pass

--- a/src/anyio/abc/_threads.py
+++ b/src/anyio/abc/_threads.py
@@ -110,7 +110,7 @@ class BlockingPortal(metaclass=ABCMeta):
 
     async def _call_func(self, func: Callable, args: tuple, kwargs: Dict[str, Any],
                          future: Future) -> None:
-        from .._core._tasks import open_cancel_scope
+        from .._core._tasks import CancelScope
 
         def callback(f: Future):
             if f.cancelled():
@@ -119,7 +119,7 @@ class BlockingPortal(metaclass=ABCMeta):
         try:
             retval = func(*args, **kwargs)
             if iscoroutine(retval):
-                with open_cancel_scope() as scope:
+                with CancelScope() as scope:
                     if future.cancelled():
                         scope.cancel()
                     else:

--- a/src/anyio/lowlevel.py
+++ b/src/anyio/lowlevel.py
@@ -40,7 +40,7 @@ async def cancel_shielded_checkpoint() -> None:
 
     Equivalent to (but potentially more efficient than)::
 
-        with open_cancel_scope(shield=True):
+        with CancelScope(shield=True):
             await checkpoint()
 
     .. versionadded:: 3.0

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -1,8 +1,8 @@
 import pytest
 
 from anyio import (
-    BrokenResourceError, ClosedResourceError, EndOfStream, WouldBlock, create_memory_object_stream,
-    create_task_group, fail_after, open_cancel_scope, wait_all_tasks_blocked)
+    BrokenResourceError, CancelScope, ClosedResourceError, EndOfStream, WouldBlock,
+    create_memory_object_stream, create_task_group, fail_after, wait_all_tasks_blocked)
 
 pytestmark = pytest.mark.anyio
 
@@ -192,7 +192,7 @@ async def test_receive_when_cancelled():
         tg.spawn(send.send, 'world')
         await wait_all_tasks_blocked()
 
-        with open_cancel_scope() as scope:
+        with CancelScope() as scope:
             scope.cancel()
             await receive.receive()
 
@@ -213,7 +213,7 @@ async def test_send_when_cancelled():
     send, receive = create_memory_object_stream()
     async with create_task_group() as tg:
         tg.spawn(receiver)
-        with open_cancel_scope() as scope:
+        with CancelScope() as scope:
             scope.cancel()
             await send.send('hello')
 
@@ -230,7 +230,7 @@ async def test_cancel_during_receive():
     """
     async def scoped_receiver():
         nonlocal receiver_scope
-        with open_cancel_scope() as receiver_scope:
+        with CancelScope() as receiver_scope:
             received.append(await receive.receive())
 
         assert receiver_scope.cancel_called

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -4,21 +4,21 @@ import sys
 import pytest
 
 from anyio import (
-    CapacityLimiter, Condition, Event, Lock, Semaphore, TaskInfo, create_memory_object_stream,
-    create_task_group, current_effective_deadline, current_time, fail_after, get_current_task,
-    get_running_tasks, maybe_async, maybe_async_cm, move_on_after, open_cancel_scope,
+    CancelScope, CapacityLimiter, Condition, Event, Lock, Semaphore, TaskInfo,
+    create_memory_object_stream, create_task_group, current_effective_deadline, current_time,
+    fail_after, get_current_task, get_running_tasks, maybe_async, maybe_async_cm, move_on_after,
     open_signal_receiver, sleep)
 
 pytestmark = pytest.mark.anyio
 
 
 async def test_maybe_async():
-    with open_cancel_scope() as scope:
+    with CancelScope() as scope:
         await maybe_async(scope.cancel())
 
 
 async def test_maybe_async_cm():
-    async with maybe_async_cm(open_cancel_scope()):
+    async with maybe_async_cm(CancelScope()):
         pass
 
 
@@ -56,7 +56,7 @@ class TestDeprecations:
                 pass
 
     async def test_cancelscope_cancel(self):
-        with open_cancel_scope() as scope:
+        with CancelScope() as scope:
             with pytest.deprecated_call():
                 await scope.cancel()
 

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -1,8 +1,8 @@
 import pytest
 
 from anyio import (
-    Condition, Event, Lock, Semaphore, WouldBlock, create_task_group,
-    current_default_worker_thread_limiter, open_cancel_scope, wait_all_tasks_blocked)
+    CancelScope, Condition, Event, Lock, Semaphore, WouldBlock, create_task_group,
+    current_default_worker_thread_limiter, wait_all_tasks_blocked)
 from anyio.abc import CapacityLimiter
 
 pytestmark = pytest.mark.anyio
@@ -280,7 +280,7 @@ class TestSemaphore:
     async def test_acquire_cancel(self):
         async def task():
             nonlocal local_scope, acquired
-            with open_cancel_scope() as local_scope:
+            with CancelScope() as local_scope:
                 async with semaphore:
                     acquired = True
 


### PR DESCRIPTION
Another step towards a trio-like API.