### PR TITLE
Fixed PEP 508 violation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,8 +45,8 @@ test =
     hypothesis >= 4.0
     pytest >= 6.0
     trustme
-    uvloop < 0.15; python_version < '3.7' and platform_python_implementation == 'CPython' and platform_system != 'Windows'
-    uvloop >= 0.15; python_version >= '3.7' and platform_python_implementation == 'CPython' and platform_system != 'Windows'
+    uvloop < 0.15; python_version < '3.7' and (platform_python_implementation == 'CPython' and platform_system != 'Windows')
+    uvloop >= 0.15; python_version >= '3.7' and (platform_python_implementation == 'CPython' and platform_system != 'Windows')
 trio = trio >= 0.16
 doc =
     sphinx_rtd_theme


### PR DESCRIPTION
The parsing of the requirements for uvloop with `pep508_parser` failed because of missing parenthesis.
```python
from pep508_parser import parser

# This line failed
parser.parse("uvloop < 0.15; python_version < '3.7' and platform_python_implementation == 'CPython' and platform_system != 'Windows'")

# This line is parsed successfully
parser.parse("uvloop < 0.15; python_version < '3.7' and (platform_python_implementation == 'CPython' and platform_system != 'Windows')")
```