### PR TITLE
Add CancelScope.cancelled_caught

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__
 .cache
 .local
 .pre-commit-config.yaml
+.vscode/

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -87,6 +87,10 @@ class CancelScope(BaseCancelScope):
         self.__original.deadline = value
 
     @property
+    def cancelled_caught(self) -> bool:
+        return self.__original.cancelled_caught
+
+    @property
     def cancel_called(self) -> bool:
         return self.__original.cancel_called
 

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -46,6 +46,11 @@ class CancelScope(DeprecatedAsyncContextManager['CancelScope']):
         raise NotImplementedError
 
     @property
+    def cancelled_caught(self) -> bool:
+        """Records whether this scope caught a ``CancelledError``."""
+        raise NotImplementedError
+
+    @property
     def cancel_called(self) -> bool:
         """``True`` if :meth:`cancel` has been called."""
         raise NotImplementedError


### PR DESCRIPTION
Added `CancelScope.cancelled_caught` to match the Trio API. Relevant
Trio documentation
[here](https://trio.readthedocs.io/en/stable/reference-core.html#trio.CancelScope.cancelled_caught).

Closes agronholm/anyio#257