### PR TITLE
Handle partial asyncio future callback

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -141,7 +141,8 @@ def find_root_task() -> asyncio.Task:
         for task in all_tasks():
             if task._callbacks:
                 for cb in _get_task_callbacks(task):
-                    if cb is _run_until_complete_cb or cb.__module__ == 'uvloop.loop':
+                    if (cb is _run_until_complete_cb
+                            or getattr(cb, '__module__', None) == 'uvloop.loop'):
                         _root_task.set(task)
                         return task
 

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -1,8 +1,8 @@
 import asyncio
-from functools import partial
 import sys
 import threading
 import time
+from functools import partial
 
 import pytest
 


### PR DESCRIPTION
If using the asyncio backend where the root task cannot be determined,
better handle partial functions and other callable objects used as
future callbacks.

Fixed #272 