### PR TITLE
Add task_status type to docs

### DIFF
--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -51,13 +51,14 @@ and handle it.
 This can be done with :meth:`TaskGroup.start() <.abc.TaskGroup.start>`::
 
     from anyio import TASK_STATUS_IGNORED, create_task_group, connect_tcp, create_tcp_listener, run
+    from anyio.abc import TaskStatus
 
 
     async def handler(stream):
         ...
 
 
-    async def start_some_service(port: int, *, task_status=TASK_STATUS_IGNORED):
+    async def start_some_service(port: int, *, task_status: TaskStatus = TASK_STATUS_IGNORED):
         async with await create_tcp_listener(local_host='127.0.0.1', local_port=port) as listener:
             task_status.started()
             await listener.serve(handler)


### PR DESCRIPTION
This type doesn't seem to be documented other than https://anyio.readthedocs.io/en/stable/api.html?highlight=taskstatus#anyio.abc.TaskStatus.  The `port` argument of `start_some_service` is typed but `task_status` is not.  