### PR TITLE
avoid redundant relative imports

### DIFF
--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Coroutine, Dict, Generator, Optional, Tuple, T
 import sniffio
 
 # This must be updated when new backends are introduced
-from anyio._core._compat import DeprecatedAwaitableFloat
+from ._compat import DeprecatedAwaitableFloat
 
 BACKENDS = 'asyncio', 'trio'
 

--- a/src/anyio/_core/_testing.py
+++ b/src/anyio/_core/_testing.py
@@ -1,7 +1,7 @@
 from typing import Coroutine, Optional
 
-from .._core._eventloop import get_asynclib
 from ._compat import DeprecatedAwaitable, DeprecatedAwaitableList
+from ._eventloop import get_asynclib
 
 
 class TaskInfo(DeprecatedAwaitable):

--- a/src/anyio/_core/_typedattr.py
+++ b/src/anyio/_core/_typedattr.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Callable, Mapping, TypeVar, Union, overload
 
-from .._core._exceptions import TypedAttributeLookupError
+from ._exceptions import TypedAttributeLookupError
 
 if sys.version_info >= (3, 8):
     from typing import final


### PR DESCRIPTION
eg imports that reach up out of the current package then back down