### PR TITLE
Pass `env` and `cwd` keyword arguments through open_process to the backend

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Fixed ``wait_all_tasks_blocked()`` returning prematurely on asyncio when a previously blocked
   task is cancelled (PR by Thomas Grainger)
+- Added ``env`` and ``cwd`` keyword arguments to ``run_process()`` and ``open_process``.
 
 **3.0.1**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,9 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added ``env`` and ``cwd`` keyword arguments to ``run_process()`` and ``open_process``.
 - Fixed ``wait_all_tasks_blocked()`` returning prematurely on asyncio when a previously blocked
   task is cancelled (PR by Thomas Grainger)
-- Added ``env`` and ``cwd`` keyword arguments to ``run_process()`` and ``open_process``.
 
 **3.0.1**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2,7 +2,6 @@ import array
 import asyncio
 import concurrent.futures
 import math
-from pathlib import Path
 import socket
 import sys
 from asyncio.base_events import _run_until_complete_cb  # type: ignore
@@ -13,6 +12,7 @@ from functools import partial, wraps
 from inspect import (
     CORO_RUNNING, CORO_SUSPENDED, GEN_RUNNING, GEN_SUSPENDED, getcoroutinestate, getgeneratorstate)
 from io import IOBase
+from os import PathLike
 from queue import Queue
 from socket import AddressFamily, SocketKind, SocketType
 from threading import Thread
@@ -879,7 +879,7 @@ class Process(abc.Process):
 
 
 async def open_process(command, *, shell: bool, stdin: int, stdout: int, stderr: int,
-                       cwd: Union[str, Path, None] = None,
+                       cwd: Union[str, bytes, PathLike, None] = None,
                        env: Optional[Mapping[str, str]] = None) -> Process:
     await checkpoint()
     if shell:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2,6 +2,7 @@ import array
 import asyncio
 import concurrent.futures
 import math
+import pathlib
 import socket
 import sys
 from asyncio.base_events import _run_until_complete_cb  # type: ignore
@@ -18,7 +19,7 @@ from threading import Thread
 from types import TracebackType
 from typing import (
     Any, Awaitable, Callable, Collection, Coroutine, Deque, Dict, Generator, Iterable, List,
-    Optional, Sequence, Set, Tuple, Type, TypeVar, Union, cast)
+    Mapping, Optional, Sequence, Set, Tuple, Type, TypeVar, Union, cast)
 from weakref import WeakKeyDictionary
 
 from .. import CapacityLimiterStatistics, EventStatistics, TaskInfo, abc
@@ -877,14 +878,16 @@ class Process(abc.Process):
         return self._stderr
 
 
-async def open_process(command, *, shell: bool, stdin: int, stdout: int, stderr: int):
+async def open_process(command, *, shell: bool, stdin: int, stdout: int, stderr: int,
+                       cwd: Optional[Union[str, pathlib.Path]] = None,
+                       env: Optional[Mapping[str, str]] = None) -> Process:
     await checkpoint()
     if shell:
         process = await asyncio.create_subprocess_shell(command, stdin=stdin, stdout=stdout,
-                                                        stderr=stderr)
+                                                        stderr=stderr, cwd=cwd, env=env)
     else:
         process = await asyncio.create_subprocess_exec(*command, stdin=stdin, stdout=stdout,
-                                                       stderr=stderr)
+                                                       stderr=stderr, cwd=cwd, env=env)
 
     stdin_stream = StreamWriterWrapper(process.stdin) if process.stdin else None
     stdout_stream = StreamReaderWrapper(process.stdout) if process.stdout else None

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2,7 +2,7 @@ import array
 import asyncio
 import concurrent.futures
 import math
-import pathlib
+from pathlib import Path
 import socket
 import sys
 from asyncio.base_events import _run_until_complete_cb  # type: ignore
@@ -879,7 +879,7 @@ class Process(abc.Process):
 
 
 async def open_process(command, *, shell: bool, stdin: int, stdout: int, stderr: int,
-                       cwd: Optional[Union[str, pathlib.Path]] = None,
+                       cwd: Union[str, Path, None] = None,
                        env: Optional[Mapping[str, str]] = None) -> Process:
     await checkpoint()
     if shell:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1,11 +1,11 @@
 import array
 import math
-from pathlib import Path
 import socket
 from concurrent.futures import Future
 from dataclasses import dataclass
 from functools import partial
 from io import IOBase
+from os import PathLike
 from types import TracebackType
 from typing import (
     Any, Awaitable, Callable, Collection, Coroutine, Dict, Generic, List, Mapping, NoReturn,
@@ -270,7 +270,7 @@ class Process(abc.Process):
 
 
 async def open_process(command, *, shell: bool, stdin: int, stdout: int, stderr: int,
-                       cwd: Union[str, Path, None] = None,
+                       cwd: Union[str, bytes, PathLike, None] = None,
                        env: Optional[Mapping[str, str]] = None) -> Process:
     process = await trio.open_process(command, stdin=stdin, stdout=stdout, stderr=stderr,
                                       shell=shell, cwd=cwd, env=env)

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1,5 +1,6 @@
 import array
 import math
+import pathlib
 import socket
 from concurrent.futures import Future
 from dataclasses import dataclass
@@ -7,8 +8,8 @@ from functools import partial
 from io import IOBase
 from types import TracebackType
 from typing import (
-    Any, Awaitable, Callable, Collection, Coroutine, Dict, Generic, List, NoReturn, Optional, Set,
-    Tuple, Type, TypeVar, Union)
+    Any, Awaitable, Callable, Collection, Coroutine, Dict, Generic, List, Mapping, NoReturn,
+    Optional, Set, Tuple, Type, TypeVar, Union)
 
 import trio.from_thread
 from outcome import Error, Value
@@ -268,9 +269,11 @@ class Process(abc.Process):
         return self._stderr
 
 
-async def open_process(command, *, shell: bool, stdin: int, stdout: int, stderr: int):
+async def open_process(command, *, shell: bool, stdin: int, stdout: int, stderr: int,
+                       cwd: Optional[Union[str, pathlib.Path]] = None,
+                       env: Optional[Mapping[str, str]] = None) -> Process:
     process = await trio.open_process(command, stdin=stdin, stdout=stdout, stderr=stderr,
-                                      shell=shell)
+                                      shell=shell, cwd=cwd, env=env)
     stdin_stream = SendStreamWrapper(process.stdin) if process.stdin else None
     stdout_stream = ReceiveStreamWrapper(process.stdout) if process.stdout else None
     stderr_stream = ReceiveStreamWrapper(process.stderr) if process.stderr else None

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1,6 +1,6 @@
 import array
 import math
-import pathlib
+from pathlib import Path
 import socket
 from concurrent.futures import Future
 from dataclasses import dataclass
@@ -270,7 +270,7 @@ class Process(abc.Process):
 
 
 async def open_process(command, *, shell: bool, stdin: int, stdout: int, stderr: int,
-                       cwd: Optional[Union[str, pathlib.Path]] = None,
+                       cwd: Union[str, Path, None] = None,
                        env: Optional[Mapping[str, str]] = None) -> Process:
     process = await trio.open_process(command, stdin=stdin, stdout=stdout, stderr=stderr,
                                       shell=shell, cwd=cwd, env=env)

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -25,7 +25,8 @@ async def run_process(command: Union[str, Sequence[str]], *, input: Optional[byt
     :param check: if ``True``, raise :exc:`~subprocess.CalledProcessError` if the process
         terminates with a return code other than 0
     :param cwd: If not ``None``, change the working directory to this before running the command
-    :param env: if not ``None``, this mapping replaces the inherited environment variables from the parent process
+    :param env: if not ``None``, this mapping replaces the inherited environment variables from the
+        parent process
     :return: an object representing the completed process
     :raises ~subprocess.CalledProcessError: if ``check`` is ``True`` and the process exits with a
         nonzero return code

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -1,5 +1,7 @@
+import os
+import pathlib
 from subprocess import DEVNULL, PIPE, CalledProcessError, CompletedProcess
-from typing import Optional, Sequence, Union, cast
+from typing import Mapping, Optional, Sequence, Union, cast
 
 from ..abc import Process
 from ._eventloop import get_asynclib
@@ -7,8 +9,9 @@ from ._tasks import create_task_group
 
 
 async def run_process(command: Union[str, Sequence[str]], *, input: Optional[bytes] = None,
-                      stdout: int = PIPE, stderr: int = PIPE,
-                      check: bool = True) -> CompletedProcess:
+                      stdout: int = PIPE, stderr: int = PIPE, check: bool = True,
+                      cwd: Optional[Union[str, pathlib.Path]] = None,
+                      env: Optional[Mapping[str, str]] = None) -> CompletedProcess:
     """
     Run an external command in a subprocess and wait until it completes.
 
@@ -22,6 +25,9 @@ async def run_process(command: Union[str, Sequence[str]], *, input: Optional[byt
         :data:`subprocess.STDOUT`
     :param check: if ``True``, raise :exc:`~subprocess.CalledProcessError` if the process
         terminates with a return code other than 0
+    :param cwd: If not ``None``, the working directory is changed before executing
+    :param env: If env is not ``None``, it must be a mapping that defines the environmen
+        variables for the new process
     :return: an object representing the completed process
     :raises ~subprocess.CalledProcessError: if ``check`` is ``True`` and the process exits with a
         nonzero return code
@@ -32,7 +38,7 @@ async def run_process(command: Union[str, Sequence[str]], *, input: Optional[byt
         stream_contents[index] = b''.join(chunks)
 
     async with await open_process(command, stdin=PIPE if input else DEVNULL, stdout=stdout,
-                                  stderr=stderr) as process:
+                                  stderr=stderr, cwd=cwd, env=env) as process:
         stream_contents = [None, None]
         try:
             async with create_task_group() as tg:
@@ -57,7 +63,9 @@ async def run_process(command: Union[str, Sequence[str]], *, input: Optional[byt
 
 
 async def open_process(command: Union[str, Sequence[str]], *, stdin: int = PIPE,
-                       stdout: int = PIPE, stderr: int = PIPE) -> Process:
+                       stdout: int = PIPE, stderr: int = PIPE,
+                       cwd: Optional[Union[str, pathlib.Path]] = None,
+                       env: Optional[Mapping[str, str]] = None) -> Process:
     """
     Start an external command in a subprocess.
 
@@ -69,9 +77,12 @@ async def open_process(command: Union[str, Sequence[str]], *, stdin: int = PIPE,
     :param stdout: either :data:`subprocess.PIPE` or :data:`subprocess.DEVNULL`
     :param stderr: one of :data:`subprocess.PIPE`, :data:`subprocess.DEVNULL` or
         :data:`subprocess.STDOUT`
+    :param cwd: If not ``None``, the working directory is changed before executing
+    :param env: If env is not ``None``, it must be a mapping that defines the environment
+        variables for the new process
     :return: an asynchronous process object
 
     """
     shell = isinstance(command, str)
     return await get_asynclib().open_process(command, shell=shell, stdin=stdin, stdout=stdout,
-                                             stderr=stderr)
+                                             stderr=stderr, cwd=cwd, env=env)

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from os import PathLike
 from subprocess import DEVNULL, PIPE, CalledProcessError, CompletedProcess
 from typing import Mapping, Optional, Sequence, Union, cast
 
@@ -9,7 +9,7 @@ from ._tasks import create_task_group
 
 async def run_process(command: Union[str, Sequence[str]], *, input: Optional[bytes] = None,
                       stdout: int = PIPE, stderr: int = PIPE, check: bool = True,
-                      cwd: Union[str, Path, None] = None,
+                      cwd: Union[str, bytes, PathLike, None] = None,
                       env: Optional[Mapping[str, str]] = None) -> CompletedProcess:
     """
     Run an external command in a subprocess and wait until it completes.
@@ -63,7 +63,7 @@ async def run_process(command: Union[str, Sequence[str]], *, input: Optional[byt
 
 async def open_process(command: Union[str, Sequence[str]], *, stdin: int = PIPE,
                        stdout: int = PIPE, stderr: int = PIPE,
-                       cwd: Union[str, Path, None] = None,
+                       cwd: Union[str, bytes, PathLike, None] = None,
                        env: Optional[Mapping[str, str]] = None) -> Process:
     """
     Start an external command in a subprocess.

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 from subprocess import DEVNULL, PIPE, CalledProcessError, CompletedProcess
 from typing import Mapping, Optional, Sequence, Union, cast

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -1,4 +1,4 @@
-import pathlib
+from pathlib import Path
 from subprocess import DEVNULL, PIPE, CalledProcessError, CompletedProcess
 from typing import Mapping, Optional, Sequence, Union, cast
 
@@ -9,7 +9,7 @@ from ._tasks import create_task_group
 
 async def run_process(command: Union[str, Sequence[str]], *, input: Optional[bytes] = None,
                       stdout: int = PIPE, stderr: int = PIPE, check: bool = True,
-                      cwd: Optional[Union[str, pathlib.Path]] = None,
+                      cwd: Union[str, Path, None] = None,
                       env: Optional[Mapping[str, str]] = None) -> CompletedProcess:
     """
     Run an external command in a subprocess and wait until it completes.
@@ -24,9 +24,8 @@ async def run_process(command: Union[str, Sequence[str]], *, input: Optional[byt
         :data:`subprocess.STDOUT`
     :param check: if ``True``, raise :exc:`~subprocess.CalledProcessError` if the process
         terminates with a return code other than 0
-    :param cwd: If not ``None``, the working directory is changed before executing
-    :param env: If env is not ``None``, it must be a mapping that defines the environmen
-        variables for the new process
+    :param cwd: If not ``None``, change the working directory to this before running the command
+    :param env: if not ``None``, this mapping replaces the inherited environment variables from the parent process
     :return: an object representing the completed process
     :raises ~subprocess.CalledProcessError: if ``check`` is ``True`` and the process exits with a
         nonzero return code
@@ -63,7 +62,7 @@ async def run_process(command: Union[str, Sequence[str]], *, input: Optional[byt
 
 async def open_process(command: Union[str, Sequence[str]], *, stdin: int = PIPE,
                        stdout: int = PIPE, stderr: int = PIPE,
-                       cwd: Optional[Union[str, pathlib.Path]] = None,
+                       cwd: Union[str, Path, None] = None,
                        env: Optional[Mapping[str, str]] = None) -> Process:
     """
     Start an external command in a subprocess.

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -69,7 +69,7 @@ async def test_terminate(tmp_path):
 async def test_process_cwd(tmp_path):
     """Test that `cwd` is successfully passed to the subprocess implementation"""
     cmd = [sys.executable, "-c", "import os; print(os.getcwd())"]
-    result = await run_process(cmd, cwd=str(tmp_path))
+    result = await run_process(cmd, cwd=tmp_path)
     assert result.stdout.decode().strip() == str(tmp_path)
 
 

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import sys
 from subprocess import CalledProcessError
@@ -74,7 +75,8 @@ async def test_process_cwd(tmp_path):
 
 async def test_process_env():
     """Test that `env` is successfully passed to the subprocess implementation"""
-    env = {"foo": "bar"}
+    env = os.environ.copy()
+    env.update({"foo": "bar"})
     cmd = [sys.executable, "-c", "import os; print(os.environ['foo'])"]
     result = await run_process(cmd, env=env)
     assert result.stdout.decode().strip() == env["foo"]

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -72,7 +72,7 @@ async def test_process_cwd(tmp_path):
     assert result.stdout.decode().strip() == str(tmp_path)
 
 
-async def test_process_env(tmp_path):
+async def test_process_env():
     """Test that `env` is successfully passed to the subprocess implementation"""
     env = {"foo": "bar"}
     cmd = [sys.executable, "-c", "import os; print(os.environ['foo'])"]

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -78,21 +78,3 @@ async def test_process_env(tmp_path):
     cmd = [sys.executable, "-c", "import os; print(os.environ['foo'])"]
     result = await run_process(cmd, env=env)
     assert result.stdout.decode().strip() == env["foo"]
-
-
-@pytest.mark.skipif(platform.system() != 'Linux',
-                    reason='This is a Posix specific test')
-async def test_posix_shell_string():
-    """Test that `run_process` cannot take a string command with `shell=False`"""
-    cmd = sys.executable + " -c 'print()'"
-    with pytest.raises(TypeError):
-        await run_process(cmd, shell=False)
-
-
-@pytest.mark.skipif(platform.system() != 'Linux',
-                    reason='This is a Posix specific test')
-async def test_posix_shell_not_string():
-    """Test that `run_process` cannot take a command list with `shell=True`"""
-    cmd = [sys.executable, "-c", "print()"]
-    with pytest.raises(TypeError):
-        await run_process(cmd, shell=True)


### PR DESCRIPTION
This allows a user to pass keyword arguments such as `cwd` to `open_process` and `run_process`.  The asyncio and trio backends support these options, but anyio did not pass them through.

Some of this code was nabbed from https://github.com/python-trio/trio/blob/6754c74eacfad9cc5c92d5c24727a2f3b620624e/trio/_subprocess.py#L329-L346 and I'm not sure if I need to credit it?