### PR TITLE
Support keyword arguments in callbacks

### DIFF
--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -1,4 +1,5 @@
 import threading
+from functools import partial
 from asyncio import iscoroutine
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import AbstractContextManager, contextmanager
@@ -17,7 +18,7 @@ T_Retval = TypeVar('T_Retval')
 T_co = TypeVar('T_co')
 
 
-def run(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args) -> T_Retval:
+def run(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args, **kwargs) -> T_Retval:
     """
     Call a coroutine function from a worker thread.
 
@@ -31,6 +32,7 @@ def run(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args) -> T_Retval:
     except AttributeError:
         raise RuntimeError('This function can only be run from an AnyIO worker thread')
 
+    func_kwargs = partial(func, **kwargs)
     return asynclib.run_async_from_thread(func, *args)
 
 
@@ -40,7 +42,7 @@ def run_async_from_thread(func: Callable[..., Coroutine[Any, Any, T_Retval]], *a
     return run(func, *args)
 
 
-def run_sync(func: Callable[..., T_Retval], *args) -> T_Retval:
+def run_sync(func: Callable[..., T_Retval], *args, **kwargs) -> T_Retval:
     """
     Call a function in the event loop thread from a worker thread.
 
@@ -54,6 +56,7 @@ def run_sync(func: Callable[..., T_Retval], *args) -> T_Retval:
     except AttributeError:
         raise RuntimeError('This function can only be run from an AnyIO worker thread')
 
+    func_kwargs = partial(func, **kwargs)
     return asynclib.run_sync_from_thread(func, *args)
 
 

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -33,7 +33,7 @@ def run(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args, **kwargs) -> 
         raise RuntimeError('This function can only be run from an AnyIO worker thread')
 
     func_kwargs = partial(func, **kwargs)
-    return asynclib.run_async_from_thread(func, *args)
+    return asynclib.run_async_from_thread(func_kwargs, *args)
 
 
 def run_async_from_thread(func: Callable[..., Coroutine[Any, Any, T_Retval]], *args) -> T_Retval:
@@ -57,7 +57,7 @@ def run_sync(func: Callable[..., T_Retval], *args, **kwargs) -> T_Retval:
         raise RuntimeError('This function can only be run from an AnyIO worker thread')
 
     func_kwargs = partial(func, **kwargs)
-    return asynclib.run_sync_from_thread(func, *args)
+    return asynclib.run_sync_from_thread(func_kwargs, *args)
 
 
 def run_sync_from_thread(func: Callable[..., T_Retval], *args) -> T_Retval:

--- a/src/anyio/to_thread.py
+++ b/src/anyio/to_thread.py
@@ -1,4 +1,5 @@
 from typing import Callable, Optional, TypeVar
+from functool import partial
 from warnings import warn
 
 from ._core._eventloop import get_asynclib
@@ -9,7 +10,7 @@ T_Retval = TypeVar('T_Retval')
 
 async def run_sync(
         func: Callable[..., T_Retval], *args, cancellable: bool = False,
-        limiter: Optional[CapacityLimiter] = None) -> T_Retval:
+        limiter: Optional[CapacityLimiter] = None, **kwargs) -> T_Retval:
     """
     Call the given function with the given arguments in a worker thread.
 
@@ -25,7 +26,8 @@ async def run_sync(
     :return: an awaitable that yields the return value of the function.
 
     """
-    return await get_asynclib().run_sync_in_worker_thread(func, *args, cancellable=cancellable,
+    func_kwargs = partial(func, **kwargs)
+    return await get_asynclib().run_sync_in_worker_thread(func_kwargs, *args, cancellable=cancellable,
                                                           limiter=limiter)
 
 

--- a/src/anyio/to_thread.py
+++ b/src/anyio/to_thread.py
@@ -1,5 +1,5 @@
 from typing import Callable, Optional, TypeVar
-from functool import partial
+from functools import partial
 from warnings import warn
 
 from ._core._eventloop import get_asynclib


### PR DESCRIPTION
This is a fix for https://github.com/agronholm/anyio/issues/291.

The following functions accept and supply `*args` and `**kwargs` to callbacks:
 - `anyio.to_thread.run_sync()`
 - `anyio.to_process.run_sync()`
 - `anyio.from_thread.run_sync()`
 - `anyio.from_thread.run()`