### PR TITLE
disallow untyped defs

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -30,6 +30,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   or the type of the contained value (PR by Thomas Grainger)
 - Fixed a deprecation warning message to refer to ``maybe_async()`` and not ``maybe_awaitable()``
   (PR by Thomas Grainger)
+- Filled in argument and return types for all functions and methods
+  previously missing them
+  (PR by Thomas Grainger)
 
 **3.0.1**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,6 +11,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Changed asyncio task groups so that if the host and child tasks have only raised
   ``CancelledErrors``, just one ``CancelledError`` will now be raised instead of an
   ``ExceptionGroup``, allowing asyncio to ignore it when it propagates out of the task
+- Changed task names to be converted to ``str`` early on asyncio (PR by Thomas Grainger)
 - Fixed ``sniffio._impl.AsyncLibraryNotFoundError: unknown async library, or not in async context``
   on asyncio and Python 3.6 when ``to_thread.run_sync()`` is used from
   ``loop.run_until_complete()``
@@ -20,6 +21,15 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   task is cancelled (PR by Thomas Grainger)
 - Fixed declared return type of ``TaskGroup.start()`` (it was declared as ``None``, but anything
   can be returned from it)
+- Fixed ``TextStream.extra_attributes`` raising ``AttributeError`` (PR by Thomas Grainger)
+- Fixed ``await maybe_async(current_task())`` returning ``None`` (PR by Thomas Grainger)
+- Fixed: ``pickle.dumps(current_task())`` now correctly raises ``TypeError`` instead of pickling to
+  ``None`` (PR by Thomas Grainger)
+- Fixed return type annotation of ``Event.wait()`` (``bool`` → ``None``) (PR by Thomas Grainger)
+- Fixed return type annotation of ``RunVar.get()`` to return either the type of the default value
+  or the type of the contained value (PR by Thomas Grainger)
+- Fixed a deprecation warning message to refer to ``maybe_async()`` and not ``maybe_awaitable()``
+  (PR by Thomas Grainger)
 
 **3.0.1**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -30,8 +30,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   or the type of the contained value (PR by Thomas Grainger)
 - Fixed a deprecation warning message to refer to ``maybe_async()`` and not ``maybe_awaitable()``
   (PR by Thomas Grainger)
-- Filled in argument and return types for all functions and methods
-  previously missing them
+- Filled in argument and return types for all functions and methods previously missing them
   (PR by Thomas Grainger)
 
 **3.0.1**

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,3 +60,4 @@ pytest11 =
 
 [mypy]
 ignore_missing_imports = true
+disallow_untyped_defs = true

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -100,8 +100,8 @@ else:
                 events.set_event_loop(None)
                 loop.close()
 
-    def create_task(coro: Union[Generator[Any, None, _T], Awaitable[_T]], *,  # type: ignore
-                    name: Optional[str] = None) -> asyncio.Task:
+    def create_task(coro: Union[Generator[Any, None, _T], Awaitable[_T]], *,
+                    name: object = None) -> asyncio.Task:
         return get_running_loop().create_task(coro)
 
     def get_running_loop() -> asyncio.AbstractEventLoop:
@@ -614,7 +614,7 @@ class TaskGroup(abc.TaskGroup):
                 self.cancel_scope._tasks.remove(task)
                 del _task_states[task]
 
-    def _spawn(self, func: Callable[..., Coroutine], args: tuple, name: Optional[str],
+    def _spawn(self, func: Callable[..., Coroutine], args: tuple, name: object,
                task_status_future: Optional[asyncio.Future] = None) -> asyncio.Task:
         def task_done(_task: asyncio.Task) -> None:
             # This is the code path for Python 3.8+
@@ -670,10 +670,12 @@ class TaskGroup(abc.TaskGroup):
         self.cancel_scope._tasks.add(task)
         return task
 
-    def start_soon(self, func: Callable[..., Coroutine], *args: object, name: str = None) -> None:
+    def start_soon(self, func: Callable[..., Coroutine], *args: object,
+                   name: object = None) -> None:
         self._spawn(func, args, name)
 
-    async def start(self, func: Callable[..., Coroutine], *args: object, name: str = None) -> None:
+    async def start(self, func: Callable[..., Coroutine], *args: object,
+                    name: object = None) -> None:
         future: asyncio.Future = asyncio.Future()
         task = self._spawn(func, args, name, future)
 
@@ -824,7 +826,7 @@ class BlockingPortal(abc.BlockingPortal):
         self._loop = get_running_loop()
 
     def _spawn_task_from_thread(self, func: Callable, args: tuple, kwargs: Dict[str, Any],
-                                name: Optional[str], future: Future) -> None:
+                                name: object, future: Future) -> None:
         run_sync_from_thread(
             partial(self._task_group.start_soon, name=name), self._call_func, func, args, kwargs,
             future, loop=self._loop)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -213,11 +213,11 @@ def _maybe_set_event_loop_policy(policy: Optional[asyncio.AbstractEventLoopPolic
         asyncio.set_event_loop_policy(policy)
 
 
-def run(func: Callable[..., T_Retval], *args, debug: bool = False, use_uvloop: bool = True,
+def run(func: Callable[..., Awaitable[T_Retval]], *args: object, debug: bool = False, use_uvloop: bool = True,
         policy: Optional[asyncio.AbstractEventLoopPolicy] = None) -> T_Retval:
     @wraps(func)
-    async def wrapper():
-        task = current_task()
+    async def wrapper() -> T_Retval:
+        task = cast(asyncio.Task, current_task())
         task_state = TaskState(None, get_callable_name(func), None)
         _task_states[task] = task_state
         if _native_task_names:
@@ -247,7 +247,7 @@ CancelledError = asyncio.CancelledError
 
 
 class CancelScope(BaseCancelScope):
-    def __new__(cls, *, deadline: float = math.inf, shield: bool = False):
+    def __new__(cls, *, deadline: float = math.inf, shield: bool = False) -> "CancelScope":
         return object.__new__(cls)
 
     def __init__(self, deadline: float = math.inf, shield: bool = False):
@@ -262,20 +262,20 @@ class CancelScope(BaseCancelScope):
         self._host_task: Optional[asyncio.Task] = None
         self._timeout_expired = False
 
-    def __enter__(self):
+    def __enter__(self) -> "CancelScope":
         if self._active:
             raise RuntimeError(
                 "Each CancelScope may only be used for a single 'with' block"
             )
 
-        self._host_task = current_task()
-        self._tasks.add(self._host_task)
+        self._host_task = host_task = cast(asyncio.Task, current_task())
+        self._tasks.add(host_task)
         try:
-            task_state = _task_states[self._host_task]
+            task_state = _task_states[host_task]
         except KeyError:
-            task_name = self._host_task.get_name() if _native_task_names else None
+            task_name = host_task.get_name() if _native_task_names else None
             task_state = TaskState(None, task_name, self)
-            _task_states[self._host_task] = task_state
+            _task_states[host_task] = task_state
         else:
             self._parent_scope = task_state.cancel_scope
             task_state.cancel_scope = self
@@ -326,7 +326,7 @@ class CancelScope(BaseCancelScope):
 
         return None
 
-    def _timeout(self):
+    def _timeout(self) -> None:
         if self._deadline != math.inf:
             loop = get_running_loop()
             if loop.time() >= self._deadline:
@@ -460,9 +460,9 @@ async def cancel_shielded_checkpoint() -> None:
         await sleep(0)
 
 
-def current_effective_deadline():
+def current_effective_deadline() -> float:
     try:
-        cancel_scope = _task_states[current_task()].cancel_scope
+        cancel_scope = _task_states[current_task()].cancel_scope  # type: ignore[index]
     except KeyError:
         return math.inf
 
@@ -477,7 +477,7 @@ def current_effective_deadline():
     return deadline
 
 
-def current_time():
+def current_time() -> float:
     return get_running_loop().time()
 
 
@@ -517,17 +517,17 @@ class _AsyncioTaskStatus(abc.TaskStatus):
     def __init__(self, future: asyncio.Future):
         self._future = future
 
-    def started(self, value=None) -> None:
+    def started(self, value: object = None) -> None:
         self._future.set_result(value)
 
 
 class TaskGroup(abc.TaskGroup):
-    def __init__(self):
+    def __init__(self) -> None:
         self.cancel_scope: CancelScope = CancelScope()
         self._active = False
         self._exceptions: List[BaseException] = []
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "TaskGroup":
         self.cancel_scope.__enter__()
         self._active = True
         return self
@@ -613,7 +613,7 @@ class TaskGroup(abc.TaskGroup):
                 self.cancel_scope._tasks.remove(task)
                 del _task_states[task]
 
-    def _spawn(self, func: Callable[..., Coroutine], args: tuple, name,
+    def _spawn(self, func: Callable[..., Coroutine], args: tuple, name: Optional[str],
                task_status_future: Optional[asyncio.Future] = None) -> asyncio.Task:
         def task_done(_task: asyncio.Task) -> None:
             # This is the code path for Python 3.8+
@@ -669,10 +669,10 @@ class TaskGroup(abc.TaskGroup):
         self.cancel_scope._tasks.add(task)
         return task
 
-    def start_soon(self, func: Callable[..., Coroutine], *args, name=None) -> None:
+    def start_soon(self, func: Callable[..., Coroutine], *args: object, name: str = None) -> None:
         self._spawn(func, args, name)
 
-    async def start(self, func: Callable[..., Coroutine], *args, name=None) -> None:
+    async def start(self, func: Callable[..., Coroutine], *args: object, name: str = None) -> None:
         future: asyncio.Future = asyncio.Future()
         task = self._spawn(func, args, name, future)
 
@@ -745,7 +745,7 @@ _threadpool_workers: RunVar[Set[WorkerThread]] = RunVar('_threadpool_workers')
 
 
 async def run_sync_in_worker_thread(
-        func: Callable[..., T_Retval], *args, cancellable: bool = False,
+        func: Callable[..., T_Retval], *args: object, cancellable: bool = False,
         limiter: Optional['CapacityLimiter'] = None) -> T_Retval:
     await checkpoint()
 
@@ -789,10 +789,10 @@ async def run_sync_in_worker_thread(
                 idle_workers.append(worker)
 
 
-def run_sync_from_thread(func: Callable[..., T_Retval], *args,
+def run_sync_from_thread(func: Callable[..., T_Retval], *args: object,
                          loop: Optional[asyncio.AbstractEventLoop] = None) -> T_Retval:
     @wraps(func)
-    def wrapper():
+    def wrapper() -> None:
         try:
             f.set_result(func(*args))
         except BaseException as exc:
@@ -806,22 +806,22 @@ def run_sync_from_thread(func: Callable[..., T_Retval], *args,
     return f.result()
 
 
-def run_async_from_thread(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args) -> T_Retval:
+def run_async_from_thread(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args: object) -> T_Retval:
     f: concurrent.futures.Future[T_Retval] = asyncio.run_coroutine_threadsafe(
         func(*args), threadlocals.loop)
     return f.result()
 
 
 class BlockingPortal(abc.BlockingPortal):
-    def __new__(cls):
+    def __new__(cls) -> "BlockingPortal":
         return object.__new__(cls)
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self._loop = get_running_loop()
 
     def _spawn_task_from_thread(self, func: Callable, args: tuple, kwargs: Dict[str, Any],
-                                name, future: Future) -> None:
+                                name: Optional[str], future: Future) -> None:
         run_sync_from_thread(
             partial(self._task_group.start_soon, name=name), self._call_func, func, args, kwargs,
             future, loop=self._loop)
@@ -908,12 +908,12 @@ class Process(abc.Process):
         return self._stderr
 
 
-async def open_process(command, *, shell: bool, stdin: int, stdout: int, stderr: int,
+async def open_process(command: Union[str, Sequence[str]], *, shell: bool, stdin: int, stdout: int, stderr: int,
                        cwd: Union[str, bytes, PathLike, None] = None,
                        env: Optional[Mapping[str, str]] = None) -> Process:
     await checkpoint()
     if shell:
-        process = await asyncio.create_subprocess_shell(command, stdin=stdin, stdout=stdout,
+        process = await asyncio.create_subprocess_shell(command, stdin=stdin, stdout=stdout,  # type: ignore[arg-type]
                                                         stderr=stderr, cwd=cwd, env=env)
     else:
         process = await asyncio.create_subprocess_exec(*command, stdin=stdin, stdout=stdout,
@@ -925,7 +925,7 @@ async def open_process(command, *, shell: bool, stdin: int, stdout: int, stderr:
     return Process(process, stdin_stream, stdout_stream, stderr_stream)
 
 
-def _forcibly_shutdown_process_pool_on_exit(workers: Set[Process], _task) -> None:
+def _forcibly_shutdown_process_pool_on_exit(workers: Set[Process], _task: object) -> None:
     """
     Forcibly shuts down worker processes belonging to this event loop."""
     child_watcher: Optional[asyncio.AbstractChildWatcher]
@@ -1142,7 +1142,7 @@ class UNIXSocketStream(abc.SocketStream):
         return self.__raw_socket
 
     def _wait_until_readable(self, loop: asyncio.AbstractEventLoop) -> asyncio.Future:
-        def callback(f):
+        def callback(f: object) -> None:
             del self._receive_future
             loop.remove_reader(self.__raw_socket)
 
@@ -1152,7 +1152,7 @@ class UNIXSocketStream(abc.SocketStream):
         return f
 
     def _wait_until_writable(self, loop: asyncio.AbstractEventLoop) -> asyncio.Future:
-        def callback(f):
+        def callback(f: object) -> None:
             del self._send_future
             loop.remove_writer(self.__raw_socket)
 
@@ -1594,10 +1594,10 @@ async def wait_socket_writable(sock: socket.SocketType) -> None:
 #
 
 class Event(BaseEvent):
-    def __new__(cls):
+    def __new__(cls) -> "Event":
         return object.__new__(cls)
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._event = asyncio.Event()
 
     def set(self) -> DeprecatedAwaitable:
@@ -1607,18 +1607,18 @@ class Event(BaseEvent):
     def is_set(self) -> bool:
         return self._event.is_set()
 
-    async def wait(self):
+    async def wait(self) -> None:
         if await self._event.wait():
             await checkpoint()
 
     def statistics(self) -> EventStatistics:
-        return EventStatistics(len(self._event._waiters))
+        return EventStatistics(len(self._event._waiters))  # type: ignore[attr-defined]
 
 
 class CapacityLimiter(BaseCapacityLimiter):
     _total_tokens: float = 0
 
-    def __new__(cls, total_tokens: float):
+    def __new__(cls, total_tokens: float) -> "CapacityLimiter":
         return object.__new__(cls)
 
     def __init__(self, total_tokens: float):
@@ -1626,7 +1626,7 @@ class CapacityLimiter(BaseCapacityLimiter):
         self._wait_queue: Dict[Any, asyncio.Event] = OrderedDict()
         self.total_tokens = total_tokens
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> None:
         await self.acquire()
 
     async def __aexit__(self, exc_type: Optional[Type[BaseException]],
@@ -1671,7 +1671,7 @@ class CapacityLimiter(BaseCapacityLimiter):
         self.acquire_on_behalf_of_nowait(current_task())
         return DeprecatedAwaitable(self.acquire_nowait)
 
-    def acquire_on_behalf_of_nowait(self, borrower) -> DeprecatedAwaitable:
+    def acquire_on_behalf_of_nowait(self, borrower: object) -> DeprecatedAwaitable:
         if borrower in self._borrowers:
             raise RuntimeError("this borrower is already holding one of this CapacityLimiter's "
                                "tokens")
@@ -1685,7 +1685,7 @@ class CapacityLimiter(BaseCapacityLimiter):
     async def acquire(self) -> None:
         return await self.acquire_on_behalf_of(current_task())
 
-    async def acquire_on_behalf_of(self, borrower) -> None:
+    async def acquire_on_behalf_of(self, borrower: object) -> None:
         await checkpoint_if_cancelled()
         try:
             self.acquire_on_behalf_of_nowait(borrower)
@@ -1705,7 +1705,7 @@ class CapacityLimiter(BaseCapacityLimiter):
     def release(self) -> None:
         self.release_on_behalf_of(current_task())
 
-    def release_on_behalf_of(self, borrower) -> None:
+    def release_on_behalf_of(self, borrower: object) -> None:
         try:
             self._borrowers.remove(borrower)
         except KeyError:
@@ -1725,7 +1725,7 @@ class CapacityLimiter(BaseCapacityLimiter):
 _default_thread_limiter: RunVar[CapacityLimiter] = RunVar('_default_thread_limiter')
 
 
-def current_default_thread_limiter():
+def current_default_thread_limiter() -> CapacityLimiter:
     try:
         return _default_thread_limiter.get()
     except LookupError:
@@ -1751,18 +1751,19 @@ class _SignalReceiver(DeprecatedAsyncContextManager):
         if not self._future.done():
             self._future.set_result(None)
 
-    def __enter__(self):
+    def __enter__(self) -> "_SignalReceiver":
         for sig in set(self._signals):
             self._loop.add_signal_handler(sig, self._deliver, sig)
             self._handled_signals.add(sig)
 
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> Optional[bool]:
         for sig in self._handled_signals:
             self._loop.remove_signal_handler(sig)
+        return None
 
-    def __aiter__(self):
+    def __aiter__(self) -> "_SignalReceiver":
         return self
 
     async def __anext__(self) -> int:
@@ -1825,7 +1826,7 @@ class TestRunner(abc.TestRunner):
         self._loop.set_debug(debug)
         asyncio.set_event_loop(self._loop)
 
-    def _cancel_all_tasks(self):
+    def _cancel_all_tasks(self) -> None:
         to_cancel = all_tasks(self._loop)
         if not to_cancel:
             return
@@ -1840,7 +1841,7 @@ class TestRunner(abc.TestRunner):
             if task.cancelled():
                 continue
             if task.exception() is not None:
-                raise task.exception()
+                raise cast(BaseException, task.exception())
 
     def close(self) -> None:
         try:
@@ -1850,23 +1851,23 @@ class TestRunner(abc.TestRunner):
             asyncio.set_event_loop(None)
             self._loop.close()
 
-    def call(self, func: Callable[..., Awaitable], *args, **kwargs):
+    def call(self, func: Callable[..., Awaitable[T_Retval]], *args: object, **kwargs: object) -> T_Retval:
         def exception_handler(loop: asyncio.AbstractEventLoop, context: Dict[str, Any]) -> None:
             exceptions.append(context['exception'])
 
         exceptions: List[Exception] = []
         self._loop.set_exception_handler(exception_handler)
         try:
-            retval = self._loop.run_until_complete(func(*args, **kwargs))
+            retval: T_Retval = self._loop.run_until_complete(func(*args, **kwargs))
         except Exception as exc:
-            retval = None
+            retval = None  # type: ignore[assignment]
             exceptions.append(exc)
         finally:
             self._loop.set_exception_handler(None)
 
-        if len(exceptions) == 1:
-            raise exceptions[0]
-        elif exceptions:
-            raise ExceptionGroup(exceptions)
+            if len(exceptions) == 1:
+                raise exceptions[0]
+            elif exceptions:
+                raise ExceptionGroup(exceptions)
 
         return retval

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1874,9 +1874,9 @@ class TestRunner(abc.TestRunner):
         finally:
             self._loop.set_exception_handler(None)
 
-            if len(exceptions) == 1:
-                raise exceptions[0]
-            elif exceptions:
-                raise ExceptionGroup(exceptions)
+        if len(exceptions) == 1:
+            raise exceptions[0]
+        elif exceptions:
+            raise ExceptionGroup(exceptions)
 
         return retval

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -644,7 +644,7 @@ class TaskGroup(abc.TaskGroup):
             raise RuntimeError('This task group is not active; no new tasks can be started.')
 
         options = {}
-        name = name or get_callable_name(func)
+        name = get_callable_name(func) if name is None else str(name)
         if _native_task_names:
             options['name'] = name
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -213,7 +213,8 @@ def _maybe_set_event_loop_policy(policy: Optional[asyncio.AbstractEventLoopPolic
         asyncio.set_event_loop_policy(policy)
 
 
-def run(func: Callable[..., Awaitable[T_Retval]], *args: object, debug: bool = False, use_uvloop: bool = True,
+def run(func: Callable[..., Awaitable[T_Retval]], *args: object,
+        debug: bool = False, use_uvloop: bool = True,
         policy: Optional[asyncio.AbstractEventLoopPolicy] = None) -> T_Retval:
     @wraps(func)
     async def wrapper() -> T_Retval:
@@ -806,7 +807,9 @@ def run_sync_from_thread(func: Callable[..., T_Retval], *args: object,
     return f.result()
 
 
-def run_async_from_thread(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args: object) -> T_Retval:
+def run_async_from_thread(
+    func: Callable[..., Coroutine[Any, Any, T_Retval]], *args: object
+) -> T_Retval:
     f: concurrent.futures.Future[T_Retval] = asyncio.run_coroutine_threadsafe(
         func(*args), threadlocals.loop)
     return f.result()
@@ -908,13 +911,16 @@ class Process(abc.Process):
         return self._stderr
 
 
-async def open_process(command: Union[str, Sequence[str]], *, shell: bool, stdin: int, stdout: int, stderr: int,
+async def open_process(command: Union[str, Sequence[str]], *, shell: bool,
+                       stdin: int, stdout: int, stderr: int,
                        cwd: Union[str, bytes, PathLike, None] = None,
                        env: Optional[Mapping[str, str]] = None) -> Process:
     await checkpoint()
     if shell:
-        process = await asyncio.create_subprocess_shell(command, stdin=stdin, stdout=stdout,  # type: ignore[arg-type]
-                                                        stderr=stderr, cwd=cwd, env=env)
+        process = await asyncio.create_subprocess_shell(
+            command, stdin=stdin, stdout=stdout,  # type: ignore[arg-type]
+            stderr=stderr, cwd=cwd, env=env,
+        )
     else:
         process = await asyncio.create_subprocess_exec(*command, stdin=stdin, stdout=stdout,
                                                        stderr=stderr, cwd=cwd, env=env)
@@ -1758,7 +1764,9 @@ class _SignalReceiver(DeprecatedAsyncContextManager):
 
         return self
 
-    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> Optional[bool]:
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> Optional[bool]:
         for sig in self._handled_signals:
             self._loop.remove_signal_handler(sig)
         return None
@@ -1851,7 +1859,8 @@ class TestRunner(abc.TestRunner):
             asyncio.set_event_loop(None)
             self._loop.close()
 
-    def call(self, func: Callable[..., Awaitable[T_Retval]], *args: object, **kwargs: object) -> T_Retval:
+    def call(self, func: Callable[..., Awaitable[T_Retval]],
+             *args: object, **kwargs: object) -> T_Retval:
         def exception_handler(loop: asyncio.AbstractEventLoop, context: Dict[str, Any]) -> None:
             exceptions.append(context['exception'])
 

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -145,14 +145,14 @@ class TaskGroup(abc.TaskGroup):
         finally:
             self._active = False
 
-    def start_soon(self, func: Callable, *args: object, name: str = None) -> None:
+    def start_soon(self, func: Callable, *args: object, name: object = None) -> None:
         if not self._active:
             raise RuntimeError('This task group is not active; no new tasks can be started.')
 
         self._nursery.start_soon(func, *args, name=name)
 
     async def start(self, func: Callable[..., Coroutine],
-                    *args: object, name: str = None) -> object:
+                    *args: object, name: object = None) -> object:
         if not self._active:
             raise RuntimeError('This task group is not active; no new tasks can be started.')
 
@@ -185,7 +185,7 @@ class BlockingPortal(abc.BlockingPortal):
         self._token = trio.lowlevel.current_trio_token()
 
     def _spawn_task_from_thread(self, func: Callable, args: tuple, kwargs: Dict[str, Any],
-                                name: Optional[str], future: Future) -> None:
+                                name: object, future: Future) -> None:
         return trio.from_thread.run_sync(
             partial(self._task_group.start_soon, name=name), self._call_func, func, args, kwargs,
             future, trio_token=self._token)

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -66,7 +66,8 @@ sleep = trio.sleep
 #
 
 class CancelScope(BaseCancelScope):
-    def __new__(cls, original: Optional[trio.CancelScope] = None, **kwargs: object) -> 'CancelScope':
+    def __new__(cls, original: Optional[trio.CancelScope] = None,
+                **kwargs: object) -> 'CancelScope':
         return object.__new__(cls)
 
     def __init__(self, original: Optional[trio.CancelScope] = None, **kwargs: object) -> None:
@@ -76,7 +77,9 @@ class CancelScope(BaseCancelScope):
         self.__original.__enter__()
         return self
 
-    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> Optional[bool]:
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> Optional[bool]:
         return self.__original.__exit__(exc_type, exc_val, exc_tb)
 
     def cancel(self) -> DeprecatedAwaitable:
@@ -148,7 +151,8 @@ class TaskGroup(abc.TaskGroup):
 
         self._nursery.start_soon(func, *args, name=name)
 
-    async def start(self, func: Callable[..., Coroutine], *args: object, name: str = None) -> object:
+    async def start(self, func: Callable[..., Coroutine],
+                    *args: object, name: str = None) -> object:
         if not self._active:
             raise RuntimeError('This task group is not active; no new tasks can be started.')
 
@@ -278,7 +282,8 @@ class Process(abc.Process):
         return self._stderr
 
 
-async def open_process(command: Union[str, Sequence[str]], *, shell: bool, stdin: int, stdout: int, stderr: int,
+async def open_process(command: Union[str, Sequence[str]], *, shell: bool,
+                       stdin: int, stdout: int, stderr: int,
                        cwd: Union[str, bytes, PathLike, None] = None,
                        env: Optional[Mapping[str, str]] = None) -> Process:
     process = await trio.open_process(command, stdin=stdin, stdout=stdout, stderr=stderr,
@@ -751,7 +756,8 @@ class TestRunner(abc.TestRunner):
         async with trio.open_nursery() as self._nursery:
             await self._stop_event.wait()
 
-    async def _call_func(self, func: Callable[..., Awaitable[object]], args: tuple, kwargs: dict) -> None:
+    async def _call_func(self, func: Callable[..., Awaitable[object]],
+                         args: tuple, kwargs: dict) -> None:
         try:
             retval = await func(*args, **kwargs)
         except BaseException as exc:
@@ -768,7 +774,8 @@ class TestRunner(abc.TestRunner):
             while self._nursery is not None:
                 self._call_queue.get()()
 
-    def call(self, func: Callable[..., Awaitable[T_Retval]], *args: object, **kwargs: object) -> T_Retval:
+    def call(self, func: Callable[..., Awaitable[T_Retval]],
+             *args: object, **kwargs: object) -> T_Retval:
         if self._nursery is None:
             trio.lowlevel.start_guest_run(
                 self._trio_main, run_sync_soon_threadsafe=self._call_queue.put,

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -8,11 +8,12 @@ from io import IOBase
 from os import PathLike
 from types import TracebackType
 from typing import (
-    TYPE_CHECKING, Any, Awaitable, Callable, Collection, ContextManager, Coroutine, Dict, Generic,
-    List, Mapping, NoReturn, Optional, Sequence, Set, Tuple, Type, TypeVar, Union)
+    Any, Awaitable, Callable, Collection, ContextManager, Coroutine, Dict, Generic, List, Mapping,
+    NoReturn, Optional, Sequence, Set, Tuple, Type, TypeVar, Union)
 
 import trio.from_thread
 from outcome import Error, Outcome, Value
+from trio.socket import SocketType as TrioSocketType
 from trio.to_thread import run_sync
 
 from .. import CapacityLimiterStatistics, EventStatistics, TaskInfo, abc
@@ -36,10 +37,6 @@ except ImportError:
 else:
     from trio.lowlevel import wait_readable, wait_writable
 
-if TYPE_CHECKING:
-    from trio.socket import SocketType as TrioSocketType
-else:
-    TrioSocketType = object
 
 T_Retval = TypeVar('T_Retval')
 T_SockAddr = TypeVar('T_SockAddr', str, IPSockAddrType)

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -8,8 +8,8 @@ from io import IOBase
 from os import PathLike
 from types import TracebackType
 from typing import (
-    Any, Awaitable, Callable, Collection, ContextManager, Coroutine, Dict, Generic, List, Mapping,
-    NoReturn, Optional, Sequence, Set, Tuple, Type, TypeVar, Union)
+    Any, Awaitable, Callable, Collection, ContextManager, Coroutine, Deque, Dict, Generic, List,
+    Mapping, NoReturn, Optional, Sequence, Set, Tuple, Type, TypeVar, Union)
 
 import trio.from_thread
 from outcome import Error, Outcome, Value
@@ -743,7 +743,7 @@ class TestRunner(abc.TestRunner):
         from queue import Queue
 
         self._call_queue: "Queue[Callable[..., object]]" = Queue()
-        self._result_queue: Outcome = deque()
+        self._result_queue: Deque[Outcome] = deque()
         self._stop_event: Optional[trio.Event] = None
         self._nursery: Optional[trio.Nursery] = None
         self._options = options

--- a/src/anyio/_core/_compat.py
+++ b/src/anyio/_core/_compat.py
@@ -87,7 +87,7 @@ def maybe_async_cm(cm: Union[ContextManager[T], AsyncContextManager[T]]) -> Asyn
 
 def _warn_deprecation(awaitable: AnyDeprecatedAwaitable, stacklevel: int = 1) -> None:
     warn(f'Awaiting on {awaitable._name}() is deprecated. Use "await '
-         f'anyio.maybe_awaitable({awaitable._name}(...)) if you have to support both AnyIO 2.x '
+         f'anyio.maybe_async({awaitable._name}(...)) if you have to support both AnyIO 2.x '
          f'and 3.x, or just remove the "await" if you are completely migrating to AnyIO 3+.',
          DeprecationWarning, stacklevel=stacklevel + 1)
 

--- a/src/anyio/_core/_compat.py
+++ b/src/anyio/_core/_compat.py
@@ -1,13 +1,22 @@
 from abc import ABCMeta, abstractmethod
 from contextlib import AbstractContextManager
+from types import TracebackType
 from typing import (
-    AsyncContextManager, Callable, ContextManager, Generic, List, Optional, TypeVar, Union,
-    overload)
+    TYPE_CHECKING, AsyncContextManager, Callable, ContextManager, Generic, Iterable, List,
+    Optional, Tuple, Type, TypeVar, Union, overload)
 from warnings import warn
+
+if TYPE_CHECKING:
+    from ._testing import TaskInfo
 
 T = TypeVar('T')
 AnyDeprecatedAwaitable = Union['DeprecatedAwaitable', 'DeprecatedAwaitableFloat',
-                               'DeprecatedAwaitableList']
+                               'DeprecatedAwaitableList', 'TaskInfo']
+
+
+@overload
+async def maybe_async(__obj: 'TaskInfo') -> 'TaskInfo':
+    ...
 
 
 @overload
@@ -16,7 +25,7 @@ async def maybe_async(__obj: 'DeprecatedAwaitableFloat') -> float:
 
 
 @overload
-async def maybe_async(__obj: 'DeprecatedAwaitableList') -> list:
+async def maybe_async(__obj: 'DeprecatedAwaitableList[T]') -> List[T]:
     ...
 
 
@@ -25,7 +34,7 @@ async def maybe_async(__obj: 'DeprecatedAwaitable') -> None:
     ...
 
 
-async def maybe_async(__obj: AnyDeprecatedAwaitable) -> Union[float, list, None]:
+async def maybe_async(__obj: AnyDeprecatedAwaitable) -> Union[TaskInfo, float, list, None]:
     """
     Await on the given object if necessary.
 
@@ -49,7 +58,7 @@ class _ContextManagerWrapper:
     async def __aenter__(self) -> T:
         return self._cm.__enter__()
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> Optional[bool]:
+    async def __aexit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> Optional[bool]:
         return self._cm.__exit__(exc_type, exc_val, exc_tb)
 
 
@@ -83,33 +92,33 @@ class DeprecatedAwaitable:
     def __init__(self, func: Callable[..., 'DeprecatedAwaitable']):
         self._name = f'{func.__module__}.{func.__qualname__}'
 
-    def __await__(self):
+    def __await__(self) -> Iterable[None]:
         _warn_deprecation(self)
         if False:
             yield
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple[Type[None], Tuple]:
         return type(None), ()
 
-    def _unwrap(self):
+    def _unwrap(self) -> None:
         return None
 
 
 class DeprecatedAwaitableFloat(float):
-    def __new__(cls, x, func):
+    def __new__(cls, x: float, func: Callable[..., 'DeprecatedAwaitableFloat']) -> DeprecatedAwaitableFloat:
         return super().__new__(cls, x)
 
     def __init__(self, x: float, func: Callable[..., 'DeprecatedAwaitableFloat']):
         self._name = f'{func.__module__}.{func.__qualname__}'
 
-    def __await__(self):
+    def __await__(self) -> Iterable[float]:
         _warn_deprecation(self)
         if False:
             yield
 
         return float(self)
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple[Type[float], Tuple[float]]:
         return float, (float(self),)
 
     def _unwrap(self) -> float:
@@ -117,18 +126,18 @@ class DeprecatedAwaitableFloat(float):
 
 
 class DeprecatedAwaitableList(List[T]):
-    def __init__(self, *args, func: Callable[..., 'DeprecatedAwaitableList']):
+    def __init__(self, *args: T, func: Callable[..., 'DeprecatedAwaitableList']):
         super().__init__(*args)
         self._name = f'{func.__module__}.{func.__qualname__}'
 
-    def __await__(self):
+    def __await__(self) -> Iterable[List[T]]:
         _warn_deprecation(self)
         if False:
             yield
 
-        return self
+        return list(self)
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple[Type[list], Tuple[List[T]]]:
         return list, (list(self),)
 
     def _unwrap(self) -> List[T]:
@@ -141,7 +150,7 @@ class DeprecatedAsyncContextManager(Generic[T], metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> Optional[bool]:
         pass
 
     async def __aenter__(self) -> T:
@@ -151,5 +160,5 @@ class DeprecatedAsyncContextManager(Generic[T], metaclass=ABCMeta):
              f'you are completely migrating to AnyIO 3+.', DeprecationWarning)
         return self.__enter__()
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> Optional[bool]:
+    async def __aexit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> Optional[bool]:
         return self.__exit__(exc_type, exc_val, exc_tb)

--- a/src/anyio/_core/_compat.py
+++ b/src/anyio/_core/_compat.py
@@ -8,6 +8,8 @@ from warnings import warn
 
 if TYPE_CHECKING:
     from ._testing import TaskInfo
+else:
+    TaskInfo = object
 
 T = TypeVar('T')
 AnyDeprecatedAwaitable = Union['DeprecatedAwaitable', 'DeprecatedAwaitableFloat',
@@ -105,7 +107,7 @@ class DeprecatedAwaitable:
 
 
 class DeprecatedAwaitableFloat(float):
-    def __new__(cls, x: float, func: Callable[..., 'DeprecatedAwaitableFloat']) -> DeprecatedAwaitableFloat:
+    def __new__(cls, x: float, func: Callable[..., 'DeprecatedAwaitableFloat']) -> 'DeprecatedAwaitableFloat':
         return super().__new__(cls, x)
 
     def __init__(self, x: float, func: Callable[..., 'DeprecatedAwaitableFloat']):

--- a/src/anyio/_core/_compat.py
+++ b/src/anyio/_core/_compat.py
@@ -13,11 +13,11 @@ else:
 
 T = TypeVar('T')
 AnyDeprecatedAwaitable = Union['DeprecatedAwaitable', 'DeprecatedAwaitableFloat',
-                               'DeprecatedAwaitableList', 'TaskInfo']
+                               'DeprecatedAwaitableList', TaskInfo]
 
 
 @overload
-async def maybe_async(__obj: 'TaskInfo') -> 'TaskInfo':
+async def maybe_async(__obj: TaskInfo) -> TaskInfo:
     ...
 
 

--- a/src/anyio/_core/_compat.py
+++ b/src/anyio/_core/_compat.py
@@ -60,7 +60,9 @@ class _ContextManagerWrapper:
     async def __aenter__(self) -> T:
         return self._cm.__enter__()
 
-    async def __aexit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> Optional[bool]:
+    async def __aexit__(self, exc_type: Optional[Type[BaseException]],
+                        exc_val: Optional[BaseException],
+                        exc_tb: Optional[TracebackType]) -> Optional[bool]:
         return self._cm.__exit__(exc_type, exc_val, exc_tb)
 
 
@@ -107,7 +109,9 @@ class DeprecatedAwaitable:
 
 
 class DeprecatedAwaitableFloat(float):
-    def __new__(cls, x: float, func: Callable[..., 'DeprecatedAwaitableFloat']) -> 'DeprecatedAwaitableFloat':
+    def __new__(
+        cls, x: float, func: Callable[..., 'DeprecatedAwaitableFloat']
+    ) -> 'DeprecatedAwaitableFloat':
         return super().__new__(cls, x)
 
     def __init__(self, x: float, func: Callable[..., 'DeprecatedAwaitableFloat']):
@@ -152,7 +156,9 @@ class DeprecatedAsyncContextManager(Generic[T], metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> Optional[bool]:
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> Optional[bool]:
         pass
 
     async def __aenter__(self) -> T:
@@ -162,5 +168,7 @@ class DeprecatedAsyncContextManager(Generic[T], metaclass=ABCMeta):
              f'you are completely migrating to AnyIO 3+.', DeprecationWarning)
         return self.__enter__()
 
-    async def __aexit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]) -> Optional[bool]:
+    async def __aexit__(self, exc_type: Optional[Type[BaseException]],
+                        exc_val: Optional[BaseException],
+                        exc_tb: Optional[TracebackType]) -> Optional[bool]:
         return self.__exit__(exc_type, exc_val, exc_tb)

--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -16,7 +16,7 @@ T_Retval = TypeVar('T_Retval')
 threadlocals = threading.local()
 
 
-def run(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args,
+def run(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args: object,
         backend: str = 'asyncio', backend_options: Optional[Dict[str, Any]] = None) -> T_Retval:
     """
     Run the given coroutine function in an asynchronous event loop.
@@ -120,7 +120,7 @@ def get_cancelled_exc_class() -> Type[BaseException]:
 #
 
 @contextmanager
-def claim_worker_thread(backend) -> Generator[Any, None, None]:
+def claim_worker_thread(backend: str) -> Generator[Any, None, None]:
     module = sys.modules['anyio._backends._' + backend]
     threadlocals.current_async_module = module
     token = sniffio.current_async_library_cvar.set(backend)
@@ -131,7 +131,7 @@ def claim_worker_thread(backend) -> Generator[Any, None, None]:
         del threadlocals.current_async_module
 
 
-def get_asynclib(asynclib_name: Optional[str] = None):
+def get_asynclib(asynclib_name: Optional[str] = None) -> Any:
     if asynclib_name is None:
         asynclib_name = sniffio.current_async_library()
 

--- a/src/anyio/_core/_exceptions.py
+++ b/src/anyio/_core/_exceptions.py
@@ -49,7 +49,7 @@ class ExceptionGroup(BaseException):
     #: the sequence of exceptions raised together
     exceptions: Sequence[BaseException]
 
-    def __str__(self):
+    def __str__(self) -> str:
         tracebacks = [''.join(format_exception(type(exc), exc, exc.__traceback__))
                       for exc in self.exceptions]
         return f'{len(self.exceptions)} exceptions were raised in the task group:\n' \
@@ -67,7 +67,7 @@ class IncompleteRead(Exception):
     connection is closed before the requested amount of bytes has been read.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('The stream was closed before the read operation could be completed')
 
 

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -1,12 +1,14 @@
 import os
 from os import PathLike
-from typing import Callable, Optional, Union
+from typing import Any, AsyncIterator, Callable, Generic, Optional, TypeVar, Union
 
 from .. import to_thread
 from ..abc import AsyncResource
 
+T_Fp = TypeVar("T_Fp")
 
-class AsyncFile(AsyncResource):
+
+class AsyncFile(AsyncResource, Generic[T_Fp]):
     """
     An asynchronous file object.
 
@@ -38,18 +40,18 @@ class AsyncFile(AsyncResource):
                 print(line)
     """
 
-    def __init__(self, fp) -> None:
-        self._fp = fp
+    def __init__(self, fp: T_Fp) -> None:
+        self._fp: Any = fp
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> object:
         return getattr(self._fp, name)
 
     @property
-    def wrapped(self):
+    def wrapped(self) -> T_Fp:
         """The wrapped file object."""
         return self._fp
 
-    async def __aiter__(self):
+    async def __aiter__(self) -> AsyncIterator[bytes]:
         while True:
             line = await self.readline()
             if line:

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -187,7 +187,7 @@ async def connect_tcp(
     if tls or tls_hostname or ssl_context:
         try:
             return await TLSStream.wrap(connected_stream, server_side=False,
-                                        hostname=tls_hostname or cast(Optional[str], remote_host),
+                                        hostname=tls_hostname or str(remote_host),
                                         ssl_context=ssl_context,
                                         standard_compatible=tls_standard_compatible)
         except BaseException:

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -491,7 +491,6 @@ def convert_ipv6_sockaddr(
     :return: the converted socket address
 
     """
-
     # This is more complicated than it should be because of MyPy
     if isinstance(sockaddr, tuple) and len(sockaddr) == 4:
         host, port, flowinfo, scope_id = cast(Tuple[str, int, int, int], sockaddr)

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -84,8 +84,10 @@ async def connect_tcp(
 
 
 async def connect_tcp(
-    remote_host: IPAddressType, remote_port: int, *, local_host: Optional[IPAddressType] = None, tls: bool = False, ssl_context: Optional[ssl.SSLContext] = None,
-    tls_standard_compatible: bool = True, tls_hostname: Optional[str] = None, happy_eyeballs_delay: float = 0.25
+    remote_host: IPAddressType, remote_port: int, *, local_host: Optional[IPAddressType] = None,
+    tls: bool = False, ssl_context: Optional[ssl.SSLContext] = None,
+    tls_standard_compatible: bool = True, tls_hostname: Optional[str] = None,
+    happy_eyeballs_delay: float = 0.25
 ) -> Union[SocketStream, TLSStream]:
     """
     Connect to a host using the TCP protocol.
@@ -491,7 +493,9 @@ class _SockAddr:
             return self.host, self.port
 
 
-def convert_ipv6_sockaddr(sockaddr: Union[Tuple[str, int, object, object], Tuple[str, int]]) -> Tuple[str, int]:
+def convert_ipv6_sockaddr(
+    sockaddr: Union[Tuple[str, int, object, object], Tuple[str, int]]
+) -> Tuple[str, int]:
     """
     Convert a 4-tuple IPv6 socket address to a 2-tuple (address, port) format.
 

--- a/src/anyio/_core/_streams.py
+++ b/src/anyio/_core/_streams.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Optional, Tuple, Type, TypeVar, overload
+from typing import Optional, Tuple, Type, TypeVar, overload
 
 from ..streams.memory import (
     MemoryObjectReceiveStream, MemoryObjectSendStream, MemoryObjectStreamState)
@@ -17,13 +17,13 @@ def create_memory_object_stream(
 @overload
 def create_memory_object_stream(
     max_buffer_size: float = 0
-) -> Tuple[MemoryObjectSendStream[Any], MemoryObjectReceiveStream[Any]]:
+) -> Tuple[MemoryObjectSendStream, MemoryObjectReceiveStream]:
     ...
 
 
 def create_memory_object_stream(
     max_buffer_size: float = 0, item_type: Optional[Type[T_Item]] = None
-) -> Tuple[MemoryObjectSendStream[Any], MemoryObjectReceiveStream[Any]]:
+) -> Tuple[MemoryObjectSendStream, MemoryObjectReceiveStream]:
     """
     Create a memory object stream.
 

--- a/src/anyio/_core/_streams.py
+++ b/src/anyio/_core/_streams.py
@@ -21,7 +21,9 @@ def create_memory_object_stream(
     ...
 
 
-def create_memory_object_stream(max_buffer_size: float = 0, item_type: Optional[Type[T_Item]] = None) -> Tuple[MemoryObjectSendStream[Any], MemoryObjectReceiveStream[Any]]:
+def create_memory_object_stream(
+    max_buffer_size: float = 0, item_type: Optional[Type[T_Item]] = None
+) -> Tuple[MemoryObjectSendStream[Any], MemoryObjectReceiveStream[Any]]:
     """
     Create a memory object stream.
 

--- a/src/anyio/_core/_streams.py
+++ b/src/anyio/_core/_streams.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Tuple, Type, TypeVar, overload
+from typing import Any, Optional, Tuple, Type, TypeVar, overload
 
 from ..streams.memory import (
     MemoryObjectReceiveStream, MemoryObjectSendStream, MemoryObjectStreamState)
@@ -21,7 +21,7 @@ def create_memory_object_stream(
     ...
 
 
-def create_memory_object_stream(max_buffer_size=0, item_type=None):
+def create_memory_object_stream(max_buffer_size: float = 0, item_type: Optional[Type[T_Item]] = None) -> Tuple[MemoryObjectSendStream[Any], MemoryObjectReceiveStream[Any]]:
     """
     Create a memory object stream.
 

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -1,6 +1,6 @@
 from os import PathLike
 from subprocess import DEVNULL, PIPE, CalledProcessError, CompletedProcess
-from typing import Mapping, Optional, Sequence, Union, cast
+from typing import AsyncIterable, List, Mapping, Optional, Sequence, Union, cast
 
 from ..abc import Process
 from ._eventloop import get_asynclib
@@ -32,13 +32,13 @@ async def run_process(command: Union[str, Sequence[str]], *, input: Optional[byt
         nonzero return code
 
     """
-    async def drain_stream(stream, index):
+    async def drain_stream(stream: AsyncIterable[bytes], index: int) -> None:
         chunks = [chunk async for chunk in stream]
         stream_contents[index] = b''.join(chunks)
 
     async with await open_process(command, stdin=PIPE if input else DEVNULL, stdout=stdout,
                                   stderr=stderr, cwd=cwd, env=env) as process:
-        stream_contents = [None, None]
+        stream_contents: List[Optional[bytes]] = [None, None]
         try:
             async with create_task_group() as tg:
                 if process.stdout:

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -73,7 +73,7 @@ class SemaphoreStatistics:
 
 
 class Event:
-    def __new__(cls):
+    def __new__(cls) -> 'Event':
         return get_asynclib().Event()
 
     def set(self) -> DeprecatedAwaitable:
@@ -84,7 +84,7 @@ class Event:
         """Return ``True`` if the flag is set, ``False`` if not."""
         raise NotImplementedError
 
-    async def wait(self) -> bool:
+    async def wait(self) -> None:
         """
         Wait until the flag has been set.
 
@@ -101,10 +101,10 @@ class Event:
 class Lock:
     _owner_task: Optional[TaskInfo] = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._waiters: Deque[Tuple[TaskInfo, Event]] = deque()
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> None:
         await self.acquire()
 
     async def __aexit__(self, exc_type: Optional[Type[BaseException]],
@@ -183,7 +183,7 @@ class Condition:
         self._lock = lock or Lock()
         self._waiters: Deque[Event] = deque()
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> None:
         await self.acquire()
 
     async def __aexit__(self, exc_type: Optional[Type[BaseException]],
@@ -351,10 +351,10 @@ class Semaphore:
 
 
 class CapacityLimiter:
-    def __new__(cls, total_tokens: float):
+    def __new__(cls, total_tokens: float) -> 'CapacityLimiter':
         return get_asynclib().CapacityLimiter(total_tokens)
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> None:
         raise NotImplementedError
 
     async def __aexit__(self, exc_type: Optional[Type[BaseException]],
@@ -380,7 +380,7 @@ class CapacityLimiter:
     def total_tokens(self, value: float) -> None:
         raise NotImplementedError
 
-    async def set_total_tokens(self, value) -> None:
+    async def set_total_tokens(self, value: float) -> None:
         warn('CapacityLimiter.set_total_tokens has been deprecated. Set the value of the'
              '"total_tokens" attribute directly.', DeprecationWarning)
         self.total_tokens = value
@@ -404,7 +404,7 @@ class CapacityLimiter:
         """
         raise NotImplementedError
 
-    def acquire_on_behalf_of_nowait(self, borrower) -> DeprecatedAwaitable:
+    def acquire_on_behalf_of_nowait(self, borrower: object) -> DeprecatedAwaitable:
         """
         Acquire a token without waiting for one to become available.
 
@@ -421,7 +421,7 @@ class CapacityLimiter:
         """
         raise NotImplementedError
 
-    async def acquire_on_behalf_of(self, borrower) -> None:
+    async def acquire_on_behalf_of(self, borrower: object) -> None:
         """
         Acquire a token, waiting if necessary for one to become available.
 
@@ -438,7 +438,7 @@ class CapacityLimiter:
         """
         raise NotImplementedError
 
-    def release_on_behalf_of(self, borrower) -> None:
+    def release_on_behalf_of(self, borrower: object) -> None:
         """
         Release the token held by the given borrower.
 
@@ -541,11 +541,14 @@ class ResourceGuard:
         self.action = action
         self._guarded = False
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         if self._guarded:
             raise BusyResourceError(self.action)
 
         self._guarded = True
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> Optional[bool]:
         self._guarded = False
+        return None

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -9,7 +9,7 @@ from ._eventloop import get_asynclib
 
 
 class _IgnoredTaskStatus(TaskStatus):
-    def started(self, value=None) -> None:
+    def started(self, value: object = None) -> None:
         pass
 
 
@@ -24,7 +24,7 @@ class CancelScope(DeprecatedAsyncContextManager['CancelScope']):
     :param shield: ``True`` to shield the cancel scope from external cancellation
     """
 
-    def __new__(cls, *, deadline: float = math.inf, shield: bool = False):
+    def __new__(cls, *, deadline: float = math.inf, shield: bool = False) -> 'CancelScope':
         return get_asynclib().CancelScope(shield=shield, deadline=deadline)
 
     def cancel(self) -> DeprecatedAwaitable:
@@ -64,7 +64,7 @@ class CancelScope(DeprecatedAsyncContextManager['CancelScope']):
     def shield(self, value: bool) -> None:
         raise NotImplementedError
 
-    def __enter__(self):
+    def __enter__(self) -> 'CancelScope':
         raise NotImplementedError
 
     def __exit__(self, exc_type: Optional[Type[BaseException]],
@@ -92,10 +92,12 @@ class FailAfterContextManager(DeprecatedAsyncContextManager):
     def __init__(self, cancel_scope: CancelScope):
         self._cancel_scope = cancel_scope
 
-    def __enter__(self):
+    def __enter__(self) -> CancelScope:
         return self._cancel_scope.__enter__()
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[TracebackType]) -> Optional[bool]:
         retval = self._cancel_scope.__exit__(exc_type, exc_val, exc_tb)
         if self._cancel_scope.cancel_called:
             raise TimeoutError

--- a/src/anyio/_core/_testing.py
+++ b/src/anyio/_core/_testing.py
@@ -43,7 +43,9 @@ class TaskInfo:
             yield
         return self
 
-    def __reduce__(self) -> Tuple[Type["TaskInfo"], Tuple[int, Optional[int], Optional[str], Coroutine]]:
+    def __reduce__(self) -> Tuple[
+        Type["TaskInfo"], Tuple[int, Optional[int], Optional[str], Coroutine]
+    ]:
         return TaskInfo, (self.id, self.parent_id, self.name, self.coro)
 
     def _unwrap(self) -> 'TaskInfo':

--- a/src/anyio/_core/_testing.py
+++ b/src/anyio/_core/_testing.py
@@ -1,4 +1,4 @@
-from typing import Coroutine, Iterable, Optional, Tuple, Type
+from typing import Coroutine, Generator, Iterable, Optional, Tuple, Type
 
 from ._compat import DeprecatedAwaitable, DeprecatedAwaitableList, _warn_deprecation
 from ._eventloop import get_asynclib
@@ -37,10 +37,11 @@ class TaskInfo:
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(id={self.id!r}, name={self.name!r})'
 
-    def __await__(self) -> Iterable["TaskInfo"]:
+    def __await__(self) -> Generator[None, None, "TaskInfo"]:
         _warn_deprecation(self)
         if False:
             yield
+        return self
 
     def __reduce__(self) -> Tuple[Type["TaskInfo"], Tuple[int, Optional[int], Optional[str], Coroutine]]:
         return TaskInfo, (self.id, self.parent_id, self.name, self.coro)

--- a/src/anyio/_core/_testing.py
+++ b/src/anyio/_core/_testing.py
@@ -1,4 +1,4 @@
-from typing import Coroutine, Generator, Optional, Tuple, Type
+from typing import Coroutine, Generator, Optional
 
 from ._compat import DeprecatedAwaitableList, _warn_deprecation
 from ._eventloop import get_asynclib
@@ -42,11 +42,6 @@ class TaskInfo:
         if False:
             yield
         return self
-
-    def __reduce__(self) -> Tuple[
-        Type["TaskInfo"], Tuple[int, Optional[int], Optional[str], Coroutine]
-    ]:
-        return TaskInfo, (self.id, self.parent_id, self.name, self.coro)
 
     def _unwrap(self) -> 'TaskInfo':
         return self

--- a/src/anyio/_core/_testing.py
+++ b/src/anyio/_core/_testing.py
@@ -41,6 +41,7 @@ class TaskInfo:
         _warn_deprecation(self)
         if False:
             yield
+
         return self
 
     def _unwrap(self) -> 'TaskInfo':

--- a/src/anyio/_core/_testing.py
+++ b/src/anyio/_core/_testing.py
@@ -1,6 +1,6 @@
-from typing import Coroutine, Generator, Iterable, Optional, Tuple, Type
+from typing import Coroutine, Generator, Optional, Tuple, Type
 
-from ._compat import DeprecatedAwaitable, DeprecatedAwaitableList, _warn_deprecation
+from ._compat import DeprecatedAwaitableList, _warn_deprecation
 from ._eventloop import get_asynclib
 
 

--- a/src/anyio/_core/_testing.py
+++ b/src/anyio/_core/_testing.py
@@ -1,10 +1,10 @@
-from typing import Coroutine, Optional
+from typing import Coroutine, Iterable, Optional, Tuple, Type
 
-from ._compat import DeprecatedAwaitable, DeprecatedAwaitableList
+from ._compat import DeprecatedAwaitable, DeprecatedAwaitableList, _warn_deprecation
 from ._eventloop import get_asynclib
 
 
-class TaskInfo(DeprecatedAwaitable):
+class TaskInfo:
     """
     Represents an asynchronous task.
 
@@ -15,30 +15,38 @@ class TaskInfo(DeprecatedAwaitable):
     :ivar ~collections.abc.Coroutine coro: the coroutine object of the task
     """
 
-    __slots__ = 'id', 'parent_id', 'name', 'coro'
+    __slots__ = '_name', 'id', 'parent_id', 'name', 'coro'
 
     def __init__(self, id: int, parent_id: Optional[int], name: Optional[str], coro: Coroutine):
-        super().__init__(get_current_task)
+        func = get_current_task
+        self._name = f'{func.__module__}.{func.__qualname__}'
         self.id = id
         self.parent_id = parent_id
         self.name = name
         self.coro = coro
 
-    def __await__(self):
-        yield from super().__await__()
-        return self
-
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, TaskInfo):
             return self.id == other.id
 
         return NotImplemented
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.id)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'{self.__class__.__name__}(id={self.id!r}, name={self.name!r})'
+
+    def __await__(self) -> Iterable["TaskInfo"]:
+        _warn_deprecation(self)
+        if False:
+            yield
+
+    def __reduce__(self) -> Tuple[Type["TaskInfo"], Tuple[int, Optional[int], Optional[str], Coroutine]]:
+        return TaskInfo, (self.id, self.parent_id, self.name, self.coro)
+
+    def _unwrap(self) -> 'TaskInfo':
+        return self
 
 
 def get_current_task() -> TaskInfo:

--- a/src/anyio/_core/_typedattr.py
+++ b/src/anyio/_core/_typedattr.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Callable, Mapping, TypeVar, Union, overload
+from typing import Any, Callable, Mapping, TypeVar, Union, overload
 
 from ._exceptions import TypedAttributeLookupError
 
@@ -13,7 +13,7 @@ T_Default = TypeVar('T_Default')
 undefined = object()
 
 
-def typed_attribute():
+def typed_attribute() -> Any:
     """Return a unique object, used to mark typed attributes."""
     return object()
 
@@ -58,7 +58,7 @@ class TypedAttributeProvider:
         ...
 
     @final
-    def extra(self, attribute, default=undefined):
+    def extra(self, attribute: Any, default: object = undefined) -> object:
         """
         extra(attribute, default=undefined)
 

--- a/src/anyio/abc/_resources.py
+++ b/src/anyio/abc/_resources.py
@@ -1,6 +1,8 @@
 from abc import ABCMeta, abstractmethod
 from types import TracebackType
-from typing import Optional, Type
+from typing import Optional, Type, TypeVar
+
+T = TypeVar("T")
 
 
 class AsyncResource(metaclass=ABCMeta):
@@ -11,7 +13,7 @@ class AsyncResource(metaclass=ABCMeta):
     :meth:`aclose` on exit.
     """
 
-    async def __aenter__(self):
+    async def __aenter__(self: T) -> "T":
         return self
 
     async def __aexit__(self, exc_type: Optional[Type[BaseException]],

--- a/src/anyio/abc/_resources.py
+++ b/src/anyio/abc/_resources.py
@@ -13,7 +13,7 @@ class AsyncResource(metaclass=ABCMeta):
     :meth:`aclose` on exit.
     """
 
-    async def __aenter__(self: T) -> "T":
+    async def __aenter__(self: T) -> T:
         return self
 
     async def __aexit__(self, exc_type: Optional[Type[BaseException]],

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -4,7 +4,8 @@ from ipaddress import IPv4Address, IPv6Address
 from socket import AddressFamily, SocketType
 from types import TracebackType
 from typing import (
-    Any, AsyncContextManager, Callable, Collection, List, Optional, Tuple, Type, TypeVar, Union)
+    Any, AsyncContextManager, Callable, Collection, List, Mapping, Optional, Tuple, Type, TypeVar,
+    Union)
 
 from .._core._typedattr import TypedAttributeProvider, TypedAttributeSet, typed_attribute
 from ._streams import ByteStream, Listener, T_Stream, UnreliableObjectStream
@@ -44,7 +45,7 @@ class SocketAttribute(TypedAttributeSet):
 
 class _SocketProvider(TypedAttributeProvider):
     @property
-    def extra_attributes(self) -> dict:
+    def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         from .._core._sockets import convert_ipv6_sockaddr as convert
 
         attributes = {

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -2,8 +2,9 @@ from abc import abstractmethod
 from io import IOBase
 from ipaddress import IPv4Address, IPv6Address
 from socket import AddressFamily, SocketType
+from types import TracebackType
 from typing import (
-    Any, AsyncContextManager, Callable, Collection, List, Optional, Tuple, TypeVar, Union)
+    Any, AsyncContextManager, Callable, Collection, List, Optional, Tuple, Type, TypeVar, Union)
 
 from .._core._typedattr import TypedAttributeProvider, TypedAttributeSet, typed_attribute
 from ._streams import ByteStream, Listener, T_Stream, UnreliableObjectStream
@@ -17,11 +18,13 @@ T_Retval = TypeVar('T_Retval')
 
 
 class _NullAsyncContextManager:
-    async def __aenter__(self):
+    async def __aenter__(self) -> None:
         pass
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        pass
+    async def __aexit__(self, exc_type: Optional[Type[BaseException]],
+                        exc_val: Optional[BaseException],
+                        exc_tb: Optional[TracebackType]) -> Optional[bool]:
+        return None
 
 
 class SocketAttribute(TypedAttributeSet):
@@ -41,7 +44,7 @@ class SocketAttribute(TypedAttributeSet):
 
 class _SocketProvider(TypedAttributeProvider):
     @property
-    def extra_attributes(self):
+    def extra_attributes(self) -> dict:
         from .._core._sockets import convert_ipv6_sockaddr as convert
 
         attributes = {
@@ -50,7 +53,7 @@ class _SocketProvider(TypedAttributeProvider):
             SocketAttribute.raw_socket: lambda: self._raw_socket
         }
         try:
-            peername = convert(self._raw_socket.getpeername())
+            peername: Optional[Tuple[str, int]] = convert(self._raw_socket.getpeername())
         except OSError:
             peername = None
 
@@ -62,7 +65,8 @@ class _SocketProvider(TypedAttributeProvider):
         if self._raw_socket.family in (AddressFamily.AF_INET, AddressFamily.AF_INET6):
             attributes[SocketAttribute.local_port] = lambda: self._raw_socket.getsockname()[1]
             if peername is not None:
-                attributes[SocketAttribute.remote_port] = lambda: peername[1]
+                remote_port = peername[1]
+                attributes[SocketAttribute.remote_port] = lambda: remote_port
 
         return attributes
 

--- a/src/anyio/abc/_streams.py
+++ b/src/anyio/abc/_streams.py
@@ -21,7 +21,7 @@ class UnreliableObjectReceiveStream(Generic[T_Item], AsyncResource, TypedAttribu
     parameter.
     """
 
-    def __aiter__(self):
+    def __aiter__(self) -> "UnreliableObjectReceiveStream[T_Item]":
         return self
 
     async def __anext__(self) -> T_Item:

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -30,7 +30,8 @@ class TaskGroup(metaclass=ABCMeta):
 
     cancel_scope: 'CancelScope'
 
-    async def spawn(self, func: Callable[..., Coroutine], *args: object, name: Optional[str] = None) -> None:
+    async def spawn(self, func: Callable[..., Coroutine],
+                    *args: object, name: Optional[str] = None) -> None:
         """
         Start a new task in this task group.
 
@@ -48,7 +49,8 @@ class TaskGroup(metaclass=ABCMeta):
         self.start_soon(func, *args, name=name)
 
     @abstractmethod
-    def start_soon(self, func: Callable[..., Coroutine], *args: object, name: Optional[str] = None) -> None:
+    def start_soon(self, func: Callable[..., Coroutine],
+                   *args: object, name: Optional[str] = None) -> None:
         """
         Start a new task in this task group.
 
@@ -60,7 +62,8 @@ class TaskGroup(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    async def start(self, func: Callable[..., Coroutine], *args: object, name: Optional[str] = None) -> object:
+    async def start(self, func: Callable[..., Coroutine],
+                    *args: object, name: Optional[str] = None) -> object:
         """
         Start a new task and wait until it signals for readiness.
 

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -12,7 +12,7 @@ T_Retval = TypeVar('T_Retval')
 
 class TaskStatus(metaclass=ABCMeta):
     @abstractmethod
-    def started(self, value=None) -> None:
+    def started(self, value: object = None) -> None:
         """
         Signal that the task has started.
 
@@ -30,7 +30,7 @@ class TaskGroup(metaclass=ABCMeta):
 
     cancel_scope: 'CancelScope'
 
-    async def spawn(self, func: Callable[..., Coroutine], *args, name=None) -> None:
+    async def spawn(self, func: Callable[..., Coroutine], *args: object, name: Optional[str] = None) -> None:
         """
         Start a new task in this task group.
 
@@ -48,7 +48,7 @@ class TaskGroup(metaclass=ABCMeta):
         self.start_soon(func, *args, name=name)
 
     @abstractmethod
-    def start_soon(self, func: Callable[..., Coroutine], *args, name=None) -> None:
+    def start_soon(self, func: Callable[..., Coroutine], *args: object, name: Optional[str] = None) -> None:
         """
         Start a new task in this task group.
 
@@ -60,7 +60,7 @@ class TaskGroup(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    async def start(self, func: Callable[..., Coroutine], *args, name=None):
+    async def start(self, func: Callable[..., Coroutine], *args: object, name: Optional[str] = None) -> object:
         """
         Start a new task and wait until it signals for readiness.
 

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -31,7 +31,7 @@ class TaskGroup(metaclass=ABCMeta):
     cancel_scope: 'CancelScope'
 
     async def spawn(self, func: Callable[..., Coroutine],
-                    *args: object, name: Optional[str] = None) -> None:
+                    *args: object, name: object = None) -> None:
         """
         Start a new task in this task group.
 
@@ -50,7 +50,7 @@ class TaskGroup(metaclass=ABCMeta):
 
     @abstractmethod
     def start_soon(self, func: Callable[..., Coroutine],
-                   *args: object, name: Optional[str] = None) -> None:
+                   *args: object, name: object = None) -> None:
         """
         Start a new task in this task group.
 
@@ -63,7 +63,7 @@ class TaskGroup(metaclass=ABCMeta):
 
     @abstractmethod
     async def start(self, func: Callable[..., Coroutine],
-                    *args: object, name: Optional[str] = None) -> object:
+                    *args: object, name: object = None) -> object:
         """
         Start a new task and wait until it signals for readiness.
 

--- a/src/anyio/abc/_testing.py
+++ b/src/anyio/abc/_testing.py
@@ -14,7 +14,9 @@ class TestRunner(metaclass=ABCMeta):
     def __enter__(self) -> 'TestRunner':
         return self
 
-    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[types.TracebackType]) -> Optional[bool]:
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_val: Optional[BaseException],
+                 exc_tb: Optional[types.TracebackType]) -> Optional[bool]:
         self.close()
         return None
 
@@ -23,7 +25,8 @@ class TestRunner(metaclass=ABCMeta):
         """Close the event loop."""
 
     @abstractmethod
-    def call(self, func: Callable[..., Awaitable[_T]], *args: tuple, **kwargs: Dict[str, Any]) -> _T:
+    def call(self, func: Callable[..., Awaitable[_T]],
+             *args: tuple, **kwargs: Dict[str, Any]) -> _T:
         """
         Call the given function within the backend's event loop.
 

--- a/src/anyio/abc/_testing.py
+++ b/src/anyio/abc/_testing.py
@@ -1,5 +1,8 @@
+import types
 from abc import ABCMeta, abstractmethod
-from typing import Any, Awaitable, Callable, Dict
+from typing import Any, Awaitable, Callable, Dict, Optional, Type, TypeVar
+
+_T = TypeVar("_T")
 
 
 class TestRunner(metaclass=ABCMeta):
@@ -11,15 +14,16 @@ class TestRunner(metaclass=ABCMeta):
     def __enter__(self) -> 'TestRunner':
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[types.TracebackType]) -> Optional[bool]:
         self.close()
+        return None
 
     @abstractmethod
     def close(self) -> None:
         """Close the event loop."""
 
     @abstractmethod
-    def call(self, func: Callable[..., Awaitable], *args: tuple, **kwargs: Dict[str, Any]):
+    def call(self, func: Callable[..., Awaitable[_T]], *args: tuple, **kwargs: Dict[str, Any]) -> _T:
         """
         Call the given function within the backend's event loop.
 

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -190,7 +190,7 @@ class BlockingPortal:
             scope = None  # type: ignore[assignment]
 
     def _spawn_task_from_thread(self, func: Callable, args: tuple, kwargs: Dict[str, Any],
-                                name: Optional[str], future: Future) -> None:
+                                name: object, future: Future) -> None:
         """
         Spawn a new task using the given callable.
 
@@ -229,7 +229,7 @@ class BlockingPortal:
         return self.start_task_soon(func, *args).result()
 
     def spawn_task(self, func: Callable[..., Union[Coroutine[Any, Any, T_Retval], T_Retval]],
-                   *args: object, name: str = None) -> "Future[T_Retval]":
+                   *args: object, name: object = None) -> "Future[T_Retval]":
         """
         Start a task in the portal's task group.
 
@@ -251,7 +251,7 @@ class BlockingPortal:
         return self.start_task_soon(func, *args, name=name)
 
     def start_task_soon(self, func: Callable[..., Union[Coroutine[Any, Any, T_Retval], T_Retval]],
-                        *args: object, name: str = None) -> "Future[T_Retval]":
+                        *args: object, name: object = None) -> "Future[T_Retval]":
         """
         Start a task in the portal's task group.
 
@@ -275,7 +275,7 @@ class BlockingPortal:
         return f
 
     def start_task(self, func: Callable[..., Coroutine], *args: object,
-                   name: str = None) -> Tuple[Future, Any]:
+                   name: object = None) -> Tuple[Future, Any]:
         """
         Start a task in the portal's task group and wait until it signals for readiness.
 

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -5,7 +5,7 @@ from contextlib import AbstractContextManager, contextmanager
 from types import TracebackType
 from typing import (
     Any, AsyncContextManager, Callable, ContextManager, Coroutine, Dict, Generator, Iterable,
-    Optional, Tuple, Type, TypeVar, cast, overload)
+    Optional, Tuple, Type, TypeVar, Union, cast, overload)
 from warnings import warn
 
 from ._core import _eventloop
@@ -17,7 +17,7 @@ T_Retval = TypeVar('T_Retval')
 T_co = TypeVar('T_co')
 
 
-def run(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args) -> T_Retval:
+def run(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args: object) -> T_Retval:
     """
     Call a coroutine function from a worker thread.
 
@@ -34,13 +34,13 @@ def run(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args) -> T_Retval:
     return asynclib.run_async_from_thread(func, *args)
 
 
-def run_async_from_thread(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args) -> T_Retval:
+def run_async_from_thread(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args: object) -> T_Retval:
     warn('run_async_from_thread() has been deprecated, use anyio.from_thread.run() instead',
          DeprecationWarning)
     return run(func, *args)
 
 
-def run_sync(func: Callable[..., T_Retval], *args) -> T_Retval:
+def run_sync(func: Callable[..., T_Retval], *args: object) -> T_Retval:
     """
     Call a function in the event loop thread from a worker thread.
 
@@ -57,7 +57,7 @@ def run_sync(func: Callable[..., T_Retval], *args) -> T_Retval:
     return asynclib.run_sync_from_thread(func, *args)
 
 
-def run_sync_from_thread(func: Callable[..., T_Retval], *args) -> T_Retval:
+def run_sync_from_thread(func: Callable[..., T_Retval], *args: object) -> T_Retval:
     warn('run_sync_from_thread() has been deprecated, use anyio.from_thread.run_sync() instead',
          DeprecationWarning)
     return run_sync(func, *args)
@@ -74,7 +74,7 @@ class _BlockingAsyncContextManager(AbstractContextManager):
         self._async_cm = async_cm
         self._portal = portal
 
-    async def run_async_cm(self):
+    async def run_async_cm(self) -> Optional[bool]:
         try:
             self._exit_event = Event()
             value = await self._async_cm.__aenter__()
@@ -105,18 +105,18 @@ class _BlockingPortalTaskStatus(TaskStatus):
     def __init__(self, future: Future):
         self._future = future
 
-    def started(self, value=None) -> None:
+    def started(self, value: object = None) -> None:
         self._future.set_result(value)
 
 
 class BlockingPortal:
     """An object tied that lets external threads run code in an asynchronous event loop."""
 
-    def __new__(cls):
+    def __new__(cls) -> 'BlockingPortal':
         return get_asynclib().BlockingPortal()
 
-    def __init__(self):
-        self._event_loop_thread_id = threading.get_ident()
+    def __init__(self) -> None:
+        self._event_loop_thread_id: Optional[int] = threading.get_ident()
         self._stop_event = Event()
         self._task_group = create_task_group()
         self._cancelled_exc_class = get_cancelled_exc_class()
@@ -125,7 +125,9 @@ class BlockingPortal:
         await self._task_group.__aenter__()
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type: Optional[Type[BaseException]],
+                        exc_val: Optional[BaseException],
+                        exc_tb: Optional[TracebackType]) -> Optional[bool]:
         await self.stop()
         return await self._task_group.__aexit__(exc_type, exc_val, exc_tb)
 
@@ -157,7 +159,7 @@ class BlockingPortal:
 
     async def _call_func(self, func: Callable, args: tuple, kwargs: Dict[str, Any],
                          future: Future) -> None:
-        def callback(f: Future):
+        def callback(f: Future) -> None:
             if f.cancelled():
                 self.call(scope.cancel)
 
@@ -184,10 +186,10 @@ class BlockingPortal:
             if not future.cancelled():
                 future.set_result(retval)
         finally:
-            scope = None
+            del scope
 
     def _spawn_task_from_thread(self, func: Callable, args: tuple, kwargs: Dict[str, Any],
-                                name, future: Future) -> None:
+                                name: Optional[str], future: Future) -> None:
         """
         Spawn a new task using the given callable.
 
@@ -204,14 +206,14 @@ class BlockingPortal:
         raise NotImplementedError
 
     @overload
-    def call(self, func: Callable[..., Coroutine[Any, Any, T_Retval]], *args) -> T_Retval:
+    def call(self, func: Callable[..., Coroutine[Any, Any, T_Retval]], *args: object) -> T_Retval:
         ...
 
     @overload
-    def call(self, func: Callable[..., T_Retval], *args) -> T_Retval:
+    def call(self, func: Callable[..., T_Retval], *args: object) -> T_Retval:
         ...
 
-    def call(self, func, *args):
+    def call(self, func: Callable[..., Union[Coroutine[Any, Any, T_Retval], T_Retval]], *args: object) -> T_Retval:
         """
         Call the given function in the event loop thread.
 
@@ -224,7 +226,7 @@ class BlockingPortal:
         """
         return self.start_task_soon(func, *args).result()
 
-    def spawn_task(self, func: Callable[..., Coroutine], *args, name=None) -> Future:
+    def spawn_task(self, func: Callable[..., Union[Coroutine[Any, Any, T_Retval], T_Retval]], *args: object, name: str = None) -> "Future[T_Retval]":
         """
         Start a task in the portal's task group.
 
@@ -245,7 +247,7 @@ class BlockingPortal:
         warn('spawn_task() is deprecated -- use start_task_soon() instead', DeprecationWarning)
         return self.start_task_soon(func, *args, name=name)
 
-    def start_task_soon(self, func: Callable[..., Coroutine], *args, name=None) -> Future:
+    def start_task_soon(self, func: Callable[..., Union[Coroutine[Any, Any, T_Retval], T_Retval]], *args: object, name: str = None) -> "Future[T_Retval]":
         """
         Start a task in the portal's task group.
 
@@ -268,7 +270,7 @@ class BlockingPortal:
         self._spawn_task_from_thread(func, args, {}, name, f)
         return f
 
-    def start_task(self, func: Callable[..., Coroutine], *args, name=None) -> Tuple[Future, Any]:
+    def start_task(self, func: Callable[..., Coroutine], *args: object, name: str = None) -> Tuple[Future, Any]:
         """
         Start a task in the portal's task group and wait until it signals for readiness.
 
@@ -350,7 +352,7 @@ def start_blocking_portal(
         Usage as a context manager is now required.
 
     """
-    async def run_portal():
+    async def run_portal() -> None:
         async with BlockingPortal() as portal_:
             if future.set_running_or_notify_cancel():
                 future.set_result(portal_)

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -34,7 +34,8 @@ def run(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args: object) -> T_
     return asynclib.run_async_from_thread(func, *args)
 
 
-def run_async_from_thread(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args: object) -> T_Retval:
+def run_async_from_thread(func: Callable[..., Coroutine[Any, Any, T_Retval]],
+                          *args: object) -> T_Retval:
     warn('run_async_from_thread() has been deprecated, use anyio.from_thread.run() instead',
          DeprecationWarning)
     return run(func, *args)
@@ -213,7 +214,8 @@ class BlockingPortal:
     def call(self, func: Callable[..., T_Retval], *args: object) -> T_Retval:
         ...
 
-    def call(self, func: Callable[..., Union[Coroutine[Any, Any, T_Retval], T_Retval]], *args: object) -> T_Retval:
+    def call(self, func: Callable[..., Union[Coroutine[Any, Any, T_Retval], T_Retval]],
+             *args: object) -> T_Retval:
         """
         Call the given function in the event loop thread.
 
@@ -226,7 +228,8 @@ class BlockingPortal:
         """
         return self.start_task_soon(func, *args).result()
 
-    def spawn_task(self, func: Callable[..., Union[Coroutine[Any, Any, T_Retval], T_Retval]], *args: object, name: str = None) -> "Future[T_Retval]":
+    def spawn_task(self, func: Callable[..., Union[Coroutine[Any, Any, T_Retval], T_Retval]],
+                   *args: object, name: str = None) -> "Future[T_Retval]":
         """
         Start a task in the portal's task group.
 
@@ -247,7 +250,8 @@ class BlockingPortal:
         warn('spawn_task() is deprecated -- use start_task_soon() instead', DeprecationWarning)
         return self.start_task_soon(func, *args, name=name)
 
-    def start_task_soon(self, func: Callable[..., Union[Coroutine[Any, Any, T_Retval], T_Retval]], *args: object, name: str = None) -> "Future[T_Retval]":
+    def start_task_soon(self, func: Callable[..., Union[Coroutine[Any, Any, T_Retval], T_Retval]],
+                        *args: object, name: str = None) -> "Future[T_Retval]":
         """
         Start a task in the portal's task group.
 
@@ -270,7 +274,8 @@ class BlockingPortal:
         self._spawn_task_from_thread(func, args, {}, name, f)
         return f
 
-    def start_task(self, func: Callable[..., Coroutine], *args: object, name: str = None) -> Tuple[Future, Any]:
+    def start_task(self, func: Callable[..., Coroutine], *args: object,
+                   name: str = None) -> Tuple[Future, Any]:
         """
         Start a task in the portal's task group and wait until it signals for readiness.
 

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -186,7 +186,7 @@ class BlockingPortal:
             if not future.cancelled():
                 future.set_result(retval)
         finally:
-            scope = None
+            scope = None  # type: ignore[assignment]
 
     def _spawn_task_from_thread(self, func: Callable, args: tuple, kwargs: Dict[str, Any],
                                 name: Optional[str], future: Future) -> None:

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -186,7 +186,7 @@ class BlockingPortal:
             if not future.cancelled():
                 future.set_result(retval)
         finally:
-            del scope
+            scope = None
 
     def _spawn_task_from_thread(self, func: Callable, args: tuple, kwargs: Dict[str, Any],
                                 name: Optional[str], future: Future) -> None:

--- a/src/anyio/lowlevel.py
+++ b/src/anyio/lowlevel.py
@@ -62,7 +62,7 @@ _token_wrappers: Dict[Any, '_TokenWrapper'] = {}
 
 @dataclass(frozen=True)
 class _TokenWrapper:
-    __slots__ = ("_token", "__weakref__")
+    __slots__ = '_token', '__weakref__'
     _token: object
 
 

--- a/src/anyio/lowlevel.py
+++ b/src/anyio/lowlevel.py
@@ -1,6 +1,6 @@
 import enum
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, NewType, Set, TypeVar, Union, cast
+from typing import Any, Dict, Generic, Set, TypeVar, Union, cast
 from weakref import WeakKeyDictionary
 
 from ._core._eventloop import get_asynclib

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -16,7 +16,6 @@ else:
 
 if TYPE_CHECKING:
     from _pytest.config import Config
-    from _pytest.fixtures import FixtureDef
 
 _current_runner: Optional[TestRunner] = None
 

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -1,7 +1,7 @@
 import sys
 from contextlib import contextmanager
 from inspect import iscoroutinefunction
-from typing import Any, Dict, Iterator, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Tuple, cast
 
 import pytest
 import sniffio
@@ -14,10 +14,14 @@ if sys.version_info >= (3, 7):
 else:
     from async_generator import isasyncgenfunction
 
+if TYPE_CHECKING:
+    from _pytest.config import Config
+    from _pytest.fixtures import FixtureDef
+
 _current_runner: Optional[TestRunner] = None
 
 
-def extract_backend_and_options(backend) -> Tuple[str, Dict[str, Any]]:
+def extract_backend_and_options(backend: object) -> Tuple[str, Dict[str, Any]]:
     if isinstance(backend, str):
         return backend, {}
     elif isinstance(backend, tuple) and len(backend) == 2:
@@ -51,13 +55,13 @@ def get_runner(backend_name: str, backend_options: Dict[str, Any]) -> Iterator[T
             sniffio.current_async_library_cvar.reset(token)
 
 
-def pytest_configure(config):
+def pytest_configure(config: "Config") -> None:
     config.addinivalue_line('markers', 'anyio: mark the (coroutine function) test to be run '
                                        'asynchronously via anyio.')
 
 
-def pytest_fixture_setup(fixturedef, request):
-    def wrapper(*args, anyio_backend, **kwargs):
+def pytest_fixture_setup(fixturedef: Any, request: Any) -> None:
+    def wrapper(*args, anyio_backend, **kwargs):  # type: ignore[no-untyped-def]
         backend_name, backend_options = extract_backend_and_options(anyio_backend)
         if has_backend_arg:
             kwargs['anyio_backend'] = anyio_backend
@@ -94,7 +98,7 @@ def pytest_fixture_setup(fixturedef, request):
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_pycollect_makeitem(collector, name, obj):
+def pytest_pycollect_makeitem(collector: Any, name: Any, obj: Any) -> None:
     if collector.istestfunction(obj, name):
         inner_func = obj.hypothesis.inner_test if hasattr(obj, 'hypothesis') else obj
         if iscoroutinefunction(inner_func):
@@ -105,8 +109,8 @@ def pytest_pycollect_makeitem(collector, name, obj):
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_pyfunc_call(pyfuncitem):
-    def run_with_hypothesis(**kwargs):
+def pytest_pyfunc_call(pyfuncitem: Any) -> Optional[bool]:
+    def run_with_hypothesis(**kwargs: Any) -> None:
         with get_runner(backend_name, backend_options) as runner:
             runner.call(original_func, **kwargs)
 
@@ -130,15 +134,16 @@ def pytest_pyfunc_call(pyfuncitem):
                 runner.call(pyfuncitem.obj, **testargs)
 
             return True
+    return None
 
 
 @pytest.fixture(params=get_all_backends())
-def anyio_backend(request):
+def anyio_backend(request: Any) -> Any:
     return request.param
 
 
 @pytest.fixture
-def anyio_backend_name(anyio_backend) -> str:
+def anyio_backend_name(anyio_backend: Any) -> str:
     if isinstance(anyio_backend, str):
         return anyio_backend
     else:
@@ -146,7 +151,7 @@ def anyio_backend_name(anyio_backend) -> str:
 
 
 @pytest.fixture
-def anyio_backend_options(anyio_backend) -> Dict[str, Any]:
+def anyio_backend_options(anyio_backend: Any) -> Dict[str, Any]:
     if isinstance(anyio_backend, str):
         return {}
     else:

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -133,6 +133,7 @@ def pytest_pyfunc_call(pyfuncitem: Any) -> Optional[bool]:
                 runner.call(pyfuncitem.obj, **testargs)
 
             return True
+
     return None
 
 

--- a/src/anyio/streams/buffered.py
+++ b/src/anyio/streams/buffered.py
@@ -25,8 +25,8 @@ class BufferedByteReceiveStream(ByteReceiveStream):
         return bytes(self._buffer)
 
     @property
-    def extra_attributes(self):
-        return self.receive_stream.extra_attributes
+    def extra_attributes(self) -> dict:
+        return self.receive_stream.extra_attributes  # type: ignore[return-value]
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
         if self._closed:

--- a/src/anyio/streams/buffered.py
+++ b/src/anyio/streams/buffered.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping
 
 from .. import ClosedResourceError, DelimiterNotFound, EndOfStream, IncompleteRead
 from ..abc import AnyByteReceiveStream, ByteReceiveStream
@@ -25,7 +26,7 @@ class BufferedByteReceiveStream(ByteReceiveStream):
         return bytes(self._buffer)
 
     @property
-    def extra_attributes(self) -> dict:
+    def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         return self.receive_stream.extra_attributes  # type: ignore[return-value]
 
     async def receive(self, max_bytes: int = 65536) -> bytes:

--- a/src/anyio/streams/file.py
+++ b/src/anyio/streams/file.py
@@ -25,8 +25,8 @@ class _BaseFileStream:
         await to_thread.run_sync(self._file.close)
 
     @property
-    def extra_attributes(self):
-        attributes = {
+    def extra_attributes(self) -> dict:
+        attributes: dict = {
             FileStreamAttribute.file: lambda: self._file,
         }
 

--- a/src/anyio/streams/file.py
+++ b/src/anyio/streams/file.py
@@ -1,6 +1,6 @@
 from io import SEEK_SET, UnsupportedOperation
 from pathlib import Path
-from typing import BinaryIO, Union, cast
+from typing import Any, BinaryIO, Callable, Dict, Mapping, Union, cast
 
 from .. import (
     BrokenResourceError, ClosedResourceError, EndOfStream, TypedAttributeSet, to_thread,
@@ -25,8 +25,8 @@ class _BaseFileStream:
         await to_thread.run_sync(self._file.close)
 
     @property
-    def extra_attributes(self) -> dict:
-        attributes: dict = {
+    def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
+        attributes: Dict[Any, Callable[[], Any]] = {
             FileStreamAttribute.file: lambda: self._file,
         }
 

--- a/src/anyio/streams/memory.py
+++ b/src/anyio/streams/memory.py
@@ -41,7 +41,7 @@ class MemoryObjectReceiveStream(Generic[T_Item], ObjectReceiveStream[T_Item]):
     _state: MemoryObjectStreamState[T_Item]
     _closed: bool = field(init=False, default=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self._state.open_receive_channels += 1
 
     def receive_nowait(self) -> T_Item:
@@ -135,7 +135,7 @@ class MemoryObjectSendStream(Generic[T_Item], ObjectSendStream[T_Item]):
     _state: MemoryObjectStreamState[T_Item]
     _closed: bool = field(init=False, default=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self._state.open_send_channels += 1
 
     def send_nowait(self, item: T_Item) -> DeprecatedAwaitable:

--- a/src/anyio/streams/stapled.py
+++ b/src/anyio/streams/stapled.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, Optional, Sequence, TypeVar
+from typing import Any, Callable, Generic, List, Optional, Sequence, TypeVar
 
 from ..abc import (
     ByteReceiveStream, ByteSendStream, ByteStream, Listener, ObjectReceiveStream, ObjectSendStream,
@@ -38,8 +38,8 @@ class StapledByteStream(ByteStream):
         await self.receive_stream.aclose()
 
     @property
-    def extra_attributes(self):
-        return dict(**self.send_stream.extra_attributes, **self.receive_stream.extra_attributes)
+    def extra_attributes(self) -> dict:
+        return {**self.send_stream.extra_attributes, **self.receive_stream.extra_attributes}
 
 
 @dataclass(eq=False)
@@ -71,8 +71,8 @@ class StapledObjectStream(Generic[T_Item], ObjectStream[T_Item]):
         await self.receive_stream.aclose()
 
     @property
-    def extra_attributes(self):
-        return dict(**self.send_stream.extra_attributes, **self.receive_stream.extra_attributes)
+    def extra_attributes(self) -> dict:
+        return {**self.send_stream.extra_attributes, **self.receive_stream.extra_attributes}
 
 
 @dataclass(eq=False)
@@ -92,12 +92,12 @@ class MultiListener(Generic[T_Stream], Listener[T_Stream]):
 
     listeners: Sequence[Listener[T_Stream]]
 
-    def __post_init__(self):
-        listeners = []
+    def __post_init__(self) -> None:
+        listeners: List[Listener[T_Stream]] = []
         for listener in self.listeners:
             if isinstance(listener, MultiListener):
                 listeners.extend(listener.listeners)
-                del listener.listeners[:]
+                del listener.listeners[:]  # type: ignore[attr-defined]
             else:
                 listeners.append(listener)
 
@@ -116,8 +116,8 @@ class MultiListener(Generic[T_Stream], Listener[T_Stream]):
             await listener.aclose()
 
     @property
-    def extra_attributes(self):
-        attributes = {}
+    def extra_attributes(self) -> dict:
+        attributes: dict = {}
         for listener in self.listeners:
             attributes.update(listener.extra_attributes)
 

--- a/src/anyio/streams/stapled.py
+++ b/src/anyio/streams/stapled.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, List, Optional, Sequence, TypeVar
+from typing import Any, Callable, Generic, List, Mapping, Optional, Sequence, TypeVar
 
 from ..abc import (
     ByteReceiveStream, ByteSendStream, ByteStream, Listener, ObjectReceiveStream, ObjectSendStream,
@@ -38,7 +38,7 @@ class StapledByteStream(ByteStream):
         await self.receive_stream.aclose()
 
     @property
-    def extra_attributes(self) -> dict:
+    def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         return {**self.send_stream.extra_attributes, **self.receive_stream.extra_attributes}
 
 
@@ -71,7 +71,7 @@ class StapledObjectStream(Generic[T_Item], ObjectStream[T_Item]):
         await self.receive_stream.aclose()
 
     @property
-    def extra_attributes(self) -> dict:
+    def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         return {**self.send_stream.extra_attributes, **self.receive_stream.extra_attributes}
 
 
@@ -116,7 +116,7 @@ class MultiListener(Generic[T_Stream], Listener[T_Stream]):
             await listener.aclose()
 
     @property
-    def extra_attributes(self) -> dict:
+    def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         attributes: dict = {}
         for listener in self.listeners:
             attributes.update(listener.extra_attributes)

--- a/src/anyio/streams/text.py
+++ b/src/anyio/streams/text.py
@@ -1,6 +1,6 @@
 import codecs
 from dataclasses import InitVar, dataclass, field
-from typing import Callable, Tuple
+from typing import Any, Callable, Mapping, Tuple
 
 from ..abc import (
     AnyByteReceiveStream, AnyByteSendStream, AnyByteStream, ObjectReceiveStream, ObjectSendStream,
@@ -45,7 +45,7 @@ class TextReceiveStream(ObjectReceiveStream[str]):
         self._decoder.reset()
 
     @property
-    def extra_attributes(self) -> dict:
+    def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         return self.transport_stream.extra_attributes  # type: ignore[return-value]
 
 
@@ -79,7 +79,7 @@ class TextSendStream(ObjectSendStream[str]):
         await self.transport_stream.aclose()
 
     @property
-    def extra_attributes(self) -> dict:
+    def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         return self.transport_stream.extra_attributes  # type: ignore[return-value]
 
 
@@ -126,5 +126,5 @@ class TextStream(ObjectStream[str]):
         await self._receive_stream.aclose()
 
     @property
-    def extra_attributes(self) -> dict:
+    def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         return {**self._send_stream.extra_attributes, **self._receive_stream.extra_attributes}

--- a/src/anyio/streams/text.py
+++ b/src/anyio/streams/text.py
@@ -29,7 +29,7 @@ class TextReceiveStream(ObjectReceiveStream[str]):
     errors: InitVar[str] = 'strict'
     _decoder: codecs.IncrementalDecoder = field(init=False)
 
-    def __post_init__(self, encoding, errors):
+    def __post_init__(self, encoding: str, errors: str) -> None:
         decoder_class = codecs.getincrementaldecoder(encoding)
         self._decoder = decoder_class(errors=errors)
 
@@ -45,8 +45,8 @@ class TextReceiveStream(ObjectReceiveStream[str]):
         self._decoder.reset()
 
     @property
-    def extra_attributes(self):
-        return self.transport_stream.extra_attributes
+    def extra_attributes(self) -> dict:
+        return self.transport_stream.extra_attributes  # type: ignore[return-value]
 
 
 @dataclass(eq=False)
@@ -68,8 +68,8 @@ class TextSendStream(ObjectSendStream[str]):
     errors: str = 'strict'
     _encoder: Callable[..., Tuple[bytes, int]] = field(init=False)
 
-    def __post_init__(self, encoding):
-        self._encoder = codecs.getencoder(encoding)
+    def __post_init__(self, encoding: str) -> None:
+        self._encoder = codecs.getencoder(encoding)  # type: ignore[assignment]
 
     async def send(self, item: str) -> None:
         encoded = self._encoder(item, self.errors)[0]
@@ -79,8 +79,8 @@ class TextSendStream(ObjectSendStream[str]):
         await self.transport_stream.aclose()
 
     @property
-    def extra_attributes(self):
-        return self.transport_stream.extra_attributes
+    def extra_attributes(self) -> dict:
+        return self.transport_stream.extra_attributes  # type: ignore[return-value]
 
 
 @dataclass(eq=False)
@@ -107,7 +107,7 @@ class TextStream(ObjectStream[str]):
     _receive_stream: TextReceiveStream = field(init=False)
     _send_stream: TextSendStream = field(init=False)
 
-    def __post_init__(self, encoding, errors):
+    def __post_init__(self, encoding: str, errors: str) -> None:
         self._receive_stream = TextReceiveStream(self.transport_stream, encoding=encoding,
                                                  errors=errors)
         self._send_stream = TextSendStream(self.transport_stream, encoding=encoding, errors=errors)
@@ -126,5 +126,5 @@ class TextStream(ObjectStream[str]):
         await self._receive_stream.aclose()
 
     @property
-    def extra_attributes(self):
-        return dict(**self.send_stream.extra_attributes, **self.receive_stream.extra_attributes)
+    def extra_attributes(self) -> dict:
+        return {**self._send_stream.extra_attributes, **self._receive_stream.extra_attributes}

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -94,7 +94,7 @@ class TLSStream(ByteStream):
         await wrapper._call_sslobject_method(ssl_object.do_handshake)
         return wrapper
 
-    async def _call_sslobject_method(self, func: Callable[..., T_Retval], *args) -> T_Retval:
+    async def _call_sslobject_method(self, func: Callable[..., T_Retval], *args: object) -> T_Retval:
         while True:
             try:
                 result = func(*args)
@@ -168,7 +168,7 @@ class TLSStream(ByteStream):
         raise NotImplementedError('send_eof() has not yet been implemented for TLS streams')
 
     @property
-    def extra_attributes(self):
+    def extra_attributes(self) -> dict:
         return {
             **self.transport_stream.extra_attributes,
             TLSAttribute.alpn_protocol: self._ssl_object.selected_alpn_protocol,
@@ -236,7 +236,7 @@ class TLSListener(Listener[TLSStream]):
     async def serve(self, handler: Callable[[TLSStream], Any],
                     task_group: Optional[TaskGroup] = None) -> None:
         @wraps(handler)
-        async def handler_wrapper(stream: AnyByteStream):
+        async def handler_wrapper(stream: AnyByteStream) -> None:
             from .. import fail_after
             try:
                 with fail_after(self.handshake_timeout):
@@ -254,7 +254,7 @@ class TLSListener(Listener[TLSStream]):
         await self.listener.aclose()
 
     @property
-    def extra_attributes(self):
+    def extra_attributes(self) -> dict:
         return {
             TLSAttribute.standard_compatible: lambda: self.standard_compatible,
         }

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -94,7 +94,9 @@ class TLSStream(ByteStream):
         await wrapper._call_sslobject_method(ssl_object.do_handshake)
         return wrapper
 
-    async def _call_sslobject_method(self, func: Callable[..., T_Retval], *args: object) -> T_Retval:
+    async def _call_sslobject_method(
+        self, func: Callable[..., T_Retval], *args: object
+    ) -> T_Retval:
         while True:
             try:
                 result = func(*args)

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -3,7 +3,7 @@ import re
 import ssl
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, TypeVar, Union
 
 from .. import BrokenResourceError, EndOfStream, aclose_forcefully, get_cancelled_exc_class
 from .._core._typedattr import TypedAttributeSet, typed_attribute
@@ -170,7 +170,7 @@ class TLSStream(ByteStream):
         raise NotImplementedError('send_eof() has not yet been implemented for TLS streams')
 
     @property
-    def extra_attributes(self) -> dict:
+    def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         return {
             **self.transport_stream.extra_attributes,
             TLSAttribute.alpn_protocol: self._ssl_object.selected_alpn_protocol,
@@ -256,7 +256,7 @@ class TLSListener(Listener[TLSStream]):
         await self.listener.aclose()
 
     @property
-    def extra_attributes(self) -> dict:
+    def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         return {
             TLSAttribute.standard_compatible: lambda: self.standard_compatible,
         }

--- a/src/anyio/to_process.py
+++ b/src/anyio/to_process.py
@@ -43,7 +43,7 @@ async def run_sync(
     :return: an awaitable that yields the return value of the function.
 
     """
-    async def send_raw_command(pickled_cmd: bytes) -> T_Retval:
+    async def send_raw_command(pickled_cmd: bytes) -> object:
         try:
             await stdin.send(pickled_cmd)
             response = await buffered.receive_until(b'\n', 50)
@@ -145,7 +145,7 @@ async def run_sync(
 
         with CancelScope(shield=not cancellable):
             try:
-                return await send_raw_command(request)
+                return cast(T_Retval, await send_raw_command(request))
             finally:
                 if process in workers:
                     idle_workers.append((process, current_time()))

--- a/src/anyio/to_process.py
+++ b/src/anyio/to_process.py
@@ -26,7 +26,7 @@ _default_process_limiter: RunVar[CapacityLimiter] = RunVar('_default_process_lim
 
 
 async def run_sync(
-        func: Callable[..., T_Retval], *args, cancellable: bool = False,
+        func: Callable[..., T_Retval], *args: object, cancellable: bool = False,
         limiter: Optional[CapacityLimiter] = None) -> T_Retval:
     """
     Call the given function with the given arguments in a worker process.
@@ -43,7 +43,7 @@ async def run_sync(
     :return: an awaitable that yields the return value of the function.
 
     """
-    async def send_raw_command(pickled_cmd: bytes):
+    async def send_raw_command(pickled_cmd: bytes) -> T_Retval:
         try:
             await stdin.send(pickled_cmd)
             response = await buffered.receive_until(b'\n', 50)

--- a/src/anyio/to_thread.py
+++ b/src/anyio/to_thread.py
@@ -30,7 +30,7 @@ async def run_sync(
 
 
 async def run_sync_in_worker_thread(
-    func: Callable[..., T_Retval], *args: object, cancellable: bool = False,
+        func: Callable[..., T_Retval], *args: object, cancellable: bool = False,
         limiter: Optional[CapacityLimiter] = None) -> T_Retval:
     warn('run_sync_in_worker_thread() has been deprecated, use anyio.to_thread.run_sync() instead',
          DeprecationWarning)

--- a/src/anyio/to_thread.py
+++ b/src/anyio/to_thread.py
@@ -8,7 +8,7 @@ T_Retval = TypeVar('T_Retval')
 
 
 async def run_sync(
-        func: Callable[..., T_Retval], *args, cancellable: bool = False,
+        func: Callable[..., T_Retval], *args: object, cancellable: bool = False,
         limiter: Optional[CapacityLimiter] = None) -> T_Retval:
     """
     Call the given function with the given arguments in a worker thread.
@@ -30,7 +30,7 @@ async def run_sync(
 
 
 async def run_sync_in_worker_thread(
-        func: Callable[..., T_Retval], *args, cancellable: bool = False,
+    func: Callable[..., T_Retval], *args: object, cancellable: bool = False,
         limiter: Optional[CapacityLimiter] = None) -> T_Retval:
     warn('run_sync_in_worker_thread() has been deprecated, use anyio.to_thread.run_sync() instead',
          DeprecationWarning)

--- a/tests/streams/test_text.py
+++ b/tests/streams/test_text.py
@@ -55,3 +55,4 @@ async def test_bidirectional_stream():
 
     await send_stream.send(b'\xc3\xa6\xc3\xb8')
     assert await text_stream.receive() == 'æø'
+    assert text_stream.extra_attributes == {}

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -35,6 +35,10 @@ class TestMaybeAsync:
         tasks = await maybe_async(get_running_tasks())
         assert type(tasks) is list
 
+    async def test_get_current_task(self):
+        task = await maybe_async(get_current_task())
+        assert type(task) is TaskInfo
+
 
 async def test_maybe_async_cm():
     async with maybe_async_cm(CancelScope()):

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -29,6 +29,25 @@ def test_main_task_name(anyio_backend_name, anyio_backend_options):
             loop.close()
 
 
+@pytest.mark.parametrize(
+    "name_input,expected",
+    [
+        (None, 'test_debugging.test_non_main_task_name.<locals>.non_main'),
+        (b'name', "b'name'"),
+        ("name", "name"),
+        ("", ""),
+    ],
+)
+async def test_non_main_task_name(name_input, expected):
+    async def non_main(*, task_status):
+        task_status.started(anyio.get_current_task().name)
+
+    async with anyio.create_task_group() as tg:
+        name = await tg.start(non_main, name=name_input)
+
+    assert name == expected
+
+
 async def test_get_running_tasks():
     async def inspect():
         await wait_all_tasks_blocked()


### PR DESCRIPTION
disallow untyped defs and fix runtime problems discovered by typing all defs:

* `TextStream.extra_attributes` no longer crashes with an attribute error
* `await maybe_async(current_task())` no longer returns None
* fix warning message to refer to `anyio.maybe_async`
* `pickle.dumps(get_current_task())` now correctly raises a TypeError (or similar on pypy) rather than pickling to None
* task `name`s are converted to `str` on the asyncio back-end

also type level errors:

* various types, such as `anyio.Lock()` that were missing a constructor type now have one, see https://github.com/python/mypy/issues/5943#issuecomment-516075196
* `anyio._backend._asyncio.run` takes a coroutine factory and returns the coroutine result - rather than any callable
* `await anyio.Event().wait()` returns `None` at runtime, rather than `bool`. Updated type annotations to reflect this
* `anyio.lowlevel.RunVar().get` type annotation was updated to return either the default value or the contained type