### PR TITLE
Add example and docs link to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,35 +19,10 @@ Applications and libraries written against AnyIO's API will run unmodified on ei
 trio_. AnyIO can also be adopted into a library or application incrementally – bit by bit, no full
 refactoring necessary. It will blend in with native libraries of your chosen backend.
 
-A small example
----------------
-
-Write an async function using ``anyio.sleep()``::
-
-  import anyio
-
-  async def main():
-      print('Hello...')
-      await anyio.sleep(2)
-      print('World!')
-
-And then you can call it from either ``asyncio`` or ``trio``! ::
-
-  import asyncio, trio
-  asyncio.run(main)
-  trio.run(main)
-
-Or alternatively, ::
-
-  anyio.run(main, backend='asyncio')
-  anyio.run(main, backend='trio')
- 
-
 Documentation
 -------------
 
-View full documentation at https://anyio.readthedocs.io/.
-
+View full documentation at: https://anyio.readthedocs.io/
 
 Features
 --------

--- a/README.rst
+++ b/README.rst
@@ -12,12 +12,45 @@
   :alt: Gitter chat
 
 AnyIO is an asynchronous networking and concurrency library that works on top of either asyncio_ or
-trio_. It implements trio-like `structured concurrency`_ on top of asyncio, and works in harmony
+trio_. It implements trio-like `structured concurrency`_ (SC) on top of asyncio, and works in harmony
 with the native SC of trio itself.
 
 Applications and libraries written against AnyIO's API will run unmodified on either asyncio_ or
 trio_. AnyIO can also be adopted into a library or application incrementally – bit by bit, no full
 refactoring necessary. It will blend in with native libraries of your chosen backend.
+
+A small example
+---------------
+
+Write an async function using ``anyio.sleep()``::
+
+  import anyio
+
+  async def main():
+      print('Hello...')
+      await anyio.sleep(2)
+      print('World!')
+
+And then you can call it from either ``asyncio`` or ``trio``! ::
+
+  import asyncio, trio
+  asyncio.run(main)
+  trio.run(main)
+
+Or alternatively, ::
+
+  anyio.run(main, backend='asyncio')
+  anyio.run(main, backend='trio')
+ 
+
+Documentation
+-------------
+
+View full documentation at https://anyio.readthedocs.io/.
+
+
+Features
+--------
 
 AnyIO offers the following functionality:
 


### PR DESCRIPTION
I believe it's good practice to include a docs link in the README for users who arrive at the GitHub page and want to understand how to proceed.

I also added an example as a quick expression of the value proposition. This has pushed the detailed features list down the page a little but I think that is acceptable; if users arrive with no idea about what AnyIO does need to understand the value proposition before diving into the full features list.