### PR TITLE
fix typing on CancelScope.__enter__

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -245,7 +245,7 @@ sleep = asyncio.sleep
 CancelledError = asyncio.CancelledError
 
 
-class CancelScope(BaseCancelScope, DeprecatedAsyncContextManager):
+class CancelScope(BaseCancelScope):
     def __new__(cls, *, deadline: float = math.inf, shield: bool = False):
         return object.__new__(cls)
 

--- a/src/anyio/_core/_compat.py
+++ b/src/anyio/_core/_compat.py
@@ -1,7 +1,8 @@
 from abc import ABCMeta, abstractmethod
 from contextlib import AbstractContextManager
 from typing import (
-    AsyncContextManager, Callable, ContextManager, List, Optional, TypeVar, Union, overload)
+    AsyncContextManager, Callable, ContextManager, Generic, List, Optional, TypeVar, Union,
+    overload)
 from warnings import warn
 
 T = TypeVar('T')
@@ -134,7 +135,7 @@ class DeprecatedAwaitableList(List[T]):
         return list(self)
 
 
-class DeprecatedAsyncContextManager(metaclass=ABCMeta):
+class DeprecatedAsyncContextManager(Generic[T], metaclass=ABCMeta):
     @abstractmethod
     def __enter__(self) -> T:
         pass

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -60,7 +60,7 @@ class CancelScope(DeprecatedAsyncContextManager):
         """
         raise NotImplementedError
 
-    def __enter__(self):
+    def __enter__(self) -> 'CancelScope':
         raise NotImplementedError
 
     def __exit__(self, exc_type: Optional[Type[BaseException]],

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -16,7 +16,7 @@ class _IgnoredTaskStatus(TaskStatus):
 TASK_STATUS_IGNORED = _IgnoredTaskStatus()
 
 
-class CancelScope(DeprecatedAsyncContextManager):
+class CancelScope(DeprecatedAsyncContextManager['CancelScope']):
     """
     Wraps a unit of work that can be made separately cancellable.
 
@@ -60,7 +60,7 @@ class CancelScope(DeprecatedAsyncContextManager):
         """
         raise NotImplementedError
 
-    def __enter__(self) -> 'CancelScope':
+    def __enter__(self):
         raise NotImplementedError
 
     def __exit__(self, exc_type: Optional[Type[BaseException]],


### PR DESCRIPTION
otherwise type check and autocomplete don't work for the typical use

![Screen Shot 2021-05-05 at 7 18 50 PM](https://user-images.githubusercontent.com/1708631/117127235-c97dbf00-add6-11eb-94e9-0259c2fb833c.png)
