### PR TITLE
type annotate the tests (using monkeytype and manual fixes)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,8 @@ author = 'Alex Grönholm'
 copyright = '2018, ' + author
 
 v = pkg_resources.get_distribution('anyio').parsed_version
-version = v.base_version
-release = v.public
+version = v.base_version  # type: ignore[attr-defined]
+release = v.public  # type: ignore[attr-defined]
 
 language = None
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,13 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed the type annotation of ``open_signal_receiver()`` as a synchronous context manager
+- Fixed the type annotations of ``AsyncFile.__aiter__``, ``readline``, ``write` to also accept/return ``str``
+  and also fixed ``AsyncFile.writelines`` to take an ``Iterable[str|bytes]`` rather than ``bytes``
+- Fixed the type annotation of ``DeprecatedAwaitable(|List|Float).__await__`` to match the ``typing.Awaitable`` protocol
+
 **3.1.0**
 
 - Added ``env`` and ``cwd`` keyword arguments to ``run_process()`` and ``open_process``.

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,8 +6,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 **UNRELEASED**
 
 - Fixed the type annotation of ``open_signal_receiver()`` as a synchronous context manager
-- Fixed the type annotations of ``AsyncFile.__aiter__``, ``readline``, ``write` to also accept/return ``str``
-  and also fixed ``AsyncFile.writelines`` to take an ``Iterable[str|bytes]`` rather than ``bytes``
 - Fixed the type annotation of ``DeprecatedAwaitable(|List|Float).__await__`` to match the ``typing.Awaitable`` protocol
 
 **3.1.0**

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,3 @@ disallow_any_generics = false
 warn_return_any = false
 disallow_untyped_decorators = false
 disallow_subclassing_any = false
-
-[mypy-tests.*]
-disallow_untyped_defs = false
-disallow_untyped_calls = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,3 +65,7 @@ disallow_any_generics = false
 warn_return_any = false
 disallow_untyped_decorators = false
 disallow_subclassing_any = false
+
+[mypy-tests.*]
+disallow_untyped_defs = false
+disallow_untyped_calls = false

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1748,7 +1748,7 @@ def current_default_thread_limiter() -> CapacityLimiter:
 # Operating system signals
 #
 
-class _SignalReceiver(DeprecatedAsyncContextManager):
+class _SignalReceiver(DeprecatedAsyncContextManager["_SignalReceiver"]):
     def __init__(self, signals: Tuple[int, ...]):
         self._signals = signals
         self._loop = get_running_loop()

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -683,7 +683,7 @@ def current_default_thread_limiter() -> CapacityLimiter:
 # Signal handling
 #
 
-class _SignalReceiver(DeprecatedAsyncContextManager):
+class _SignalReceiver(DeprecatedAsyncContextManager[T]):
     def __init__(self, cm: ContextManager[T]):
         self._cm = cm
 

--- a/src/anyio/_core/_compat.py
+++ b/src/anyio/_core/_compat.py
@@ -2,8 +2,8 @@ from abc import ABCMeta, abstractmethod
 from contextlib import AbstractContextManager
 from types import TracebackType
 from typing import (
-    TYPE_CHECKING, AsyncContextManager, Callable, ContextManager, Generic, Iterable, List,
-    Optional, Tuple, Type, TypeVar, Union, overload)
+    TYPE_CHECKING, AsyncContextManager, Callable, ContextManager, Generator, Generic, Iterable,
+    List, Optional, Tuple, Type, TypeVar, Union, overload)
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -96,7 +96,7 @@ class DeprecatedAwaitable:
     def __init__(self, func: Callable[..., 'DeprecatedAwaitable']):
         self._name = f'{func.__module__}.{func.__qualname__}'
 
-    def __await__(self) -> Iterable[None]:
+    def __await__(self) -> Generator[None, None, None]:
         _warn_deprecation(self)
         if False:
             yield
@@ -117,7 +117,7 @@ class DeprecatedAwaitableFloat(float):
     def __init__(self, x: float, func: Callable[..., 'DeprecatedAwaitableFloat']):
         self._name = f'{func.__module__}.{func.__qualname__}'
 
-    def __await__(self) -> Iterable[float]:
+    def __await__(self) -> Generator[None, None, float]:
         _warn_deprecation(self)
         if False:
             yield
@@ -132,11 +132,12 @@ class DeprecatedAwaitableFloat(float):
 
 
 class DeprecatedAwaitableList(List[T]):
-    def __init__(self, *args: T, func: Callable[..., 'DeprecatedAwaitableList']):
-        super().__init__(*args)
+    def __init__(self, iterable: Iterable[T] = (), *,
+                 func: Callable[..., 'DeprecatedAwaitableList']):
+        super().__init__(iterable)
         self._name = f'{func.__module__}.{func.__qualname__}'
 
-    def __await__(self) -> Iterable[List[T]]:
+    def __await__(self) -> Generator[None, None, List[T]]:
         _warn_deprecation(self)
         if False:
             yield

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -1,6 +1,6 @@
 import os
 from os import PathLike
-from typing import Any, AsyncIterator, Callable, Generic, Optional, TypeVar, Union
+from typing import Any, AsyncIterator, Callable, Generic, Iterable, List, Optional, TypeVar, Union
 
 from .. import to_thread
 from ..abc import AsyncResource
@@ -51,7 +51,7 @@ class AsyncFile(AsyncResource, Generic[T_Fp]):
         """The wrapped file object."""
         return self._fp
 
-    async def __aiter__(self) -> AsyncIterator[bytes]:
+    async def __aiter__(self) -> AsyncIterator[Union[bytes, str]]:
         while True:
             line = await self.readline()
             if line:
@@ -68,10 +68,10 @@ class AsyncFile(AsyncResource, Generic[T_Fp]):
     async def read1(self, size: int = -1) -> Union[bytes, str]:
         return await to_thread.run_sync(self._fp.read1, size)
 
-    async def readline(self) -> bytes:
+    async def readline(self) -> Union[bytes, str]:
         return await to_thread.run_sync(self._fp.readline)
 
-    async def readlines(self) -> bytes:
+    async def readlines(self) -> List[Union[bytes, str]]:
         return await to_thread.run_sync(self._fp.readlines)
 
     async def readinto(self, b: Union[bytes, memoryview]) -> bytes:
@@ -80,10 +80,10 @@ class AsyncFile(AsyncResource, Generic[T_Fp]):
     async def readinto1(self, b: Union[bytes, memoryview]) -> bytes:
         return await to_thread.run_sync(self._fp.readinto1, b)
 
-    async def write(self, b: bytes) -> None:
+    async def write(self, b: Union[bytes, str]) -> None:
         return await to_thread.run_sync(self._fp.write, b)
 
-    async def writelines(self, lines: bytes) -> None:
+    async def writelines(self, lines: Iterable[Union[bytes, str]]) -> None:
         return await to_thread.run_sync(self._fp.writelines, lines)
 
     async def truncate(self, size: Optional[int] = None) -> int:

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -1,6 +1,6 @@
 import os
 from os import PathLike
-from typing import Any, AsyncIterator, Callable, Generic, Iterable, List, Optional, TypeVar, Union
+from typing import Any, AsyncIterator, Callable, Generic, Optional, TypeVar, Union
 
 from .. import to_thread
 from ..abc import AsyncResource
@@ -51,7 +51,7 @@ class AsyncFile(AsyncResource, Generic[T_Fp]):
         """The wrapped file object."""
         return self._fp
 
-    async def __aiter__(self) -> AsyncIterator[Union[bytes, str]]:
+    async def __aiter__(self) -> AsyncIterator[bytes]:
         while True:
             line = await self.readline()
             if line:
@@ -68,10 +68,10 @@ class AsyncFile(AsyncResource, Generic[T_Fp]):
     async def read1(self, size: int = -1) -> Union[bytes, str]:
         return await to_thread.run_sync(self._fp.read1, size)
 
-    async def readline(self) -> Union[bytes, str]:
+    async def readline(self) -> bytes:
         return await to_thread.run_sync(self._fp.readline)
 
-    async def readlines(self) -> List[Union[bytes, str]]:
+    async def readlines(self) -> bytes:
         return await to_thread.run_sync(self._fp.readlines)
 
     async def readinto(self, b: Union[bytes, memoryview]) -> bytes:
@@ -80,10 +80,10 @@ class AsyncFile(AsyncResource, Generic[T_Fp]):
     async def readinto1(self, b: Union[bytes, memoryview]) -> bytes:
         return await to_thread.run_sync(self._fp.readinto1, b)
 
-    async def write(self, b: Union[bytes, str]) -> None:
+    async def write(self, b: bytes) -> None:
         return await to_thread.run_sync(self._fp.write, b)
 
-    async def writelines(self, lines: Iterable[Union[bytes, str]]) -> None:
+    async def writelines(self, lines: bytes) -> None:
         return await to_thread.run_sync(self._fp.writelines, lines)
 
     async def truncate(self, size: Optional[int] = None) -> int:

--- a/src/anyio/_core/_signals.py
+++ b/src/anyio/_core/_signals.py
@@ -1,9 +1,10 @@
-from typing import AsyncContextManager, AsyncIterator
+from typing import AsyncIterator
 
+from ._compat import DeprecatedAsyncContextManager
 from ._eventloop import get_asynclib
 
 
-def open_signal_receiver(*signals: int) -> AsyncContextManager[AsyncIterator[int]]:
+def open_signal_receiver(*signals: int) -> DeprecatedAsyncContextManager[AsyncIterator[int]]:
     """
     Start receiving operating system signals.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,7 @@ pytest_plugins = ['pytester']
                  id='asyncio+uvloop'),
     pytest.param('trio')
 ])
-def anyio_backend(
-    request: SubRequest,
-) -> Tuple[str, Dict[str, Any]]:
+def anyio_backend(request: SubRequest) -> Tuple[str, Dict[str, Any]]:
     return request.param
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import asyncio
 import ssl
 from ssl import SSLContext
-from typing import Dict, Generator, Tuple, Union
+from typing import Any, Dict, Generator, Tuple
 
 import pytest
 import trustme
@@ -34,7 +34,7 @@ pytest_plugins = ['pytester']
 ])
 def anyio_backend(
     request: SubRequest,
-) -> Tuple[str, Dict[str, Union[bool, asyncio.AbstractEventLoopPolicy]]]:
+) -> Tuple[str, Dict[str, Any]]:
     return request.param
 
 

--- a/tests/streams/test_buffered.py
+++ b/tests/streams/test_buffered.py
@@ -6,7 +6,7 @@ from anyio.streams.buffered import BufferedByteReceiveStream
 pytestmark = pytest.mark.anyio
 
 
-async def test_receive_exactly():
+async def test_receive_exactly() -> None:
     send_stream, receive_stream = create_memory_object_stream(2)
     buffered_stream = BufferedByteReceiveStream(receive_stream)
     await send_stream.send(b'abcd')
@@ -16,7 +16,7 @@ async def test_receive_exactly():
     assert isinstance(result, bytes)
 
 
-async def test_receive_exactly_incomplete():
+async def test_receive_exactly_incomplete() -> None:
     send_stream, receive_stream = create_memory_object_stream(1)
     buffered_stream = BufferedByteReceiveStream(receive_stream)
     await send_stream.send(b'abcd')
@@ -25,7 +25,7 @@ async def test_receive_exactly_incomplete():
         await buffered_stream.receive_exactly(8)
 
 
-async def test_receive_until():
+async def test_receive_until() -> None:
     send_stream, receive_stream = create_memory_object_stream(2)
     buffered_stream = BufferedByteReceiveStream(receive_stream)
     await send_stream.send(b'abcd')
@@ -40,7 +40,7 @@ async def test_receive_until():
     assert isinstance(result, bytes)
 
 
-async def test_receive_until_incomplete():
+async def test_receive_until_incomplete() -> None:
     send_stream, receive_stream = create_memory_object_stream(1)
     buffered_stream = BufferedByteReceiveStream(receive_stream)
     await send_stream.send(b'abcd')

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -1,6 +1,12 @@
+import pathlib
+from typing import Union
+
 import pytest
+from _pytest.fixtures import SubRequest
+from _pytest.tmpdir import TempPathFactory
 
 from anyio import ClosedResourceError, EndOfStream
+from anyio.abc import ByteReceiveStream
 from anyio.streams.file import FileReadStream, FileStreamAttribute, FileWriteStream
 
 pytestmark = pytest.mark.anyio
@@ -8,38 +14,39 @@ pytestmark = pytest.mark.anyio
 
 class TestFileReadStream:
     @pytest.fixture(scope='class')
-    def file_path(self, tmp_path_factory):
+    def file_path(self, tmp_path_factory: TempPathFactory) -> pathlib.Path:
         path = tmp_path_factory.mktemp('filestream') / 'data.txt'
         path.write_text('Hello')
         return path
 
-    async def _run_filestream_test(self, stream):
+    @pytest.fixture(params=[False, True], ids=["str", "path"])
+    def file_path_or_str(self, request: SubRequest,
+                         file_path: pathlib.Path) -> Union[pathlib.Path, str]:
+        return file_path if request.param else str(file_path)
+
+    async def _run_filestream_test(self, stream: ByteReceiveStream) -> None:
         assert await stream.receive(3) == b'Hel'
         assert await stream.receive(3) == b'lo'
         with pytest.raises(EndOfStream):
             await stream.receive(1)
 
-    @pytest.mark.parametrize('as_path', [True, False], ids=['path', 'str'])
-    async def test_read_file_as_path(self, file_path, as_path):
-        if not as_path:
-            file_path = str(file_path)
-
-        async with await FileReadStream.from_path(file_path) as stream:
+    async def test_read_file_as_path(self, file_path_or_str: Union[pathlib.Path, str]) -> None:
+        async with await FileReadStream.from_path(file_path_or_str) as stream:
             await self._run_filestream_test(stream)
 
-    async def test_read_file(self, file_path):
+    async def test_read_file(self, file_path: pathlib.Path) -> None:
         with file_path.open('rb') as file:
             async with FileReadStream(file) as stream:
                 await self._run_filestream_test(stream)
 
-    async def test_read_after_close(self, file_path):
+    async def test_read_after_close(self, file_path: pathlib.Path) -> None:
         async with await FileReadStream.from_path(file_path) as stream:
             pass
 
         with pytest.raises(ClosedResourceError):
             await stream.receive()
 
-    async def test_seek(self, file_path):
+    async def test_seek(self, file_path: pathlib.Path) -> None:
         with file_path.open('rb') as file:
             async with FileReadStream(file) as stream:
                 await stream.seek(2)
@@ -48,7 +55,7 @@ class TestFileReadStream:
                 assert data == b'llo'
                 assert await stream.tell() == 5
 
-    async def test_extra_attributes(self, file_path):
+    async def test_extra_attributes(self, file_path: pathlib.Path) -> None:
         async with await FileReadStream.from_path(file_path) as stream:
             path = stream.extra(FileStreamAttribute.path)
             assert path == file_path
@@ -62,31 +69,31 @@ class TestFileReadStream:
 
 class TestFileWriteStream:
     @pytest.fixture
-    def file_path(self, tmp_path):
+    def file_path(self, tmp_path: pathlib.Path) -> pathlib.Path:
         return tmp_path / 'written_data.txt'
 
-    async def test_write_file(self, file_path):
+    async def test_write_file(self, file_path: pathlib.Path) -> None:
         async with await FileWriteStream.from_path(file_path) as stream:
             await stream.send(b'Hel')
             await stream.send(b'lo')
 
         assert file_path.read_text() == 'Hello'
 
-    async def test_append_file(self, file_path):
+    async def test_append_file(self, file_path: pathlib.Path) -> None:
         file_path.write_text('Hello')
         async with await FileWriteStream.from_path(file_path, True) as stream:
             await stream.send(b', World!')
 
         assert file_path.read_text() == 'Hello, World!'
 
-    async def test_write_after_close(self, file_path):
+    async def test_write_after_close(self, file_path: pathlib.Path) -> None:
         async with await FileWriteStream.from_path(file_path, True) as stream:
             pass
 
         with pytest.raises(ClosedResourceError):
             await stream.send(b'foo')
 
-    async def test_extra_attributes(self, file_path):
+    async def test_extra_attributes(self, file_path: pathlib.Path) -> None:
         async with await FileWriteStream.from_path(file_path) as stream:
             path = stream.extra(FileStreamAttribute.path)
             assert path == file_path

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -1,4 +1,4 @@
-import pathlib
+from pathlib import Path
 from typing import Union
 
 import pytest
@@ -14,14 +14,14 @@ pytestmark = pytest.mark.anyio
 
 class TestFileReadStream:
     @pytest.fixture(scope='class')
-    def file_path(self, tmp_path_factory: TempPathFactory) -> pathlib.Path:
+    def file_path(self, tmp_path_factory: TempPathFactory) -> Path:
         path = tmp_path_factory.mktemp('filestream') / 'data.txt'
         path.write_text('Hello')
         return path
 
     @pytest.fixture(params=[False, True], ids=["str", "path"])
     def file_path_or_str(self, request: SubRequest,
-                         file_path: pathlib.Path) -> Union[pathlib.Path, str]:
+                         file_path: Path) -> Union[Path, str]:
         return file_path if request.param else str(file_path)
 
     async def _run_filestream_test(self, stream: ByteReceiveStream) -> None:
@@ -30,23 +30,23 @@ class TestFileReadStream:
         with pytest.raises(EndOfStream):
             await stream.receive(1)
 
-    async def test_read_file_as_path(self, file_path_or_str: Union[pathlib.Path, str]) -> None:
+    async def test_read_file_as_path(self, file_path_or_str: Union[Path, str]) -> None:
         async with await FileReadStream.from_path(file_path_or_str) as stream:
             await self._run_filestream_test(stream)
 
-    async def test_read_file(self, file_path: pathlib.Path) -> None:
+    async def test_read_file(self, file_path: Path) -> None:
         with file_path.open('rb') as file:
             async with FileReadStream(file) as stream:
                 await self._run_filestream_test(stream)
 
-    async def test_read_after_close(self, file_path: pathlib.Path) -> None:
+    async def test_read_after_close(self, file_path: Path) -> None:
         async with await FileReadStream.from_path(file_path) as stream:
             pass
 
         with pytest.raises(ClosedResourceError):
             await stream.receive()
 
-    async def test_seek(self, file_path: pathlib.Path) -> None:
+    async def test_seek(self, file_path: Path) -> None:
         with file_path.open('rb') as file:
             async with FileReadStream(file) as stream:
                 await stream.seek(2)
@@ -55,7 +55,7 @@ class TestFileReadStream:
                 assert data == b'llo'
                 assert await stream.tell() == 5
 
-    async def test_extra_attributes(self, file_path: pathlib.Path) -> None:
+    async def test_extra_attributes(self, file_path: Path) -> None:
         async with await FileReadStream.from_path(file_path) as stream:
             path = stream.extra(FileStreamAttribute.path)
             assert path == file_path
@@ -69,31 +69,31 @@ class TestFileReadStream:
 
 class TestFileWriteStream:
     @pytest.fixture
-    def file_path(self, tmp_path: pathlib.Path) -> pathlib.Path:
+    def file_path(self, tmp_path: Path) -> Path:
         return tmp_path / 'written_data.txt'
 
-    async def test_write_file(self, file_path: pathlib.Path) -> None:
+    async def test_write_file(self, file_path: Path) -> None:
         async with await FileWriteStream.from_path(file_path) as stream:
             await stream.send(b'Hel')
             await stream.send(b'lo')
 
         assert file_path.read_text() == 'Hello'
 
-    async def test_append_file(self, file_path: pathlib.Path) -> None:
+    async def test_append_file(self, file_path: Path) -> None:
         file_path.write_text('Hello')
         async with await FileWriteStream.from_path(file_path, True) as stream:
             await stream.send(b', World!')
 
         assert file_path.read_text() == 'Hello, World!'
 
-    async def test_write_after_close(self, file_path: pathlib.Path) -> None:
+    async def test_write_after_close(self, file_path: Path) -> None:
         async with await FileWriteStream.from_path(file_path, True) as stream:
             pass
 
         with pytest.raises(ClosedResourceError):
             await stream.send(b'foo')
 
-    async def test_extra_attributes(self, file_path: pathlib.Path) -> None:
+    async def test_extra_attributes(self, file_path: Path) -> None:
         async with await FileWriteStream.from_path(file_path) as stream:
             path = stream.extra(FileStreamAttribute.path)
             assert path == file_path

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -10,18 +10,18 @@ from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStre
 pytestmark = pytest.mark.anyio
 
 
-def test_invalid_max_buffer():
+def test_invalid_max_buffer() -> None:
     pytest.raises(ValueError, create_memory_object_stream, 1.0).\
         match('max_buffer_size must be either an integer or math.inf')
 
 
-def test_negative_max_buffer():
+def test_negative_max_buffer() -> None:
     pytest.raises(ValueError, create_memory_object_stream, -1).\
         match('max_buffer_size cannot be negative')
 
 
-async def test_receive_then_send():
-    async def receiver():
+async def test_receive_then_send() -> None:
+    async def receiver() -> None:
         received_objects.append(await receive.receive())
         received_objects.append(await receive.receive())
 
@@ -36,8 +36,8 @@ async def test_receive_then_send():
     assert received_objects == ['hello', 'anyio']
 
 
-async def test_receive_then_send_nowait():
-    async def receiver():
+async def test_receive_then_send_nowait() -> None:
+    async def receiver() -> None:
         received_objects.append(await receive.receive())
 
     send, receive = create_memory_object_stream(0)
@@ -52,7 +52,7 @@ async def test_receive_then_send_nowait():
     assert sorted(received_objects, reverse=True) == ['hello', 'anyio']
 
 
-async def test_send_then_receive_nowait():
+async def test_send_then_receive_nowait() -> None:
     send, receive = create_memory_object_stream(0)
     async with create_task_group() as tg:
         tg.start_soon(send.send, 'hello')
@@ -60,7 +60,7 @@ async def test_send_then_receive_nowait():
         assert receive.receive_nowait() == 'hello'
 
 
-async def test_send_is_unblocked_after_receive_nowait():
+async def test_send_is_unblocked_after_receive_nowait() -> None:
     send, receive = create_memory_object_stream(1)
     send.send_nowait('hello')
 
@@ -73,7 +73,7 @@ async def test_send_is_unblocked_after_receive_nowait():
     assert receive.receive_nowait() == 'anyio'
 
 
-async def test_send_nowait_then_receive_nowait():
+async def test_send_nowait_then_receive_nowait() -> None:
     send, receive = create_memory_object_stream(2)
     send.send_nowait('hello')
     send.send_nowait('anyio')
@@ -81,8 +81,8 @@ async def test_send_nowait_then_receive_nowait():
     assert receive.receive_nowait() == 'anyio'
 
 
-async def test_iterate():
-    async def receiver():
+async def test_iterate() -> None:
+    async def receiver() -> None:
         async for item in receive:
             received_objects.append(item)
 
@@ -97,7 +97,7 @@ async def test_iterate():
     assert received_objects == ['hello', 'anyio']
 
 
-async def test_receive_send_closed_send_stream():
+async def test_receive_send_closed_send_stream() -> None:
     send, receive = create_memory_object_stream()
     await send.aclose()
     with pytest.raises(EndOfStream):
@@ -107,7 +107,7 @@ async def test_receive_send_closed_send_stream():
         await send.send(None)
 
 
-async def test_receive_send_closed_receive_stream():
+async def test_receive_send_closed_receive_stream() -> None:
     send, receive = create_memory_object_stream()
     await receive.aclose()
     with pytest.raises(ClosedResourceError):
@@ -117,7 +117,7 @@ async def test_receive_send_closed_receive_stream():
         await send.send(None)
 
 
-async def test_cancel_receive():
+async def test_cancel_receive() -> None:
     send, receive = create_memory_object_stream()
     async with create_task_group() as tg:
         tg.start_soon(receive.receive)
@@ -128,7 +128,7 @@ async def test_cancel_receive():
         send.send_nowait('hello')
 
 
-async def test_cancel_send():
+async def test_cancel_send() -> None:
     send, receive = create_memory_object_stream()
     async with create_task_group() as tg:
         tg.start_soon(send.send, 'hello')
@@ -139,7 +139,7 @@ async def test_cancel_send():
         receive.receive_nowait()
 
 
-async def test_clone():
+async def test_clone() -> None:
     send1, receive1 = create_memory_object_stream(1)
     send2 = send1.clone()
     receive2 = receive1.clone()
@@ -149,7 +149,7 @@ async def test_clone():
     assert receive2.receive_nowait() == 'hello'
 
 
-async def test_clone_closed():
+async def test_clone_closed() -> None:
     send, receive = create_memory_object_stream(1)
     await send.aclose()
     await receive.aclose()
@@ -157,7 +157,7 @@ async def test_clone_closed():
     pytest.raises(ClosedResourceError, receive.clone)
 
 
-async def test_close_send_while_receiving():
+async def test_close_send_while_receiving() -> None:
     send, receive = create_memory_object_stream(1)
     with pytest.raises(EndOfStream):
         async with create_task_group() as tg:
@@ -166,7 +166,7 @@ async def test_close_send_while_receiving():
             await send.aclose()
 
 
-async def test_close_receive_while_sending():
+async def test_close_receive_while_sending() -> None:
     send, receive = create_memory_object_stream(0)
     with pytest.raises(BrokenResourceError):
         async with create_task_group() as tg:
@@ -175,14 +175,14 @@ async def test_close_receive_while_sending():
             await receive.aclose()
 
 
-async def test_receive_after_send_closed():
+async def test_receive_after_send_closed() -> None:
     send, receive = create_memory_object_stream(1)
     await send.send('hello')
     await send.aclose()
     assert await receive.receive() == 'hello'
 
 
-async def test_receive_when_cancelled():
+async def test_receive_when_cancelled() -> None:
     """
     Test that calling receive() in a cancelled scope prevents it from going through with the
     operation.
@@ -203,13 +203,13 @@ async def test_receive_when_cancelled():
         assert await receive.receive() == 'world'
 
 
-async def test_send_when_cancelled():
+async def test_send_when_cancelled() -> None:
     """
     Test that calling send() in a cancelled scope prevents it from going through with the
     operation.
 
     """
-    async def receiver():
+    async def receiver() -> None:
         received.append(await receive.receive())
 
     received: List[str] = []
@@ -225,7 +225,7 @@ async def test_send_when_cancelled():
     assert received == ['world']
 
 
-async def test_cancel_during_receive():
+async def test_cancel_during_receive() -> None:
     """
     Test that cancelling a pending receive() operation does not cause an item in the stream to be
     lost.
@@ -233,7 +233,7 @@ async def test_cancel_during_receive():
     """
     receiver_scope = None
 
-    async def scoped_receiver():
+    async def scoped_receiver() -> None:
         nonlocal receiver_scope
         with CancelScope() as receiver_scope:
             received.append(await receive.receive())
@@ -252,7 +252,7 @@ async def test_cancel_during_receive():
     assert received == ['hello']
 
 
-async def test_close_receive_after_send():
+async def test_close_receive_after_send() -> None:
     async def send() -> None:
         async with send_stream:
             await send_stream.send('test')
@@ -267,7 +267,7 @@ async def test_close_receive_after_send():
         tg.start_soon(receive)
 
 
-async def test_statistics():
+async def test_statistics() -> None:
     send_stream, receive_stream = create_memory_object_stream(1)
     streams: List[Union[MemoryObjectReceiveStream[int], MemoryObjectSendStream[int]]] = [
         send_stream, receive_stream]

--- a/tests/streams/test_stapled.py
+++ b/tests/streams/test_stapled.py
@@ -1,6 +1,6 @@
 from collections import deque
 from dataclasses import InitVar, dataclass, field
-from typing import Iterable
+from typing import Deque, Iterable, List, TypeVar
 
 import pytest
 
@@ -11,57 +11,68 @@ from anyio.streams.stapled import StapledByteStream, StapledObjectStream
 pytestmark = pytest.mark.anyio
 
 
+@dataclass
+class DummyByteReceiveStream(ByteReceiveStream):
+    data: InitVar[bytes]
+    buffer: bytearray = field(init=False)
+    _closed: bool = field(init=False, default=False)
+
+    def __post_init__(self, data: bytes) -> None:
+        self.buffer = bytearray(data)
+
+    async def receive(self, max_bytes: int = 65536) -> bytes:
+        if self._closed:
+            raise ClosedResourceError
+
+        data = bytes(self.buffer[:max_bytes])
+        del self.buffer[:max_bytes]
+        return data
+
+    async def aclose(self) -> None:
+        self._closed = True
+
+
+@dataclass
+class DummyByteSendStream(ByteSendStream):
+    buffer: bytearray = field(init=False, default_factory=bytearray)
+    _closed: bool = field(init=False, default=False)
+
+    async def send(self, item: bytes) -> None:
+        if self._closed:
+            raise ClosedResourceError
+
+        self.buffer.extend(item)
+
+    async def aclose(self) -> None:
+        self._closed = True
+
+
 class TestStapledByteStream:
-    @dataclass
-    class DummyByteReceiveStream(ByteReceiveStream):
-        data: InitVar[bytes]
-        buffer: bytearray = field(init=False)
-        _closed: bool = field(init=False, default=False)
-
-        def __post_init__(self, data: bytes) -> None:
-            self.buffer = bytearray(data)
-
-        async def receive(self, max_bytes: int = 65536) -> bytes:
-            if self._closed:
-                raise ClosedResourceError
-
-            data = bytes(self.buffer[:max_bytes])
-            del self.buffer[:max_bytes]
-            return data
-
-        async def aclose(self) -> None:
-            self._closed = True
-
-    @dataclass
-    class DummyByteSendStream(ByteSendStream):
-        buffer: bytearray = field(init=False, default_factory=bytearray)
-        _closed: bool = field(init=False, default=False)
-
-        async def send(self, item: bytes) -> None:
-            if self._closed:
-                raise ClosedResourceError
-
-            self.buffer.extend(item)
-
-        async def aclose(self) -> None:
-            self._closed = True
+    @pytest.fixture
+    def send_stream(self) -> DummyByteSendStream:
+        return DummyByteSendStream()
 
     @pytest.fixture
-    def stapled(self):
-        receive = self.DummyByteReceiveStream(b'hello, world')
-        send = self.DummyByteSendStream()
-        return StapledByteStream(send, receive)
+    def receive_stream(self) -> DummyByteReceiveStream:
+        return DummyByteReceiveStream(b'hello, world')
 
-    async def test_receive_send(self, stapled):
+    @pytest.fixture
+    def stapled(self, send_stream: DummyByteSendStream,
+                receive_stream: DummyByteReceiveStream) -> StapledByteStream:
+        return StapledByteStream(send_stream, receive_stream)
+
+    async def test_receive_send(self, stapled: StapledByteStream,
+                                send_stream: DummyByteSendStream) -> None:
         assert await stapled.receive(3) == b'hel'
         assert await stapled.receive() == b'lo, world'
         assert await stapled.receive() == b''
 
         await stapled.send(b'how are you ')
         await stapled.send(b'today?')
-        assert bytes(stapled.send_stream.buffer) == b'how are you today?'
+        assert stapled.send_stream is send_stream
+        assert bytes(send_stream.buffer) == b'how are you today?'
 
-    async def test_send_eof(self, stapled):
+    async def test_send_eof(self, stapled: StapledByteStream) -> None:
         await stapled.send_eof()
         await stapled.send_eof()
         with pytest.raises(ClosedResourceError):
@@ -69,7 +80,7 @@ class TestStapledByteStream:
 
         assert await stapled.receive() == b'hello, world'
 
-    async def test_aclose(self, stapled):
+    async def test_aclose(self, stapled: StapledByteStream) -> None:
         await stapled.aclose()
         with pytest.raises(ClosedResourceError):
             await stapled.receive()
@@ -77,48 +88,61 @@ class TestStapledByteStream:
             await stapled.send(b'')
 
 
+T_Item = TypeVar('T_Item')
+
+
+@dataclass
+class DummyObjectReceiveStream(ObjectReceiveStream[T_Item]):
+    data: InitVar[Iterable[T_Item]]
+    buffer: Deque[T_Item] = field(init=False)
+    _closed: bool = field(init=False, default=False)
+
+    def __post_init__(self, data: Iterable[T_Item]) -> None:
+        self.buffer = deque(data)
+
+    async def receive(self) -> T_Item:
+        if self._closed:
+            raise ClosedResourceError
+        if not self.buffer:
+            raise EndOfStream
+
+        return self.buffer.popleft()
+
+    async def aclose(self) -> None:
+        self._closed = True
+
+
+@dataclass
+class DummyObjectSendStream(ObjectSendStream[T_Item]):
+    buffer: List[T_Item] = field(init=False, default_factory=list)
+    _closed: bool = field(init=False, default=False)
+
+    async def send(self, item: T_Item) -> None:
+        if self._closed:
+            raise ClosedResourceError
+
+        self.buffer.append(item)
+
+    async def aclose(self) -> None:
+        self._closed = True
+
+
 class TestStapledObjectStream:
-    @dataclass
-    class DummyObjectReceiveStream(ObjectReceiveStream):
-        data: InitVar[Iterable]
-        buffer: deque = field(init=False)
-        _closed: bool = field(init=False, default=False)
-
-        def __post_init__(self, data: Iterable) -> None:
-            self.buffer = deque(data)
-
-        async def receive(self):
-            if self._closed:
-                raise ClosedResourceError
-            if not self.buffer:
-                raise EndOfStream
-
-            return self.buffer.popleft()
-
-        async def aclose(self) -> None:
-            self._closed = True
-
-    @dataclass
-    class DummyObjectSendStream(ObjectSendStream):
-        buffer: list = field(init=False, default_factory=list)
-        _closed: bool = field(init=False, default=False)
-
-        async def send(self, item: object) -> None:
-            if self._closed:
-                raise ClosedResourceError
-
-            self.buffer.append(item)
-
-        async def aclose(self) -> None:
-            self._closed = True
+    @pytest.fixture
+    def receive_stream(self) -> DummyObjectReceiveStream[str]:
+        return DummyObjectReceiveStream(['hello', 'world'])
 
     @pytest.fixture
-    def stapled(self):
-        receive = self.DummyObjectReceiveStream(['hello', 'world'])
-        send = self.DummyObjectSendStream()
-        return StapledObjectStream(send, receive)
+    def send_stream(self) -> DummyObjectSendStream[str]:
+        return DummyObjectSendStream[str]()
 
-    async def test_receive_send(self, stapled):
+    @pytest.fixture
+    def stapled(self, receive_stream: DummyObjectReceiveStream[str],
+                send_stream: DummyObjectSendStream[str]) -> StapledObjectStream[str]:
+        return StapledObjectStream(send_stream, receive_stream)
+
+    async def test_receive_send(self, stapled: StapledObjectStream[str],
+                                send_stream: DummyObjectSendStream[str]) -> None:
         assert await stapled.receive() == 'hello'
         assert await stapled.receive() == 'world'
         with pytest.raises(EndOfStream):
@@ -126,9 +150,10 @@ class TestStapledObjectStream:
 
         await stapled.send('how are you ')
         await stapled.send('today?')
-        assert stapled.send_stream.buffer == ['how are you ', 'today?']
+        assert stapled.send_stream is send_stream
+        assert send_stream.buffer == ['how are you ', 'today?']
 
-    async def test_send_eof(self, stapled):
+    async def test_send_eof(self, stapled: StapledObjectStream[str]) -> None:
         await stapled.send_eof()
         await stapled.send_eof()
         with pytest.raises(ClosedResourceError):
@@ -137,9 +162,9 @@ class TestStapledObjectStream:
         assert await stapled.receive() == 'hello'
         assert await stapled.receive() == 'world'
 
-    async def test_aclose(self, stapled):
+    async def test_aclose(self, stapled: StapledObjectStream[str]) -> None:
         await stapled.aclose()
         with pytest.raises(ClosedResourceError):
             await stapled.receive()
         with pytest.raises(ClosedResourceError):
-            await stapled.send(b'')
+            await stapled.send(b'')  # type: ignore[arg-type]

--- a/tests/streams/test_stapled.py
+++ b/tests/streams/test_stapled.py
@@ -18,7 +18,7 @@ class TestStapledByteStream:
         buffer: bytearray = field(init=False)
         _closed: bool = field(init=False, default=False)
 
-        def __post_init__(self, data: bytes):
+        def __post_init__(self, data: bytes) -> None:
             self.buffer = bytearray(data)
 
         async def receive(self, max_bytes: int = 65536) -> bytes:
@@ -84,7 +84,7 @@ class TestStapledObjectStream:
         buffer: deque = field(init=False)
         _closed: bool = field(init=False, default=False)
 
-        def __post_init__(self, data: Iterable):
+        def __post_init__(self, data: Iterable) -> None:
             self.buffer = deque(data)
 
         async def receive(self):
@@ -103,7 +103,7 @@ class TestStapledObjectStream:
         buffer: list = field(init=False, default_factory=list)
         _closed: bool = field(init=False, default=False)
 
-        async def send(self, item) -> None:
+        async def send(self, item: object) -> None:
             if self._closed:
                 raise ClosedResourceError
 

--- a/tests/streams/test_text.py
+++ b/tests/streams/test_text.py
@@ -29,7 +29,7 @@ async def test_send():
 
 
 @pytest.mark.xfail(platform.python_implementation() == 'PyPy'
-                   and sys.pypy_version_info < (7, 3, 2),
+                   and sys.pypy_version_info < (7, 3, 2),  # type: ignore[attr-defined]
                    reason='PyPy has a bug in its incremental UTF-8 decoder (#3274)')
 async def test_receive_encoding_error():
     send_stream, receive_stream = create_memory_object_stream(1)

--- a/tests/streams/test_text.py
+++ b/tests/streams/test_text.py
@@ -10,7 +10,7 @@ from anyio.streams.text import TextReceiveStream, TextSendStream, TextStream
 pytestmark = pytest.mark.anyio
 
 
-async def test_receive():
+async def test_receive() -> None:
     send_stream, receive_stream = create_memory_object_stream(1)
     text_stream = TextReceiveStream(receive_stream)
     await send_stream.send(b'\xc3\xa5\xc3\xa4\xc3')  # ends with half of the "ö" letter
@@ -21,7 +21,7 @@ async def test_receive():
     assert await text_stream.receive() == 'ö'
 
 
-async def test_send():
+async def test_send() -> None:
     send_stream, receive_stream = create_memory_object_stream(1)
     text_stream = TextSendStream(send_stream)
     await text_stream.send('åäö')
@@ -31,21 +31,21 @@ async def test_send():
 @pytest.mark.xfail(platform.python_implementation() == 'PyPy'
                    and sys.pypy_version_info < (7, 3, 2),  # type: ignore[attr-defined]
                    reason='PyPy has a bug in its incremental UTF-8 decoder (#3274)')
-async def test_receive_encoding_error():
+async def test_receive_encoding_error() -> None:
     send_stream, receive_stream = create_memory_object_stream(1)
     text_stream = TextReceiveStream(receive_stream, errors='replace')
     await send_stream.send(b'\xe5\xe4\xf6')  # "åäö" in latin-1
     assert await text_stream.receive() == '���'
 
 
-async def test_send_encoding_error():
+async def test_send_encoding_error() -> None:
     send_stream, receive_stream = create_memory_object_stream(1)
     text_stream = TextSendStream(send_stream, encoding='iso-8859-1', errors='replace')
     await text_stream.send('€')
     assert await receive_stream.receive() == b'?'
 
 
-async def test_bidirectional_stream():
+async def test_bidirectional_stream() -> None:
     send_stream, receive_stream = create_memory_object_stream(1)
     stapled_stream = StapledObjectStream(send_stream, receive_stream)
     text_stream = TextStream(stapled_stream)

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -2,8 +2,10 @@ import socket
 import ssl
 from contextlib import ExitStack
 from threading import Thread
+from typing import NoReturn
 
 import pytest
+from trustme import CA
 
 from anyio import (
     BrokenResourceError, EndOfStream, Event, connect_tcp, create_task_group, create_tcp_listener)
@@ -14,8 +16,9 @@ pytestmark = pytest.mark.anyio
 
 
 class TestTLSStream:
-    async def test_send_receive(self, server_context, client_context):
-        def serve_sync():
+    async def test_send_receive(self, server_context: ssl.SSLContext,
+                                client_context: ssl.SSLContext) -> None:
+        def serve_sync() -> None:
             conn, addr = server_sock.accept()
             conn.settimeout(1)
             data = conn.recv(10)
@@ -40,8 +43,9 @@ class TestTLSStream:
         server_sock.close()
         assert response == b'olleh'
 
-    async def test_extra_attributes(self, server_context, client_context):
-        def serve_sync():
+    async def test_extra_attributes(self, server_context: ssl.SSLContext,
+                                    client_context: ssl.SSLContext) -> None:
+        def serve_sync() -> None:
             conn, addr = server_sock.accept()
             with conn:
                 conn.settimeout(1)
@@ -80,8 +84,9 @@ class TestTLSStream:
         server_thread.join()
         server_sock.close()
 
-    async def test_unwrap(self, server_context, client_context):
-        def serve_sync():
+    async def test_unwrap(self, server_context: ssl.SSLContext,
+                          client_context: ssl.SSLContext) -> None:
+        def serve_sync() -> None:
             conn, addr = server_sock.accept()
             conn.settimeout(1)
             conn.send(b'encrypted')
@@ -111,11 +116,14 @@ class TestTLSStream:
         assert msg2 == b'unencrypted'
 
     @pytest.mark.skipif(not ssl.HAS_ALPN, reason='ALPN support not available')
-    async def test_alpn_negotiation(self, server_context, client_context):
-        def serve_sync():
+    async def test_alpn_negotiation(self, server_context: ssl.SSLContext,
+                                    client_context: ssl.SSLContext) -> None:
+        def serve_sync() -> None:
             conn, addr = server_sock.accept()
             conn.settimeout(1)
-            conn.send(conn.selected_alpn_protocol().encode())
+            selected_alpn_protocol = conn.selected_alpn_protocol()
+            assert selected_alpn_protocol is not None
+            conn.send(selected_alpn_protocol.encode())
             conn.close()
 
         server_context.set_alpn_protocols(['dummy1', 'dummy2'])
@@ -145,11 +153,12 @@ class TestTLSStream:
         pytest.param(False, True, id='client_standard'),
         pytest.param(False, False, id='neither_standard')
     ])
-    async def test_ragged_eofs(self, server_context, client_context, server_compatible,
-                               client_compatible):
+    async def test_ragged_eofs(self, server_context: ssl.SSLContext,
+                               client_context: ssl.SSLContext, server_compatible: bool,
+                               client_compatible: bool) -> None:
         server_exc = None
 
-        def serve_sync():
+        def serve_sync() -> None:
             nonlocal server_exc
             conn, addr = server_sock.accept()
             try:
@@ -189,8 +198,9 @@ class TestTLSStream:
         else:
             assert server_exc is None
 
-    async def test_receive_send_after_eof(self, server_context, client_context):
-        def serve_sync():
+    async def test_receive_send_after_eof(self, server_context: ssl.SSLContext,
+                                          client_context: ssl.SSLContext) -> None:
+        def serve_sync() -> None:
             conn, addr = server_sock.accept()
             conn.sendall(b'hello')
             conn.unwrap()
@@ -219,8 +229,9 @@ class TestTLSStream:
                                                       reason='No TLS 1.3 support')]),
         pytest.param(True)
     ], ids=['tlsv13', 'tlsv12'])
-    async def test_send_eof_not_implemented(self, server_context, ca, force_tlsv12):
-        def serve_sync():
+    async def test_send_eof_not_implemented(self, server_context: ssl.SSLContext,
+                                            ca: CA, force_tlsv12: bool) -> None:
+        def serve_sync() -> None:
             conn, addr = server_sock.accept()
             conn.sendall(b'hello')
             conn.unwrap()
@@ -256,8 +267,8 @@ class TestTLSStream:
 
 
 class TestTLSListener:
-    async def test_handshake_fail(self, server_context):
-        def handler(stream):
+    async def test_handshake_fail(self, server_context: ssl.SSLContext) -> None:
+        def handler(stream: object) -> NoReturn:  # type: ignore[misc]
             pytest.fail('This function should never be called in this scenario')
 
         exception = None

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -2,6 +2,7 @@ import pickle
 import signal
 import sys
 import threading
+from typing import Union
 
 import pytest
 
@@ -19,52 +20,52 @@ pytestmark = pytest.mark.anyio
 
 
 class TestMaybeAsync:
-    async def test_cancel_scope(self):
+    async def test_cancel_scope(self) -> None:
         with CancelScope() as scope:
             await maybe_async(scope.cancel())
 
-    async def test_current_time(self):
+    async def test_current_time(self) -> None:
         value = await maybe_async(current_time())
         assert type(value) is float
 
-    async def test_current_effective_deadline(self):
+    async def test_current_effective_deadline(self) -> None:
         value = await maybe_async(current_effective_deadline())
         assert type(value) is float
 
-    async def test_get_running_tasks(self):
+    async def test_get_running_tasks(self) -> None:
         tasks = await maybe_async(get_running_tasks())
         assert type(tasks) is list
 
-    async def test_get_current_task(self):
+    async def test_get_current_task(self) -> None:
         task = await maybe_async(get_current_task())
         assert type(task) is TaskInfo
 
 
-async def test_maybe_async_cm():
+async def test_maybe_async_cm() -> None:
     async with maybe_async_cm(CancelScope()):
         pass
 
 
 class TestDeprecations:
-    async def test_current_effective_deadlinee(self):
+    async def test_current_effective_deadlinee(self) -> None:
         with pytest.deprecated_call():
             deadline = await current_effective_deadline()
 
         assert isinstance(deadline, float)
 
-    async def test_current_time(self):
+    async def test_current_time(self) -> None:
         with pytest.deprecated_call():
             timestamp = await current_time()
 
         assert isinstance(timestamp, float)
 
-    async def test_get_current_task(self):
+    async def test_get_current_task(self) -> None:
         with pytest.deprecated_call():
             task = await get_current_task()
 
         assert isinstance(task, TaskInfo)
 
-    async def test_running_tasks(self):
+    async def test_running_tasks(self) -> None:
         with pytest.deprecated_call():
             tasks = await get_running_tasks()
 
@@ -73,82 +74,82 @@ class TestDeprecations:
 
     @pytest.mark.skipif(sys.platform == 'win32',
                         reason='Signal delivery cannot be tested on Windows')
-    async def test_open_signal_receiver(self):
+    async def test_open_signal_receiver(self) -> None:
         with pytest.deprecated_call():
             async with open_signal_receiver(signal.SIGINT):
                 pass
 
-    async def test_cancelscope_cancel(self):
+    async def test_cancelscope_cancel(self) -> None:
         with CancelScope() as scope:
             with pytest.deprecated_call():
                 await scope.cancel()
 
-    async def test_taskgroup_cancel(self):
+    async def test_taskgroup_cancel(self) -> None:
         async with create_task_group() as tg:
             with pytest.deprecated_call():
                 await tg.cancel_scope.cancel()
 
-    async def test_capacitylimiter_acquire_nowait(self):
+    async def test_capacitylimiter_acquire_nowait(self) -> None:
         limiter = CapacityLimiter(1)
         with pytest.deprecated_call():
             await limiter.acquire_nowait()
 
-    async def test_capacitylimiter_acquire_on_behalf_of_nowait(self):
+    async def test_capacitylimiter_acquire_on_behalf_of_nowait(self) -> None:
         limiter = CapacityLimiter(1)
         with pytest.deprecated_call():
             await limiter.acquire_on_behalf_of_nowait(object())
 
-    async def test_capacitylimiter_set_total_tokens(self):
+    async def test_capacitylimiter_set_total_tokens(self) -> None:
         limiter = CapacityLimiter(1)
         with pytest.deprecated_call():
             await limiter.set_total_tokens(3)
 
         assert limiter.total_tokens == 3
 
-    async def test_condition_release(self):
+    async def test_condition_release(self) -> None:
         condition = Condition()
         condition.acquire_nowait()
         with pytest.deprecated_call():
             await condition.release()
 
-    async def test_event_set(self):
+    async def test_event_set(self) -> None:
         event = Event()
         with pytest.deprecated_call():
             await event.set()
 
-    async def test_lock_release(self):
+    async def test_lock_release(self) -> None:
         lock = Lock()
         lock.acquire_nowait()
         with pytest.deprecated_call():
             await lock.release()
 
-    async def test_memory_object_stream_send_nowait(self):
+    async def test_memory_object_stream_send_nowait(self) -> None:
         send, receive = create_memory_object_stream(1)
         with pytest.deprecated_call():
             await send.send_nowait(None)
 
-    async def test_semaphore_release(self):
+    async def test_semaphore_release(self) -> None:
         semaphore = Semaphore(1)
         semaphore.acquire_nowait()
         with pytest.deprecated_call():
             await semaphore.release()
 
-    async def test_move_on_after(self):
+    async def test_move_on_after(self) -> None:
         with pytest.deprecated_call():
             async with move_on_after(0):
                 pass
 
-    async def test_fail_after(self):
+    async def test_fail_after(self) -> None:
         with pytest.raises(TimeoutError), pytest.deprecated_call():
             async with fail_after(0):
                 pass
 
-    async def test_run_sync_in_worker_thread(self):
+    async def test_run_sync_in_worker_thread(self) -> None:
         with pytest.deprecated_call():
             thread_id = await run_sync_in_worker_thread(threading.get_ident)
             assert thread_id != threading.get_ident()
 
-    async def test_run_async_from_thread(self):
+    async def test_run_async_from_thread(self) -> None:
         async def get_ident():
             return threading.get_ident()
 
@@ -158,38 +159,47 @@ class TestDeprecations:
 
         assert await to_thread.run_sync(thread_func) == threading.get_ident()
 
-    async def test_run_sync_from_thread(self):
+    async def test_run_sync_from_thread(self) -> None:
         def thread_func():
             with pytest.deprecated_call():
                 return run_sync_from_thread(threading.get_ident)
 
         assert await to_thread.run_sync(thread_func) == threading.get_ident()
 
-    async def test_current_default_worker_thread_limiter(self):
+    async def test_current_default_worker_thread_limiter(self) -> None:
         with pytest.deprecated_call():
             default_limiter = to_thread.current_default_thread_limiter()
             assert current_default_worker_thread_limiter() is default_limiter
 
-    async def test_create_blocking_portal(self):
+    async def test_create_blocking_portal(self) -> None:
         with pytest.deprecated_call():
             async with create_blocking_portal():
                 pass
 
 
 class TestPickle:
-    def test_deprecated_awaitable_none(self):
-        obj = DeprecatedAwaitable(threading.get_ident)
+    def test_deprecated_awaitable_none(self) -> None:
+        def fn() -> DeprecatedAwaitable:
+            return DeprecatedAwaitable(fn)
+
+        obj = fn()
         result = pickle.loads(pickle.dumps(obj))
         assert result is None
 
-    def test_deprecated_awaitable_float(self):
-        obj = DeprecatedAwaitableFloat(2.3, threading.get_ident)
+    def test_deprecated_awaitable_float(self) -> None:
+        def fn() -> DeprecatedAwaitableFloat:
+            return DeprecatedAwaitableFloat(2.3, fn)
+
+        obj = fn()
         result = pickle.loads(pickle.dumps(obj))
         assert type(result) is float
         assert result == 2.3
 
-    def test_deprecated_awaitable_list(self):
-        obj = DeprecatedAwaitableList([1, 'a'], func=threading.get_ident)
+    def test_deprecated_awaitable_list(self) -> None:
+        def fn() -> DeprecatedAwaitableList[Union[str, int]]:
+            return DeprecatedAwaitableList([1, 'a'], func=fn)
+
+        obj = fn()
         result = pickle.loads(pickle.dumps(obj))
         assert type(result) is list
         assert result == [1, 'a']

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -150,17 +150,17 @@ class TestDeprecations:
             assert thread_id != threading.get_ident()
 
     async def test_run_async_from_thread(self) -> None:
-        async def get_ident():
+        async def get_ident() -> int:
             return threading.get_ident()
 
-        def thread_func():
+        def thread_func() -> int:
             with pytest.deprecated_call():
                 return run_async_from_thread(get_ident)
 
         assert await to_thread.run_sync(thread_func) == threading.get_ident()
 
     async def test_run_sync_from_thread(self) -> None:
-        def thread_func():
+        def thread_func() -> int:
             with pytest.deprecated_call():
                 return run_sync_from_thread(threading.get_ident)
 

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -1,24 +1,29 @@
 import asyncio
 import sys
+from typing import Any, Dict, List, Optional, Union
 
 import pytest
 
 import anyio
 from anyio import (
-    Event, create_task_group, get_current_task, get_running_tasks, move_on_after,
+    Event, TaskInfo, create_task_group, get_current_task, get_running_tasks, move_on_after,
     wait_all_tasks_blocked)
 
 pytestmark = pytest.mark.anyio
 
 
-def test_main_task_name(anyio_backend_name, anyio_backend_options):
+def test_main_task_name(
+    anyio_backend_name: str,
+    anyio_backend_options: Dict[str, Union[bool, asyncio.AbstractEventLoopPolicy]],
+) -> None:
+    task_name = None
+
     async def main():
         nonlocal task_name
         task_name = get_current_task().name
 
-    task_name = None
     anyio.run(main, backend=anyio_backend_name, backend_options=anyio_backend_options)
-    assert task_name == 'test_debugging.test_main_task_name.<locals>.main'
+    assert task_name == 'tests.test_debugging.test_main_task_name.<locals>.main'
 
     # Work around sniffio/asyncio bug that leaves behind an unclosed event loop
     if anyio_backend_name == 'asyncio':
@@ -32,13 +37,13 @@ def test_main_task_name(anyio_backend_name, anyio_backend_options):
 @pytest.mark.parametrize(
     "name_input,expected",
     [
-        (None, 'test_debugging.test_non_main_task_name.<locals>.non_main'),
+        (None, 'tests.test_debugging.test_non_main_task_name.<locals>.non_main'),
         (b'name', "b'name'"),
         ("name", "name"),
         ("", ""),
     ],
 )
-async def test_non_main_task_name(name_input, expected):
+async def test_non_main_task_name(name_input: Optional[Union[bytes, str]], expected: str) -> None:
     async def non_main(*, task_status):
         task_status.started(anyio.get_current_task().name)
 
@@ -56,7 +61,7 @@ async def test_get_running_tasks():
         event.set()
 
     event = Event()
-    task_infos = []
+    task_infos: List[TaskInfo] = []
     host_task = get_current_task()
     async with create_task_group() as tg:
         existing_tasks = set(get_running_tasks())
@@ -65,22 +70,31 @@ async def test_get_running_tasks():
         tg.start_soon(inspect)
 
     assert len(task_infos) == 3
-    expected_names = ['task1', 'task2', 'test_debugging.test_get_running_tasks.<locals>.inspect']
+    expected_names = ['task1', 'task2',
+                      'tests.test_debugging.test_get_running_tasks.<locals>.inspect']
     for task, expected_name in zip(task_infos, expected_names):
         assert task.parent_id == host_task.id
         assert task.name == expected_name
         assert repr(task) == f'TaskInfo(id={task.id}, name={expected_name!r})'
 
 
+if sys.version_info >= (3, 8):
+    get_coro = asyncio.Task.get_coro
+else:
+    def get_coro(self: asyncio.Task) -> Any:
+        return self._coro
+
+
 @pytest.mark.filterwarnings('ignore:"@coroutine" decorator is deprecated:DeprecationWarning')
-def test_wait_generator_based_task_blocked(asyncio_event_loop):
+def test_wait_generator_based_task_blocked(asyncio_event_loop: asyncio.AbstractEventLoop) -> None:
     async def native_coro_part():
         await wait_all_tasks_blocked()
-        assert not gen_task._coro.gi_running
+        coro = get_coro(gen_task)
+        assert not coro.gi_running
         if sys.version_info < (3, 7):
-            assert gen_task._coro.gi_yieldfrom.gi_code.co_name == 'wait'
+            assert coro.gi_yieldfrom.gi_code.co_name == 'wait'
         else:
-            assert gen_task._coro.gi_yieldfrom.cr_code.co_name == 'wait'
+            assert coro.gi_yieldfrom.cr_code.co_name == 'wait'
 
         event.set()
 
@@ -94,7 +108,7 @@ def test_wait_generator_based_task_blocked(asyncio_event_loop):
 
 
 @pytest.mark.parametrize('anyio_backend', ['asyncio'])
-async def test_wait_all_tasks_blocked_asend(anyio_backend):
+async def test_wait_all_tasks_blocked_asend(anyio_backend: str) -> None:
     """Test that wait_all_tasks_blocked() does not crash on an `asend()` object."""
 
     async def agen_func():
@@ -109,7 +123,9 @@ async def test_wait_all_tasks_blocked_asend(anyio_backend):
     await agen.aclose()
 
 
-async def test_wait_all_tasks_blocked_cancelled_task():
+async def test_wait_all_tasks_blocked_cancelled_task() -> None:
+    done = False
+
     async def self_cancel(*, task_status):
         nonlocal done
         task_status.started()
@@ -118,7 +134,6 @@ async def test_wait_all_tasks_blocked_cancelled_task():
 
         done = True
 
-    done = False
     async with create_task_group() as tg:
         await tg.start(self_cancel)
         await wait_all_tasks_blocked()

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -13,10 +13,7 @@ from anyio.abc import TaskStatus
 pytestmark = pytest.mark.anyio
 
 
-def test_main_task_name(
-    anyio_backend_name: str,
-    anyio_backend_options: Dict[str, Any],
-) -> None:
+def test_main_task_name(anyio_backend_name: str, anyio_backend_options: Dict[str, Any]) -> None:
     task_name = None
 
     async def main() -> None:

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -13,6 +13,13 @@ from anyio.abc import TaskStatus
 pytestmark = pytest.mark.anyio
 
 
+if sys.version_info >= (3, 8):
+    get_coro = asyncio.Task.get_coro
+else:
+    def get_coro(self: asyncio.Task) -> Any:
+        return self._coro
+
+
 def test_main_task_name(anyio_backend_name: str, anyio_backend_options: Dict[str, Any]) -> None:
     task_name = None
 
@@ -74,13 +81,6 @@ async def test_get_running_tasks() -> None:
         assert task.parent_id == host_task.id
         assert task.name == expected_name
         assert repr(task) == f'TaskInfo(id={task.id}, name={expected_name!r})'
-
-
-if sys.version_info >= (3, 8):
-    get_coro = asyncio.Task.get_coro
-else:
-    def get_coro(self: asyncio.Task) -> Any:
-        return self._coro
 
 
 @pytest.mark.filterwarnings('ignore:"@coroutine" decorator is deprecated:DeprecationWarning')

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -2,6 +2,7 @@ import math
 import sys
 
 import pytest
+from pytest_mock.plugin import MockerFixture
 
 from anyio import sleep_forever, sleep_until
 
@@ -15,23 +16,23 @@ fake_current_time = 1620581544.0
 
 
 @pytest.fixture
-def fake_sleep(mocker):
+def fake_sleep(mocker: MockerFixture) -> AsyncMock:
     mocker.patch('anyio._core._eventloop.current_time', return_value=fake_current_time)
     return mocker.patch('anyio._core._eventloop.sleep', AsyncMock())
 
 
-async def test_sleep_until(fake_sleep):
+async def test_sleep_until(fake_sleep: AsyncMock) -> None:
     deadline = fake_current_time + 500.102352
     await sleep_until(deadline)
     fake_sleep.assert_called_once_with(deadline - fake_current_time)
 
 
-async def test_sleep_until_in_past(fake_sleep):
+async def test_sleep_until_in_past(fake_sleep: AsyncMock) -> None:
     deadline = fake_current_time - 500.102352
     await sleep_until(deadline)
     fake_sleep.assert_called_once_with(0)
 
 
-async def test_sleep_forever(fake_sleep):
+async def test_sleep_forever(fake_sleep: AsyncMock) -> None:
     await sleep_forever()
     fake_sleep.assert_called_once_with(math.inf)

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -47,4 +47,4 @@ async def test_async_iteration(tmp_path: PosixPath) -> None:
     async with await open_file(str(testpath)) as f:
         lines_i = iter(lines)
         async for line in f:
-            assert line == next(lines_i)
+            assert line == next(lines_i)  # type: ignore[comparison-overlap]

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -1,4 +1,7 @@
+from pathlib import PosixPath
+
 import pytest
+from _pytest.tmpdir import TempPathFactory
 
 from anyio import open_file
 
@@ -6,23 +9,23 @@ pytestmark = pytest.mark.anyio
 
 
 @pytest.fixture(scope='module')
-def testdata():
+def testdata() -> bytes:
     return b''.join(bytes([i] * 1000) for i in range(10))
 
 
 @pytest.fixture
-def testdatafile(tmp_path_factory, testdata):
+def testdatafile(tmp_path_factory: TempPathFactory, testdata: bytes) -> PosixPath:
     file = tmp_path_factory.mktemp('file').joinpath('testdata')
     file.write_bytes(testdata)
     return file
 
 
-async def test_open_close(testdatafile):
+async def test_open_close(testdatafile: PosixPath) -> None:
     f = await open_file(testdatafile)
     await f.aclose()
 
 
-async def test_read(testdatafile, testdata):
+async def test_read(testdatafile: PosixPath, testdata: bytes) -> None:
     async with await open_file(testdatafile, 'rb') as f:
         data = await f.read()
 
@@ -30,14 +33,14 @@ async def test_read(testdatafile, testdata):
     assert data == testdata
 
 
-async def test_write(testdatafile, testdata):
+async def test_write(testdatafile: PosixPath, testdata: bytes) -> None:
     async with await open_file(testdatafile, 'ab') as f:
         await f.write(b'f' * 1000)
 
     assert testdatafile.stat().st_size == len(testdata) + 1000
 
 
-async def test_async_iteration(tmp_path):
+async def test_async_iteration(tmp_path: PosixPath) -> None:
     lines = ['blah blah\n', 'foo foo\n', 'bar bar']
     testpath = tmp_path.joinpath('testfile')
     testpath.write_text(''.join(lines), 'ascii')

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -13,12 +13,13 @@ from anyio import (
 from anyio.abc import TaskStatus
 from anyio.from_thread import BlockingPortal, start_blocking_portal
 
-pytestmark = pytest.mark.anyio
-
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
+
+
+pytestmark = pytest.mark.anyio
 
 
 class TestRunAsyncFromThread:

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -1,26 +1,33 @@
+import sys
 import threading
 import time
 from concurrent.futures import CancelledError
 from contextlib import suppress
-from typing import List, Optional
+from typing import Any, Dict, List, NoReturn, Optional
 
 import pytest
 
 from anyio import (
     Event, from_thread, get_cancelled_exc_class, get_current_task, run, sleep, to_thread,
     wait_all_tasks_blocked)
+from anyio.abc import TaskStatus
 from anyio.from_thread import BlockingPortal, start_blocking_portal
 
 pytestmark = pytest.mark.anyio
 
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
 
 class TestRunAsyncFromThread:
-    async def test_run_async_from_thread(self):
-        async def add(a, b):
+    async def test_run_async_from_thread(self) -> None:
+        async def add(a: int, b: int) -> int:
             assert threading.get_ident() == event_loop_thread_id
             return a + b
 
-        def worker(a, b):
+        def worker(a: int, b: int) -> int:
             assert threading.get_ident() != event_loop_thread_id
             return from_thread.run(add, a, b)
 
@@ -28,12 +35,12 @@ class TestRunAsyncFromThread:
         result = await to_thread.run_sync(worker, 1, 2)
         assert result == 3
 
-    async def test_run_sync_from_thread(self):
-        def add(a, b):
+    async def test_run_sync_from_thread(self) -> None:
+        def add(a: int, b: int) -> int:
             assert threading.get_ident() == event_loop_thread_id
             return a + b
 
-        def worker(a, b):
+        def worker(a: int, b: int) -> int:
             assert threading.get_ident() != event_loop_thread_id
             return from_thread.run_sync(add, a, b)
 
@@ -41,8 +48,8 @@ class TestRunAsyncFromThread:
         result = await to_thread.run_sync(worker, 1, 2)
         assert result == 3
 
-    def test_run_sync_from_thread_pooling(self):
-        async def main():
+    def test_run_sync_from_thread_pooling(self) -> None:
+        async def main() -> None:
             thread_ids = set()
             for _ in range(5):
                 thread_ids.add(await to_thread.run_sync(threading.get_ident))
@@ -64,12 +71,12 @@ class TestRunAsyncFromThread:
 
         pytest.fail('Worker thread did not exit within 1 second')
 
-    async def test_run_async_from_thread_exception(self):
-        async def add(a, b):
+    async def test_run_async_from_thread_exception(self) -> None:
+        async def add(a: int, b: int) -> int:
             assert threading.get_ident() == event_loop_thread_id
             return a + b
 
-        def worker(a, b):
+        def worker(a: int, b: int) -> int:
             assert threading.get_ident() != event_loop_thread_id
             return from_thread.run(add, a, b)
 
@@ -79,12 +86,12 @@ class TestRunAsyncFromThread:
 
         exc.match("unsupported operand type")
 
-    async def test_run_sync_from_thread_exception(self):
-        def add(a, b):
+    async def test_run_sync_from_thread_exception(self) -> None:
+        def add(a: int, b: int) -> int:
             assert threading.get_ident() == event_loop_thread_id
             return a + b
 
-        def worker(a, b):
+        def worker(a: int, b: int) -> int:
             assert threading.get_ident() != event_loop_thread_id
             return from_thread.run_sync(add, a, b)
 
@@ -94,15 +101,15 @@ class TestRunAsyncFromThread:
 
         exc.match("unsupported operand type")
 
-    async def test_run_anyio_async_func_from_thread(self):
-        def worker(*args):
+    async def test_run_anyio_async_func_from_thread(self) -> None:
+        def worker(*args: int) -> Literal[True]:
             from_thread.run(sleep, *args)
             return True
 
         assert await to_thread.run_sync(worker, 0)
 
-    def test_run_async_from_unclaimed_thread(self):
-        async def foo():
+    def test_run_async_from_unclaimed_thread(self) -> None:
+        async def foo() -> None:
             pass
 
         exc = pytest.raises(RuntimeError, from_thread.run, foo)
@@ -110,8 +117,8 @@ class TestRunAsyncFromThread:
 
 
 class TestRunSyncFromThread:
-    def test_run_sync_from_unclaimed_thread(self):
-        def foo():
+    def test_run_sync_from_unclaimed_thread(self) -> None:
+        def foo() -> None:
             pass
 
         exc = pytest.raises(RuntimeError, from_thread.run_sync, foo)
@@ -120,20 +127,20 @@ class TestRunSyncFromThread:
 
 class TestBlockingPortal:
     class AsyncCM:
-        def __init__(self, ignore_error):
+        def __init__(self, ignore_error: bool):
             self.ignore_error = ignore_error
 
-        async def __aenter__(self):
+        async def __aenter__(self) -> Literal["test"]:
             return 'test'
 
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
+        async def __aexit__(self, exc_type: object, exc_val: object, exc_tb: object) -> bool:
             return self.ignore_error
 
-    async def test_successful_call(self):
-        async def async_get_thread_id():
+    async def test_successful_call(self) -> None:
+        async def async_get_thread_id() -> int:
             return threading.get_ident()
 
-        def external_thread():
+        def external_thread() -> None:
             thread_ids.append(portal.call(threading.get_ident))
             thread_ids.append(portal.call(async_get_thread_id))
 
@@ -146,9 +153,9 @@ class TestBlockingPortal:
         for thread_id in thread_ids:
             assert thread_id == threading.get_ident()
 
-    async def test_aexit_with_exception(self):
+    async def test_aexit_with_exception(self) -> None:
         """Test that when the portal exits with an exception, all tasks are cancelled."""
-        def external_thread():
+        def external_thread() -> None:
             try:
                 portal.call(sleep, 3)
             except BaseException as exc:
@@ -174,9 +181,9 @@ class TestBlockingPortal:
         assert isinstance(results[0], CancelledError)
         assert isinstance(results[1], CancelledError)
 
-    async def test_aexit_without_exception(self):
+    async def test_aexit_without_exception(self) -> None:
         """Test that when the portal exits, it waits for all tasks to finish."""
-        def external_thread():
+        def external_thread() -> None:
             try:
                 portal.call(sleep, 0.2)
             except BaseException as exc:
@@ -198,13 +205,14 @@ class TestBlockingPortal:
 
         assert results == [None, None]
 
-    async def test_call_portal_from_event_loop_thread(self):
+    async def test_call_portal_from_event_loop_thread(self) -> None:
         async with BlockingPortal() as portal:
             exc = pytest.raises(RuntimeError, portal.call, threading.get_ident)
             exc.match('This method cannot be called from the event loop thread')
 
-    def test_start_with_new_event_loop(self, anyio_backend_name, anyio_backend_options):
-        async def async_get_thread_id():
+    def test_start_with_new_event_loop(self, anyio_backend_name: str,
+                                       anyio_backend_options: Dict[str, Any]) -> None:
+        async def async_get_thread_id() -> int:
             return threading.get_ident()
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
@@ -213,22 +221,24 @@ class TestBlockingPortal:
         assert isinstance(thread_id, int)
         assert thread_id != threading.get_ident()
 
-    def test_start_with_nonexistent_backend(self):
+    def test_start_with_nonexistent_backend(self) -> None:
         with pytest.raises(LookupError) as exc:
             with start_blocking_portal('foo'):
                 pass
 
         exc.match('No such backend: foo')
 
-    def test_call_stopped_portal(self, anyio_backend_name, anyio_backend_options):
+    def test_call_stopped_portal(self, anyio_backend_name: str,
+                                 anyio_backend_options: Dict[str, Any]) -> None:
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
             pass
 
         pytest.raises(RuntimeError, portal.call, threading.get_ident).\
             match('This portal is not running')
 
-    def test_start_task_soon(self, anyio_backend_name, anyio_backend_options):
-        async def event_waiter():
+    def test_start_task_soon(self, anyio_backend_name: str,
+                             anyio_backend_options: Dict[str, Any]) -> None:
+        async def event_waiter() -> Literal["test"]:
             await event1.wait()
             event2.set()
             return 'test'
@@ -241,8 +251,9 @@ class TestBlockingPortal:
             portal.call(event2.wait)
             assert future.result() == 'test'
 
-    def test_start_task_soon_cancel_later(self, anyio_backend_name, anyio_backend_options):
-        async def noop():
+    def test_start_task_soon_cancel_later(self, anyio_backend_name: str,
+                                          anyio_backend_options: Dict[str, Any]) -> None:
+        async def noop() -> None:
             await sleep(2)
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
@@ -252,10 +263,11 @@ class TestBlockingPortal:
 
         assert future.cancelled()
 
-    def test_start_task_soon_cancel_immediately(self, anyio_backend_name, anyio_backend_options):
+    def test_start_task_soon_cancel_immediately(self, anyio_backend_name: str,
+                                                anyio_backend_options: Dict[str, Any]) -> None:
         cancelled = False
 
-        async def event_waiter():
+        async def event_waiter() -> None:
             nonlocal cancelled
             try:
                 await sleep(3)
@@ -268,10 +280,11 @@ class TestBlockingPortal:
 
         assert cancelled
 
-    def test_start_task_soon_with_name(self, anyio_backend_name, anyio_backend_options):
+    def test_start_task_soon_with_name(self, anyio_backend_name: str,
+                                       anyio_backend_options: Dict[str, Any]) -> None:
         task_name = None
 
-        async def taskfunc():
+        async def taskfunc() -> None:
             nonlocal task_name
             task_name = get_current_task().name
 
@@ -280,12 +293,14 @@ class TestBlockingPortal:
 
         assert task_name == 'testname'
 
-    def test_async_context_manager_success(self, anyio_backend_name, anyio_backend_options):
+    def test_async_context_manager_success(self, anyio_backend_name: str,
+                                           anyio_backend_options: Dict[str, Any]) -> None:
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
             with portal.wrap_async_context_manager(TestBlockingPortal.AsyncCM(False)) as cm:
                 assert cm == 'test'
 
-    def test_async_context_manager_error(self, anyio_backend_name, anyio_backend_options):
+    def test_async_context_manager_error(self, anyio_backend_name: str,
+                                         anyio_backend_options: Dict[str, Any]) -> None:
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
             with pytest.raises(Exception) as exc:
                 with portal.wrap_async_context_manager(TestBlockingPortal.AsyncCM(False)) as cm:
@@ -294,40 +309,45 @@ class TestBlockingPortal:
 
                 exc.match('should NOT be ignored')
 
-    def test_async_context_manager_error_ignore(self, anyio_backend_name, anyio_backend_options):
+    def test_async_context_manager_error_ignore(self, anyio_backend_name: str,
+                                                anyio_backend_options: Dict[str, Any]) -> None:
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
             with portal.wrap_async_context_manager(TestBlockingPortal.AsyncCM(True)) as cm:
                 assert cm == 'test'
                 raise Exception('should be ignored')
 
-    def test_start_no_value(self, anyio_backend_name, anyio_backend_options):
-        def taskfunc(*, task_status):
+    def test_start_no_value(self, anyio_backend_name: str,
+                            anyio_backend_options: Dict[str, Any]) -> None:
+        def taskfunc(*, task_status: TaskStatus) -> None:
             task_status.started()
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
-            future, value = portal.start_task(taskfunc)
+            future, value = portal.start_task(taskfunc)  # type: ignore[arg-type]
             assert value is None
             assert future.result() is None
 
-    def test_start_with_value(self, anyio_backend_name, anyio_backend_options):
-        def taskfunc(*, task_status):
+    def test_start_with_value(self, anyio_backend_name: str,
+                              anyio_backend_options: Dict[str, Any]) -> None:
+        def taskfunc(*, task_status: TaskStatus) -> None:
             task_status.started('foo')
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
-            future, value = portal.start_task(taskfunc)
+            future, value = portal.start_task(taskfunc)  # type: ignore[arg-type]
             assert value == 'foo'
             assert future.result() is None
 
-    def test_start_crash_before_started_call(self, anyio_backend_name, anyio_backend_options):
-        def taskfunc(*, task_status):
+    def test_start_crash_before_started_call(self, anyio_backend_name: str,
+                                             anyio_backend_options: Dict[str, Any]) -> None:
+        def taskfunc(*, task_status: object) -> NoReturn:
             raise Exception('foo')
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
             with pytest.raises(Exception, match='foo'):
                 portal.start_task(taskfunc)
 
-    def test_start_crash_after_started_call(self, anyio_backend_name, anyio_backend_options):
-        def taskfunc(*, task_status):
+    def test_start_crash_after_started_call(self, anyio_backend_name: str,
+                                            anyio_backend_options: Dict[str, Any]) -> None:
+        def taskfunc(*, task_status: TaskStatus) -> NoReturn:
             task_status.started(2)
             raise Exception('foo')
 
@@ -337,18 +357,21 @@ class TestBlockingPortal:
             with pytest.raises(Exception, match='foo'):
                 future.result()
 
-    def test_start_no_started_call(self, anyio_backend_name, anyio_backend_options):
-        def taskfunc(*, task_status):
+    def test_start_no_started_call(self, anyio_backend_name: str,
+                                   anyio_backend_options: Dict[str, Any]) -> None:
+        def taskfunc(*, task_status: TaskStatus) -> None:
             pass
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
             with pytest.raises(RuntimeError, match='Task exited'):
-                portal.start_task(taskfunc)
+                portal.start_task(taskfunc)  # type: ignore[arg-type]
 
-    def test_start_with_name(self, anyio_backend_name, anyio_backend_options):
-        def taskfunc(*, task_status):
+    def test_start_with_name(self, anyio_backend_name: str,
+                             anyio_backend_options: Dict[str, Any]) -> None:
+        def taskfunc(*, task_status: TaskStatus) -> None:
             task_status.started(get_current_task().name)
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
-            future, start_value = portal.start_task(taskfunc, name='testname')
+            future, start_value = portal.start_task(
+                taskfunc, name='testname')  # type: ignore[arg-type]
             assert start_value == 'testname'

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1,5 +1,4 @@
-import asyncio
-from typing import Dict, Union
+from typing import Any, Dict
 
 import pytest
 
@@ -13,7 +12,7 @@ pytestmark = pytest.mark.anyio
 async def test_checkpoint_if_cancelled(cancel: bool) -> None:
     finished = second_finished = False
 
-    async def func():
+    async def func() -> None:
         nonlocal finished
         tg.start_soon(second_func)
         if cancel:
@@ -22,7 +21,7 @@ async def test_checkpoint_if_cancelled(cancel: bool) -> None:
         await checkpoint_if_cancelled()
         finished = True
 
-    async def second_func():
+    async def second_func() -> None:
         nonlocal second_finished
         assert finished != cancel
         second_finished = True
@@ -38,12 +37,12 @@ async def test_checkpoint_if_cancelled(cancel: bool) -> None:
 async def test_cancel_shielded_checkpoint(cancel: bool) -> None:
     finished = second_finished = False
 
-    async def func():
+    async def func() -> None:
         nonlocal finished
         await cancel_shielded_checkpoint()
         finished = True
 
-    async def second_func():
+    async def second_func() -> None:
         nonlocal second_finished
         assert not finished
         second_finished = True
@@ -62,12 +61,12 @@ async def test_cancel_shielded_checkpoint(cancel: bool) -> None:
 async def test_checkpoint(cancel: bool) -> None:
     finished = second_finished = False
 
-    async def func():
+    async def func() -> None:
         nonlocal finished
         await checkpoint()
         finished = True
 
-    async def second_func():
+    async def second_func() -> None:
         nonlocal second_finished
         assert not finished
         second_finished = True
@@ -86,13 +85,13 @@ class TestRunVar:
     def test_get_set(
         self,
         anyio_backend_name: str,
-        anyio_backend_options: Dict[str, Union[bool, asyncio.AbstractEventLoopPolicy]],
+        anyio_backend_options: Dict[str, Any],
     ) -> None:
-        async def taskfunc(index):
+        async def taskfunc(index: int) -> None:
             assert var.get() == index
             var.set(index + 1)
 
-        async def main():
+        async def main() -> None:
             pytest.raises(LookupError, var.get)
             for i in range(2):
                 var.set(i)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,4 +1,5 @@
 import pytest
+from _pytest.pytester import Testdir
 
 from anyio import get_all_backends
 
@@ -6,7 +7,7 @@ pytestmark = pytest.mark.filterwarnings(
     'ignore:The TerminalReporter.writer attribute is deprecated:pytest.PytestDeprecationWarning:')
 
 
-def test_plugin(testdir):
+def test_plugin(testdir: Testdir) -> None:
     testdir.makeconftest(
         """
         import sniffio
@@ -64,7 +65,7 @@ def test_plugin(testdir):
     result.assert_outcomes(passed=3 * len(get_all_backends()), skipped=len(get_all_backends()))
 
 
-def test_asyncio(testdir):
+def test_asyncio(testdir: Testdir) -> None:
     testdir.makeconftest(
         """
         import asyncio
@@ -137,7 +138,7 @@ def test_asyncio(testdir):
     result.assert_outcomes(passed=2, failed=1, errors=2)
 
 
-def test_autouse_async_fixture(testdir):
+def test_autouse_async_fixture(testdir: Testdir) -> None:
     testdir.makeconftest(
         """
         import pytest
@@ -174,7 +175,7 @@ def test_autouse_async_fixture(testdir):
     result.assert_outcomes(passed=len(get_all_backends()))
 
 
-def test_cancel_scope_in_asyncgen_fixture(testdir):
+def test_cancel_scope_in_asyncgen_fixture(testdir: Testdir) -> None:
     testdir.makepyfile(
         """
         import pytest
@@ -201,7 +202,7 @@ def test_cancel_scope_in_asyncgen_fixture(testdir):
     result.assert_outcomes(passed=len(get_all_backends()))
 
 
-def test_hypothesis_module_mark(testdir):
+def test_hypothesis_module_mark(testdir: Testdir) -> None:
     testdir.makepyfile(
         """
         import pytest
@@ -232,7 +233,7 @@ def test_hypothesis_module_mark(testdir):
     result.assert_outcomes(passed=len(get_all_backends()) + 1, xfailed=len(get_all_backends()))
 
 
-def test_hypothesis_function_mark(testdir):
+def test_hypothesis_function_mark(testdir: Testdir) -> None:
     testdir.makepyfile(
         """
         import pytest

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -41,7 +41,7 @@ def test_plugin(testdir: Testdir) -> None:
 
 
         @pytest.mark.anyio
-        async def test_marked_test():
+        async def test_marked_test() -> None:
             # Test that tests marked with @pytest.mark.anyio are run
             pass
 
@@ -115,7 +115,7 @@ def test_asyncio(testdir: Testdir) -> None:
                 assert anyio_backend_name == 'asyncio'
                 assert async_class_fixture == 'asyncio'
 
-        async def test_callback_exception_during_test():
+        async def test_callback_exception_during_test() -> None:
             def callback():
                 nonlocal started
                 started = True

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -15,7 +15,7 @@ pytestmark = [
 ]
 
 
-async def test_receive_signals():
+async def test_receive_signals() -> None:
     with open_signal_receiver(signal.SIGUSR1, signal.SIGUSR2) as sigiter:
         await to_thread.run_sync(os.kill, os.getpid(), signal.SIGUSR1)
         await to_thread.run_sync(os.kill, os.getpid(), signal.SIGUSR2)
@@ -24,7 +24,7 @@ async def test_receive_signals():
             assert await sigiter.__anext__() == signal.SIGUSR2
 
 
-async def test_task_group_cancellation_open():
+async def test_task_group_cancellation_open() -> None:
     async def signal_handler():
         with open_signal_receiver(signal.SIGUSR1) as sigiter:
             async for v in sigiter:
@@ -39,7 +39,7 @@ async def test_task_group_cancellation_open():
         tg.cancel_scope.cancel()
 
 
-async def test_task_group_cancellation_consume():
+async def test_task_group_cancellation_consume() -> None:
     async def consume(sigiter):
         async for v in sigiter:
             pytest.fail("SIGUSR1 should not be sent")

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,6 +1,7 @@
 import os
 import signal
 import sys
+from typing import AsyncIterable
 
 import pytest
 
@@ -25,7 +26,7 @@ async def test_receive_signals() -> None:
 
 
 async def test_task_group_cancellation_open() -> None:
-    async def signal_handler():
+    async def signal_handler() -> None:
         with open_signal_receiver(signal.SIGUSR1) as sigiter:
             async for v in sigiter:
                 pytest.fail("SIGUSR1 should not be sent")
@@ -40,7 +41,7 @@ async def test_task_group_cancellation_open() -> None:
 
 
 async def test_task_group_cancellation_consume() -> None:
-    async def consume(sigiter):
+    async def consume(sigiter: AsyncIterable[int]) -> None:
         async for v in sigiter:
             pytest.fail("SIGUSR1 should not be sent")
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1,5 +1,7 @@
 import array
+import io
 import os
+import pathlib
 import platform
 import socket
 import sys
@@ -9,11 +11,12 @@ from contextlib import suppress
 from socket import AddressFamily
 from ssl import SSLContext, SSLError
 from threading import Thread
-from typing import Any, Iterator, List, Tuple, Type, Union
+from typing import Any, Iterable, Iterator, List, NoReturn, Tuple, Type, Union
 
 import pytest
 from _pytest.fixtures import SubRequest
 from _pytest.monkeypatch import MonkeyPatch
+from _pytest.tmpdir import TempPathFactory
 
 from anyio import (
     BrokenResourceError, BusyResourceError, ClosedResourceError, Event, ExceptionGroup,
@@ -28,12 +31,15 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
+AnyIPAddressFamily = Literal[AddressFamily.AF_UNSPEC, AddressFamily.AF_INET,
+                             AddressFamily.AF_INET6]
+
 pytestmark = pytest.mark.anyio
 
 
 @pytest.fixture
 def fake_localhost_dns(monkeypatch: MonkeyPatch) -> None:
-    def fake_getaddrinfo(*args, **kwargs):
+    def fake_getaddrinfo(*args: Any, **kwargs: Any) -> object:
         # Make it return IPv4 addresses first so we can test the IPv6 preference
         results = real_getaddrinfo(*args, **kwargs)
         return sorted(results, key=lambda item: item[0])
@@ -47,12 +53,12 @@ def fake_localhost_dns(monkeypatch: MonkeyPatch) -> None:
     pytest.param(AddressFamily.AF_INET6, id='ipv6',
                  marks=[pytest.mark.skipif(not socket.has_ipv6, reason='no IPv6 support')])
 ])
-def family(request: SubRequest) -> AddressFamily:
+def family(request: SubRequest) -> AnyIPAddressFamily:
     return request.param
 
 
 @pytest.fixture
-def check_asyncio_bug(anyio_backend_name, family):
+def check_asyncio_bug(anyio_backend_name: str, family: AnyIPAddressFamily) -> None:
     if (
         anyio_backend_name == 'asyncio'
         and sys.platform == 'win32'
@@ -66,7 +72,7 @@ def check_asyncio_bug(anyio_backend_name, family):
 
 class TestTCPStream:
     @pytest.fixture
-    def server_sock(self, family: AddressFamily) -> Iterator[socket.socket]:
+    def server_sock(self, family: AnyIPAddressFamily) -> Iterator[socket.socket]:
         sock = socket.socket(family, socket.SOCK_STREAM)
         sock.settimeout(1)
         sock.bind(('localhost', 0))
@@ -79,7 +85,8 @@ class TestTCPStream:
         return server_sock.getsockname()[:2]
 
     async def test_extra_attributes(self, server_sock: socket.socket,
-                                    server_addr: Tuple[str, int], family: AddressFamily) -> None:
+                                    server_addr: Tuple[str, int],
+                                    family: AnyIPAddressFamily) -> None:
         async with await connect_tcp(*server_addr) as stream:
             raw_socket = stream.extra(SocketAttribute.raw_socket)
             assert stream.extra(SocketAttribute.family) == family
@@ -102,7 +109,7 @@ class TestTCPStream:
 
     async def test_send_large_buffer(self, server_sock: socket.socket,
                                      server_addr: Tuple[str, int]) -> None:
-        def serve():
+        def serve() -> None:
             client, _ = server_sock.accept()
             client.sendall(buffer)
             client.close()
@@ -120,7 +127,7 @@ class TestTCPStream:
 
     async def test_send_eof(self, server_sock: socket.socket,
                             server_addr: Tuple[str, int]) -> None:
-        def serve():
+        def serve() -> None:
             client, _ = server_sock.accept()
             request = b''
             while True:
@@ -144,7 +151,7 @@ class TestTCPStream:
         assert response == b'\ndlrow ,olleh'
 
     async def test_iterate(self, server_sock: socket.socket, server_addr: Tuple[str, int]) -> None:
-        def serve():
+        def serve() -> None:
             client, _ = server_sock.accept()
             client.sendall(b'bl')
             event.wait(1)
@@ -163,7 +170,7 @@ class TestTCPStream:
         thread.join()
         assert chunks == [b'bl', b'ah']
 
-    async def test_socket_options(self, family: AddressFamily,
+    async def test_socket_options(self, family: AnyIPAddressFamily,
                                   server_addr: Tuple[str, int]) -> None:
         async with await connect_tcp(*server_addr) as stream:
             raw_socket = stream.extra(SocketAttribute.raw_socket)
@@ -179,7 +186,7 @@ class TestTCPStream:
                                   fake_localhost_dns: None) -> None:
         client_addr = None, None
 
-        def serve():
+        def serve() -> None:
             nonlocal client_addr
             client, client_addr = server_sock.accept()
             client.close()
@@ -228,7 +235,7 @@ class TestTCPStream:
 
     async def test_receive_timeout(self, server_sock: socket.socket,
                                    server_addr: Tuple[str, int]) -> None:
-        def serve():
+        def serve() -> None:
             conn, _ = server_sock.accept()
             time.sleep(1)
             conn.close()
@@ -244,7 +251,7 @@ class TestTCPStream:
                 pytest.fail('The timeout was not respected')
 
     async def test_concurrent_send(self, server_addr: Tuple[str, int]) -> None:
-        async def send_data():
+        async def send_data() -> NoReturn:
             while True:
                 await stream.send(b'\x00' * 4096)
 
@@ -272,7 +279,7 @@ class TestTCPStream:
                     tg.cancel_scope.cancel()
 
     async def test_close_during_receive(self, server_addr: Tuple[str, int]) -> None:
-        async def interrupt():
+        async def interrupt() -> None:
             await wait_all_tasks_blocked()
             await stream.aclose()
 
@@ -294,8 +301,8 @@ class TestTCPStream:
         with pytest.raises(ClosedResourceError):
             await stream.send(b'foo')
 
-    async def test_send_after_peer_closed(self, family: AddressFamily) -> None:
-        def serve_once():
+    async def test_send_after_peer_closed(self, family: AnyIPAddressFamily) -> None:
+        def serve_once() -> None:
             client_sock, _ = server_sock.accept()
             client_sock.close()
             server_sock.close()
@@ -318,7 +325,7 @@ class TestTCPStream:
     async def test_connect_tcp_with_tls(self, server_context: SSLContext,
                                         client_context: SSLContext, server_sock: socket.socket,
                                         server_addr: Tuple[str, int]) -> None:
-        def serve():
+        def serve() -> None:
             with suppress(socket.timeout):
                 client, addr = server_sock.accept()
                 client.settimeout(1)
@@ -344,7 +351,7 @@ class TestTCPStream:
                                                         server_addr: Tuple[str, int]) -> None:
         thread_exception = None
 
-        def serve():
+        def serve() -> None:
             nonlocal thread_exception
             client, addr = server_sock.accept()
             with client:
@@ -363,10 +370,6 @@ class TestTCPStream:
 
         thread.join()
         assert thread_exception is None
-
-
-AnyIPAddressFamily = Literal[AddressFamily.AF_UNSPEC, AddressFamily.AF_INET,
-                             AddressFamily.AF_INET6]
 
 
 class TestTCPListener:
@@ -466,8 +469,8 @@ class TestTCPListener:
                 await listener.aclose()
                 tg.cancel_scope.cancel()
 
-    async def test_send_after_eof(self, family):
-        async def handle(stream):
+    async def test_send_after_eof(self, family: AnyIPAddressFamily) -> None:
+        async def handle(stream: SocketStream) -> None:
             async with stream:
                 await stream.send(b'Hello\n')
 
@@ -497,11 +500,16 @@ class TestTCPListener:
                     reason='UNIX sockets are not available on Windows')
 class TestUNIXStream:
     @pytest.fixture
-    def socket_path(self, tmp_path_factory):
+    def socket_path(self, tmp_path_factory: TempPathFactory) -> pathlib.Path:
         return tmp_path_factory.mktemp('unix').joinpath('socket')
 
+    @pytest.fixture(params=[False, True], ids=["str", "path"])
+    def socket_path_or_str(self, request: SubRequest,
+                           socket_path: pathlib.Path) -> Union[pathlib.Path, str]:
+        return socket_path if request.param else str(socket_path)
+
     @pytest.fixture
-    def server_sock(self, socket_path):
+    def server_sock(self, socket_path: pathlib.Path) -> Iterable[socket.socket]:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.settimeout(1)
         sock.bind(str(socket_path))
@@ -509,7 +517,8 @@ class TestUNIXStream:
         yield sock
         sock.close()
 
-    async def test_extra_attributes(self, server_sock, socket_path):
+    async def test_extra_attributes(self, server_sock: socket.socket,
+                                    socket_path: pathlib.Path) -> None:
         async with await connect_unix(socket_path) as stream:
             raw_socket = stream.extra(SocketAttribute.raw_socket)
             assert stream.extra(SocketAttribute.family) == socket.AF_UNIX
@@ -518,9 +527,9 @@ class TestUNIXStream:
             pytest.raises(TypedAttributeLookupError, stream.extra, SocketAttribute.local_port)
             pytest.raises(TypedAttributeLookupError, stream.extra, SocketAttribute.remote_port)
 
-    @pytest.mark.parametrize('as_path', [False, True], ids=['str', 'path'])
-    async def test_send_receive(self, server_sock, socket_path, as_path):
-        async with await connect_unix(socket_path) as stream:
+    async def test_send_receive(self, server_sock: socket.socket,
+                                socket_path_or_str: Union[pathlib.Path, str]) -> None:
+        async with await connect_unix(socket_path_or_str) as stream:
             client, _ = server_sock.accept()
             await stream.send(b'blah')
             request = client.recv(100)
@@ -530,8 +539,9 @@ class TestUNIXStream:
 
         assert response == b'halb'
 
-    async def test_send_large_buffer(self, server_sock, socket_path):
-        def serve():
+    async def test_send_large_buffer(self, server_sock: socket.socket,
+                                     socket_path: pathlib.Path) -> None:
+        def serve() -> None:
             client, _ = server_sock.accept()
             client.sendall(buffer)
             client.close()
@@ -547,8 +557,9 @@ class TestUNIXStream:
         thread.join()
         assert response == buffer
 
-    async def test_receive_fds(self, server_sock, socket_path, tmp_path):
-        def serve():
+    async def test_receive_fds(self, server_sock: socket.socket,
+                               socket_path: pathlib.Path, tmp_path: pathlib.Path) -> None:
+        def serve() -> None:
             path1 = tmp_path / 'file1'
             path2 = tmp_path / 'file2'
             path1.write_text('Hello, ')
@@ -556,8 +567,9 @@ class TestUNIXStream:
             with path1.open() as file1, path2.open() as file2:
                 fdarray = array.array('i', [file1.fileno(), file2.fileno()])
                 client, _ = server_sock.accept()
+                cmsg = (socket.SOL_SOCKET, socket.SCM_RIGHTS, fdarray)
                 with client:
-                    client.sendmsg([b'test'], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fdarray)])
+                    client.sendmsg([b'test'], [cmsg])  # type: ignore[list-item]
 
         async with await connect_unix(socket_path) as stream:
             thread = Thread(target=serve, daemon=True)
@@ -573,7 +585,8 @@ class TestUNIXStream:
         assert message == b'test'
         assert text == 'Hello, World!'
 
-    async def test_receive_fds_bad_args(self, server_sock, socket_path):
+    async def test_receive_fds_bad_args(self, server_sock: socket.socket,
+                                        socket_path: pathlib.Path) -> None:
         async with await connect_unix(socket_path) as stream:
             for msglen in (-1, 'foo'):
                 with pytest.raises(ValueError, match='msglen must be a non-negative integer'):
@@ -583,8 +596,9 @@ class TestUNIXStream:
                 with pytest.raises(ValueError, match='maxfds must be a positive integer'):
                     await stream.receive_fds(0, maxfds)  # type: ignore[arg-type]
 
-    async def test_send_fds(self, server_sock, socket_path, tmp_path):
-        def serve():
+    async def test_send_fds(self, server_sock: socket.socket,
+                            socket_path: pathlib.Path, tmp_path: pathlib.Path) -> None:
+        def serve() -> None:
             fds = array.array('i')
             client, _ = server_sock.accept()
             msg, ancdata, *_ = client.recvmsg(10, socket.CMSG_LEN(2 * fds.itemsize))
@@ -607,14 +621,16 @@ class TestUNIXStream:
         path1.write_text('Hello, ')
         path2.write_text('World!')
         with path1.open() as file1, path2.open() as file2, fail_after(2):
+            assert isinstance(file1, io.TextIOWrapper)
+            assert isinstance(file2, io.TextIOWrapper)
             async with await connect_unix(socket_path) as stream:
                 thread = Thread(target=serve, daemon=True)
                 thread.start()
                 await stream.send_fds(b'test', [file1, file2])
                 thread.join()
 
-    async def test_send_eof(self, server_sock, socket_path):
-        def serve():
+    async def test_send_eof(self, server_sock: socket.socket, socket_path: pathlib.Path) -> None:
+        def serve() -> None:
             client, _ = server_sock.accept()
             request = b''
             while True:
@@ -637,8 +653,8 @@ class TestUNIXStream:
         thread.join()
         assert response == b'\ndlrow ,olleh'
 
-    async def test_iterate(self, server_sock, socket_path):
-        def serve():
+    async def test_iterate(self, server_sock: socket.socket, socket_path: pathlib.Path) -> None:
+        def serve() -> None:
             client, _ = server_sock.accept()
             client.sendall(b'bl')
             time.sleep(0.05)
@@ -655,7 +671,8 @@ class TestUNIXStream:
         thread.join()
         assert chunks == [b'bl', b'ah']
 
-    async def test_send_fds_bad_args(self, server_sock, socket_path):
+    async def test_send_fds_bad_args(self, server_sock: socket.socket,
+                                     socket_path: pathlib.Path) -> None:
         async with await connect_unix(socket_path) as stream:
             with pytest.raises(ValueError, match='message must not be empty'):
                 await stream.send_fds(b'', [0])
@@ -663,8 +680,9 @@ class TestUNIXStream:
             with pytest.raises(ValueError, match='fds must not be empty'):
                 await stream.send_fds(b'test', [])
 
-    async def test_concurrent_send(self, server_sock, socket_path):
-        async def send_data():
+    async def test_concurrent_send(self, server_sock: socket.socket,
+                                   socket_path: pathlib.Path) -> None:
+        async def send_data() -> NoReturn:
             while True:
                 await client.send(b'\x00' * 4096)
 
@@ -678,7 +696,8 @@ class TestUNIXStream:
                 exc.match('already writing to')
                 tg.cancel_scope.cancel()
 
-    async def test_concurrent_receive(self, server_sock, socket_path):
+    async def test_concurrent_receive(self, server_sock: socket.socket,
+                                      socket_path: pathlib.Path) -> None:
         async with await connect_unix(socket_path) as client:
             async with create_task_group() as tg:
                 tg.start_soon(client.receive)
@@ -691,8 +710,9 @@ class TestUNIXStream:
                 finally:
                     tg.cancel_scope.cancel()
 
-    async def test_close_during_receive(self, server_sock, socket_path):
-        async def interrupt():
+    async def test_close_during_receive(self, server_sock: socket.socket,
+                                        socket_path: pathlib.Path) -> None:
+        async def interrupt() -> None:
             await wait_all_tasks_blocked()
             await stream.aclose()
 
@@ -702,13 +722,15 @@ class TestUNIXStream:
                 with pytest.raises(ClosedResourceError):
                     await stream.receive()
 
-    async def test_receive_after_close(self, server_sock, socket_path):
+    async def test_receive_after_close(self, server_sock: socket.socket,
+                                       socket_path: pathlib.Path) -> None:
         stream = await connect_unix(socket_path)
         await stream.aclose()
         with pytest.raises(ClosedResourceError):
             await stream.receive()
 
-    async def test_send_after_close(self, server_sock, socket_path):
+    async def test_send_after_close(self, server_sock: socket.socket,
+                                    socket_path: pathlib.Path) -> None:
         stream = await connect_unix(socket_path)
         await stream.aclose()
         with pytest.raises(ClosedResourceError):
@@ -719,10 +741,15 @@ class TestUNIXStream:
                     reason='UNIX sockets are not available on Windows')
 class TestUNIXListener:
     @pytest.fixture
-    def socket_path(self, tmp_path_factory):
+    def socket_path(self, tmp_path_factory: TempPathFactory) -> pathlib.Path:
         return tmp_path_factory.mktemp('unix').joinpath('socket')
 
-    async def test_extra_attributes(self, socket_path):
+    @pytest.fixture(params=[False, True], ids=["str", "path"])
+    def socket_path_or_str(self, request: SubRequest,
+                           socket_path: pathlib.Path) -> Union[pathlib.Path, str]:
+        return socket_path if request.param else str(socket_path)
+
+    async def test_extra_attributes(self, socket_path: pathlib.Path) -> None:
         async with await create_unix_listener(socket_path) as listener:
             raw_socket = listener.extra(SocketAttribute.raw_socket)
             assert listener.extra(SocketAttribute.family) == socket.AF_UNIX
@@ -732,15 +759,11 @@ class TestUNIXListener:
                           SocketAttribute.remote_address)
             pytest.raises(TypedAttributeLookupError, listener.extra, SocketAttribute.remote_port)
 
-    @pytest.mark.parametrize('as_path', [False, True], ids=['str', 'path'])
-    async def test_accept(self, socket_path, as_path):
-        if not as_path:
-            socket_path = str(socket_path)
-
-        async with await create_unix_listener(socket_path) as listener:
+    async def test_accept(self, socket_path_or_str: Union[pathlib.Path, str]) -> None:
+        async with await create_unix_listener(socket_path_or_str) as listener:
             client = socket.socket(socket.AF_UNIX)
             client.settimeout(1)
-            client.connect(str(socket_path))
+            client.connect(str(socket_path_or_str))
             stream = await listener.accept()
             client.sendall(b'blah')
             request = await stream.receive()
@@ -749,7 +772,7 @@ class TestUNIXListener:
             client.close()
             await stream.aclose()
 
-    async def test_socket_options(self, socket_path):
+    async def test_socket_options(self, socket_path: pathlib.Path) -> None:
         async with await create_unix_listener(socket_path) as listener:
             listener_socket = listener.extra(SocketAttribute.raw_socket)
             assert listener_socket.family == socket.AddressFamily.AF_UNIX
@@ -766,8 +789,8 @@ class TestUNIXListener:
 
             client.close()
 
-    async def test_send_after_eof(self, socket_path):
-        async def handle(stream):
+    async def test_send_after_eof(self, socket_path: pathlib.Path) -> None:
+        async def handle(stream: SocketStream) -> None:
             async with stream:
                 await stream.send(b'Hello\n')
 
@@ -791,7 +814,7 @@ class TestUNIXListener:
 
             tg.cancel_scope.cancel()
 
-    async def test_bind_twice(self, socket_path):
+    async def test_bind_twice(self, socket_path: pathlib.Path) -> None:
         """Test that the previous socket is removed before binding to the path."""
         for _ in range(2):
             async with await create_unix_listener(socket_path):
@@ -801,8 +824,8 @@ class TestUNIXListener:
 IPSockAddrType = Tuple[str, int]
 
 
-async def test_multi_listener(tmp_path_factory: Any) -> None:
-    async def handle(stream):
+async def test_multi_listener(tmp_path_factory: TempPathFactory) -> None:
+    async def handle(stream: SocketStream) -> None:
         client_addresses.append(stream.extra(SocketAttribute.remote_address))
         event.set()
         await stream.aclose()
@@ -839,7 +862,7 @@ async def test_multi_listener(tmp_path_factory: Any) -> None:
 
 @pytest.mark.usefixtures('check_asyncio_bug')
 class TestUDPSocket:
-    async def test_extra_attributes(self, family):
+    async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:
         async with await create_udp_socket(family=family, local_host='localhost') as udp:
             raw_socket = udp.extra(SocketAttribute.raw_socket)
             assert udp.extra(SocketAttribute.family) == family
@@ -848,7 +871,7 @@ class TestUDPSocket:
             pytest.raises(TypedAttributeLookupError, udp.extra, SocketAttribute.remote_address)
             pytest.raises(TypedAttributeLookupError, udp.extra, SocketAttribute.remote_port)
 
-    async def test_send_receive(self, family):
+    async def test_send_receive(self, family: AnyIPAddressFamily) -> None:
         async with await create_udp_socket(local_host='localhost', family=family) as sock:
             host, port = sock.extra(SocketAttribute.local_address)  # type: ignore[misc]
             await sock.sendto(b'blah', host, port)
@@ -861,8 +884,8 @@ class TestUDPSocket:
             assert response == b'halb'
             assert addr == (host, port)
 
-    async def test_iterate(self, family):
-        async def serve():
+    async def test_iterate(self, family: AnyIPAddressFamily) -> None:
+        async def serve() -> None:
             async for packet, addr in server:
                 await server.send((packet[::-1], addr))
 
@@ -879,7 +902,7 @@ class TestUDPSocket:
 
     @pytest.mark.skipif(not hasattr(socket, "SO_REUSEPORT"),
                         reason='SO_REUSEPORT option not supported')
-    async def test_reuse_port(self, family):
+    async def test_reuse_port(self, family: AnyIPAddressFamily) -> None:
         async with await create_udp_socket(family=family, local_host='localhost',
                                            reuse_port=True) as udp:
             port = udp.extra(SocketAttribute.local_port)
@@ -888,7 +911,7 @@ class TestUDPSocket:
                                                local_port=port, reuse_port=True) as udp2:
                 assert port == udp2.extra(SocketAttribute.local_port)
 
-    async def test_concurrent_receive(self):
+    async def test_concurrent_receive(self) -> None:
         async with await create_udp_socket(family=AddressFamily.AF_INET,
                                            local_host='localhost') as udp:
             async with create_task_group() as tg:
@@ -902,8 +925,8 @@ class TestUDPSocket:
                 finally:
                     tg.cancel_scope.cancel()
 
-    async def test_close_during_receive(self):
-        async def close_when_blocked():
+    async def test_close_during_receive(self) -> None:
+        async def close_when_blocked() -> None:
             await wait_all_tasks_blocked()
             await udp.aclose()
 
@@ -914,13 +937,13 @@ class TestUDPSocket:
                 with pytest.raises(ClosedResourceError):
                     await udp.receive()
 
-    async def test_receive_after_close(self):
+    async def test_receive_after_close(self) -> None:
         udp = await create_udp_socket(family=AddressFamily.AF_INET, local_host='localhost')
         await udp.aclose()
         with pytest.raises(ClosedResourceError):
             await udp.receive()
 
-    async def test_send_after_close(self):
+    async def test_send_after_close(self) -> None:
         udp = await create_udp_socket(family=AddressFamily.AF_INET, local_host='localhost')
         host, port = udp.extra(SocketAttribute.local_address)  # type: ignore[misc]
         await udp.aclose()
@@ -930,7 +953,7 @@ class TestUDPSocket:
 
 @pytest.mark.usefixtures('check_asyncio_bug')
 class TestConnectedUDPSocket:
-    async def test_extra_attributes(self, family):
+    async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:
         async with await create_connected_udp_socket('localhost', 5000, family=family) as udp:
             raw_socket = udp.extra(SocketAttribute.raw_socket)
             assert udp.extra(SocketAttribute.family) == family
@@ -939,7 +962,7 @@ class TestConnectedUDPSocket:
             assert udp.extra(SocketAttribute.remote_address) == raw_socket.getpeername()[:2]
             assert udp.extra(SocketAttribute.remote_port) == 5000
 
-    async def test_send_receive(self, family):
+    async def test_send_receive(self, family: AnyIPAddressFamily) -> None:
         async with await create_udp_socket(family=family, local_host='localhost') as udp1:
             host, port = udp1.extra(SocketAttribute.local_address)  # type: ignore[misc]
             async with await create_connected_udp_socket(
@@ -953,8 +976,8 @@ class TestConnectedUDPSocket:
                 response = await udp2.receive()
                 assert response == b'halb'
 
-    async def test_iterate(self, family):
-        async def serve():
+    async def test_iterate(self, family: AnyIPAddressFamily) -> None:
+        async def serve() -> None:
             async for packet in udp2:
                 await udp2.send(packet[::-1])
 
@@ -972,7 +995,7 @@ class TestConnectedUDPSocket:
 
     @pytest.mark.skipif(not hasattr(socket, "SO_REUSEPORT"),
                         reason='SO_REUSEPORT option not supported')
-    async def test_reuse_port(self, family):
+    async def test_reuse_port(self, family: AnyIPAddressFamily) -> None:
         async with await create_connected_udp_socket(
                 'localhost', 6000, family=family, local_host='localhost', reuse_port=True) as udp:
             port = udp.extra(SocketAttribute.local_port)
@@ -982,7 +1005,7 @@ class TestConnectedUDPSocket:
                     reuse_port=True) as udp2:
                 assert port == udp2.extra(SocketAttribute.local_port)
 
-    async def test_concurrent_receive(self):
+    async def test_concurrent_receive(self) -> None:
         async with await create_connected_udp_socket(
                 'localhost', 5000, local_host='localhost', family=AddressFamily.AF_INET) as udp:
             async with create_task_group() as tg:
@@ -996,8 +1019,8 @@ class TestConnectedUDPSocket:
                 finally:
                     tg.cancel_scope.cancel()
 
-    async def test_close_during_receive(self):
-        async def close_when_blocked():
+    async def test_close_during_receive(self) -> None:
+        async def close_when_blocked() -> None:
             await wait_all_tasks_blocked()
             await udp.aclose()
 
@@ -1008,14 +1031,14 @@ class TestConnectedUDPSocket:
                 with pytest.raises(ClosedResourceError):
                     await udp.receive()
 
-    async def test_receive_after_close(self, family):
+    async def test_receive_after_close(self, family: AnyIPAddressFamily) -> None:
         udp = await create_connected_udp_socket('localhost', 5000, local_host='localhost',
                                                 family=family)
         await udp.aclose()
         with pytest.raises(ClosedResourceError):
             await udp.receive()
 
-    async def test_send_after_close(self, family):
+    async def test_send_after_close(self, family: AnyIPAddressFamily) -> None:
         udp = await create_connected_udp_socket('localhost', 5000, local_host='localhost',
                                                 family=family)
         await udp.aclose()
@@ -1024,7 +1047,7 @@ class TestConnectedUDPSocket:
 
 
 @pytest.mark.network
-async def test_getaddrinfo():
+async def test_getaddrinfo() -> None:
     # IDNA 2003 gets this wrong
     correct = await getaddrinfo('faß.de', 0)
     wrong = await getaddrinfo('fass.de', 0)
@@ -1032,7 +1055,7 @@ async def test_getaddrinfo():
 
 
 @pytest.mark.parametrize('sock_type', [socket.SOCK_STREAM, socket.SocketKind.SOCK_STREAM])
-async def test_getaddrinfo_ipv6addr(sock_type):
+async def test_getaddrinfo_ipv6addr(sock_type: Literal[socket.SocketKind.SOCK_STREAM]) -> None:
     # IDNA trips up over raw IPv6 addresses
     proto = 0 if platform.system() == 'Windows' else 6
     assert await getaddrinfo('::1', 0, type=sock_type) == [
@@ -1040,7 +1063,7 @@ async def test_getaddrinfo_ipv6addr(sock_type):
     ]
 
 
-async def test_getnameinfo():
+async def test_getnameinfo() -> None:
     expected_result = socket.getnameinfo(('127.0.0.1', 6666), 0)
     result = await getnameinfo(('127.0.0.1', 6666))
     assert result == expected_result

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -1,7 +1,7 @@
 import os
-import pathlib
 import platform
 import sys
+from pathlib import Path
 from subprocess import CalledProcessError
 from textwrap import dedent
 from typing import List, Union
@@ -48,7 +48,7 @@ async def test_run_process_checked() -> None:
 
 @pytest.mark.skipif(platform.system() == 'Windows',
                     reason='process.terminate() kills the process instantly on Windows')
-async def test_terminate(tmp_path: pathlib.Path) -> None:
+async def test_terminate(tmp_path: Path) -> None:
     script_path = tmp_path / 'script.py'
     script_path.write_text(dedent("""\
         import signal, sys, time
@@ -71,7 +71,7 @@ async def test_terminate(tmp_path: pathlib.Path) -> None:
         assert await process.wait() == 2
 
 
-async def test_process_cwd(tmp_path: pathlib.Path) -> None:
+async def test_process_cwd(tmp_path: Path) -> None:
     """Test that `cwd` is successfully passed to the subprocess implementation"""
     cmd = [sys.executable, "-c", "import os; print(os.getcwd())"]
     result = await run_process(cmd, cwd=tmp_path)

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -58,7 +58,9 @@ async def test_terminate(tmp_path):
         time.sleep(5)
     """))
     async with await open_process([sys.executable, str(script_path)]) as process:
-        buffered_stdout = BufferedByteReceiveStream(process.stdout)
+        stdout = process.stdout
+        assert stdout is not None
+        buffered_stdout = BufferedByteReceiveStream(stdout)
         line = await buffered_stdout.receive_until(b'\n', 100)
         assert line.rstrip() == b'ready'
 

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pytest
 
 from anyio import (
@@ -9,8 +11,8 @@ pytestmark = pytest.mark.anyio
 
 
 class TestLock:
-    async def test_contextmanager(self):
-        async def task():
+    async def test_contextmanager(self) -> None:
+        async def task() -> None:
             assert lock.locked()
             async with lock:
                 results.append('2')
@@ -26,8 +28,8 @@ class TestLock:
         assert not lock.locked()
         assert results == ['1', '2']
 
-    async def test_manual_acquire(self):
-        async def task():
+    async def test_manual_acquire(self) -> None:
+        async def task() -> None:
             assert lock.locked()
             await lock.acquire()
             try:
@@ -49,13 +51,13 @@ class TestLock:
         assert not lock.locked()
         assert results == ['1', '2']
 
-    async def test_acquire_nowait(self):
+    async def test_acquire_nowait(self) -> None:
         lock = Lock()
         lock.acquire_nowait()
         assert lock.locked()
 
-    async def test_acquire_nowait_wouldblock(self):
-        async def try_lock():
+    async def test_acquire_nowait_wouldblock(self) -> None:
+        async def try_lock() -> None:
             pytest.raises(WouldBlock, lock.acquire_nowait)
 
         lock = Lock()
@@ -63,10 +65,10 @@ class TestLock:
             assert lock.locked()
             tg.start_soon(try_lock)
 
-    async def test_cancel(self):
+    async def test_cancel(self) -> None:
         task_started = got_lock = False
 
-        async def task():
+        async def task() -> None:
             nonlocal task_started, got_lock
             task_started = True
             async with lock:
@@ -81,8 +83,8 @@ class TestLock:
         assert task_started
         assert not got_lock
 
-    async def test_statistics(self):
-        async def waiter():
+    async def test_statistics(self) -> None:
+        async def waiter() -> None:
             async with lock:
                 pass
 
@@ -103,8 +105,8 @@ class TestLock:
 
 
 class TestEvent:
-    async def test_event(self):
-        async def setter():
+    async def test_event(self) -> None:
+        async def setter() -> None:
             assert not event.is_set()
             event.set()
 
@@ -115,10 +117,10 @@ class TestEvent:
 
         assert event.is_set()
 
-    async def test_event_cancel(self):
+    async def test_event_cancel(self) -> None:
         task_started = event_set = False
 
-        async def task():
+        async def task() -> None:
             nonlocal task_started, event_set
             task_started = True
             await event.wait()
@@ -133,8 +135,8 @@ class TestEvent:
         assert task_started
         assert not event_set
 
-    async def test_statistics(self):
-        async def waiter():
+    async def test_statistics(self) -> None:
+        async def waiter() -> None:
             await event.wait()
 
         event = Event()
@@ -151,8 +153,8 @@ class TestEvent:
 
 
 class TestCondition:
-    async def test_contextmanager(self):
-        async def notifier():
+    async def test_contextmanager(self) -> None:
+        async def notifier() -> None:
             async with condition:
                 condition.notify_all()
 
@@ -163,8 +165,8 @@ class TestCondition:
                 tg.start_soon(notifier)
                 await condition.wait()
 
-    async def test_manual_acquire(self):
-        async def notifier():
+    async def test_manual_acquire(self) -> None:
+        async def notifier() -> None:
             await condition.acquire()
             try:
                 condition.notify_all()
@@ -181,13 +183,13 @@ class TestCondition:
             finally:
                 condition.release()
 
-    async def test_acquire_nowait(self):
+    async def test_acquire_nowait(self) -> None:
         condition = Condition()
         condition.acquire_nowait()
         assert condition.locked()
 
-    async def test_acquire_nowait_wouldblock(self):
-        async def try_lock():
+    async def test_acquire_nowait_wouldblock(self) -> None:
+        async def try_lock() -> None:
             pytest.raises(WouldBlock, condition.acquire_nowait)
 
         condition = Condition()
@@ -195,10 +197,10 @@ class TestCondition:
             assert condition.locked()
             tg.start_soon(try_lock)
 
-    async def test_wait_cancel(self):
+    async def test_wait_cancel(self) -> None:
         task_started = notified = False
 
-        async def task():
+        async def task() -> None:
             nonlocal task_started, notified
             task_started = True
             async with condition:
@@ -217,8 +219,8 @@ class TestCondition:
         assert task_started
         assert not notified
 
-    async def test_statistics(self):
-        async def waiter():
+    async def test_statistics(self) -> None:
+        async def waiter() -> None:
             async with condition:
                 await condition.wait()
 
@@ -247,8 +249,8 @@ class TestCondition:
 
 
 class TestSemaphore:
-    async def test_contextmanager(self):
-        async def acquire():
+    async def test_contextmanager(self) -> None:
+        async def acquire() -> None:
             async with semaphore:
                 assert semaphore.value in (0, 1)
 
@@ -259,8 +261,8 @@ class TestSemaphore:
 
         assert semaphore.value == 2
 
-    async def test_manual_acquire(self):
-        async def acquire():
+    async def test_manual_acquire(self) -> None:
+        async def acquire() -> None:
             await semaphore.acquire()
             try:
                 assert semaphore.value in (0, 1)
@@ -274,16 +276,16 @@ class TestSemaphore:
 
         assert semaphore.value == 2
 
-    async def test_acquire_nowait(self):
+    async def test_acquire_nowait(self) -> None:
         semaphore = Semaphore(1)
         semaphore.acquire_nowait()
         assert semaphore.value == 0
         pytest.raises(WouldBlock, semaphore.acquire_nowait)
 
-    async def test_acquire_cancel(self):
+    async def test_acquire_cancel(self) -> None:
         local_scope = acquired = None
 
-        async def task():
+        async def task() -> None:
             nonlocal local_scope, acquired
             with CancelScope() as local_scope:
                 async with semaphore:
@@ -300,17 +302,17 @@ class TestSemaphore:
         assert not acquired
 
     @pytest.mark.parametrize('max_value', [2, None])
-    async def test_max_value(self, max_value):
+    async def test_max_value(self, max_value: Optional[int]) -> None:
         semaphore = Semaphore(0, max_value=max_value)
         assert semaphore.max_value == max_value
 
-    async def test_max_value_exceeded(self):
+    async def test_max_value_exceeded(self) -> None:
         semaphore = Semaphore(1, max_value=2)
         semaphore.release()
         pytest.raises(ValueError, semaphore.release)
 
-    async def test_statistics(self):
-        async def waiter():
+    async def test_statistics(self) -> None:
+        async def waiter() -> None:
             async with semaphore:
                 pass
 
@@ -326,7 +328,7 @@ class TestSemaphore:
 
         assert semaphore.statistics().tasks_waiting == 0
 
-    async def test_acquire_race(self):
+    async def test_acquire_race(self) -> None:
         """
         Test against a race condition: when a task waiting on acquire() is rescheduled but another
         task snatches the last available slot, the task should not raise WouldBlock.
@@ -342,15 +344,15 @@ class TestSemaphore:
 
 
 class TestCapacityLimiter:
-    async def test_bad_init_type(self):
+    async def test_bad_init_type(self) -> None:
         pytest.raises(TypeError, CapacityLimiter, 1.0).\
             match('total_tokens must be an int or math.inf')
 
-    async def test_bad_init_value(self):
+    async def test_bad_init_value(self) -> None:
         pytest.raises(ValueError, CapacityLimiter, 0).\
             match('total_tokens must be >= 1')
 
-    async def test_borrow(self):
+    async def test_borrow(self) -> None:
         limiter = CapacityLimiter(2)
         assert limiter.total_tokens == 2
         assert limiter.available_tokens == 2
@@ -360,10 +362,10 @@ class TestCapacityLimiter:
             assert limiter.available_tokens == 1
             assert limiter.borrowed_tokens == 1
 
-    async def test_limit(self):
+    async def test_limit(self) -> None:
         value = 0
 
-        async def taskfunc():
+        async def taskfunc() -> None:
             nonlocal value
             for _ in range(5):
                 async with limiter:
@@ -377,7 +379,7 @@ class TestCapacityLimiter:
             for _ in range(3):
                 tg.start_soon(taskfunc)
 
-    async def test_borrow_twice(self):
+    async def test_borrow_twice(self) -> None:
         limiter = CapacityLimiter(1)
         await limiter.acquire()
         with pytest.raises(RuntimeError) as exc:
@@ -385,22 +387,22 @@ class TestCapacityLimiter:
 
         exc.match("this borrower is already holding one of this CapacityLimiter's tokens")
 
-    async def test_bad_release(self):
+    async def test_bad_release(self) -> None:
         limiter = CapacityLimiter(1)
         with pytest.raises(RuntimeError) as exc:
             limiter.release()
 
         exc.match("this borrower isn't holding any of this CapacityLimiter's tokens")
 
-    async def test_increase_tokens(self):
-        async def setter():
+    async def test_increase_tokens(self) -> None:
+        async def setter() -> None:
             # Wait until waiter() is inside the limiter block
             await event1.wait()
             async with limiter:
                 # This can only happen when total_tokens has been increased
                 event2.set()
 
-        async def waiter():
+        async def waiter() -> None:
             async with limiter:
                 event1.set()
                 await event2.wait()
@@ -417,13 +419,13 @@ class TestCapacityLimiter:
 
         assert event2.is_set()
 
-    async def test_current_default_thread_limiter(self):
+    async def test_current_default_thread_limiter(self) -> None:
         limiter = to_thread.current_default_thread_limiter()
         assert isinstance(limiter, CapacityLimiter)
         assert limiter.total_tokens == 40
 
-    async def test_statistics(self):
-        async def waiter():
+    async def test_statistics(self) -> None:
+        async def waiter() -> None:
             async with limiter:
                 pass
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -98,8 +98,8 @@ async def test_start_no_value() -> None:
         assert value is None
 
 
-async def test_start_called_twice():
-    async def taskfunc(*, task_status):
+async def test_start_called_twice() -> None:
+    async def taskfunc(*, task_status: TaskStatus) -> None:
         task_status.started()
 
         with pytest.raises(RuntimeError,

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -12,14 +12,14 @@ pytestmark = pytest.mark.anyio
 
 
 @pytest.fixture(autouse=True)
-def check_compatibility(anyio_backend_name):
+def check_compatibility(anyio_backend_name: str) -> None:
     if anyio_backend_name == 'asyncio':
         if platform.system() == 'Windows' and sys.version_info < (3, 8):
             pytest.skip('Python < 3.8 uses SelectorEventLoop by default and it does not support '
                         'subprocesses')
 
 
-async def test_run_sync_in_process_pool():
+async def test_run_sync_in_process_pool() -> None:
     """
     Test that the function runs in a different process, and the same process in both calls.
 
@@ -29,23 +29,23 @@ async def test_run_sync_in_process_pool():
     assert await to_process.run_sync(os.getpid) == worker_pid
 
 
-async def test_identical_sys_path():
+async def test_identical_sys_path() -> None:
     """Test that partial() can be used to pass keyword arguments."""
     assert await to_process.run_sync(eval, 'sys.path') == sys.path
 
 
-async def test_partial():
+async def test_partial() -> None:
     """Test that partial() can be used to pass keyword arguments."""
     assert await to_process.run_sync(partial(sorted, reverse=True), ['a', 'b']) == ['b', 'a']
 
 
-async def test_exception():
+async def test_exception() -> None:
     """Test that exceptions are delivered properly."""
     with pytest.raises(ValueError, match='invalid literal for int'):
         assert await to_process.run_sync(int, 'a')
 
 
-async def test_print():
+async def test_print() -> None:
     """Test that print() won't interfere with parent-worker communication."""
     worker_pid = await to_process.run_sync(os.getpid)
     await to_process.run_sync(print, 'hello')
@@ -53,7 +53,7 @@ async def test_print():
     assert await to_process.run_sync(os.getpid) == worker_pid
 
 
-async def test_cancel_before():
+async def test_cancel_before() -> None:
     """
     Test that starting to_process.run_sync() in a cancelled scope does not cause a worker
     process to be reserved.
@@ -66,7 +66,7 @@ async def test_cancel_before():
     pytest.raises(LookupError, to_process._process_pool_workers.get)
 
 
-async def test_cancel_during():
+async def test_cancel_during() -> None:
     """
     Test that cancelling an operation on the worker process causes the process to be killed.
 

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -3,7 +3,7 @@ import sys
 import threading
 import time
 from functools import partial
-from typing import List, Optional
+from typing import Any, List, NoReturn, Optional
 
 import pytest
 
@@ -19,14 +19,14 @@ else:
 pytestmark = pytest.mark.anyio
 
 
-async def test_run_in_thread_cancelled():
+async def test_run_in_thread_cancelled() -> None:
     state = 0
 
-    def thread_worker():
+    def thread_worker() -> None:
         nonlocal state
         state = 2
 
-    async def worker():
+    async def worker() -> None:
         nonlocal state
         state = 1
         await to_thread.run_sync(thread_worker)
@@ -39,8 +39,8 @@ async def test_run_in_thread_cancelled():
     assert state == 1
 
 
-async def test_run_in_thread_exception():
-    def thread_worker():
+async def test_run_in_thread_exception() -> None:
+    def thread_worker() -> NoReturn:
         raise ValueError('foo')
 
     with pytest.raises(ValueError) as exc:
@@ -49,17 +49,17 @@ async def test_run_in_thread_exception():
     exc.match('^foo$')
 
 
-async def test_run_in_custom_limiter():
+async def test_run_in_custom_limiter() -> None:
     num_active_threads = max_active_threads = 0
 
-    def thread_worker():
+    def thread_worker() -> None:
         nonlocal num_active_threads, max_active_threads
         num_active_threads += 1
         max_active_threads = max(num_active_threads, max_active_threads)
         event.wait(1)
         num_active_threads -= 1
 
-    async def task_worker():
+    async def task_worker() -> None:
         await to_thread.run_sync(thread_worker, limiter=limiter)
 
     event = threading.Event()
@@ -81,7 +81,7 @@ async def test_run_in_custom_limiter():
     (False, 'task'),
     (True, 'thread')
 ], ids=['uncancellable', 'cancellable'])
-async def test_cancel_worker_thread(cancellable, expected_last_active):
+async def test_cancel_worker_thread(cancellable: bool, expected_last_active: str) -> None:
     """
     Test that when a task running a worker thread is cancelled, the cancellation is not acted on
     until the thread finishes.
@@ -89,14 +89,14 @@ async def test_cancel_worker_thread(cancellable, expected_last_active):
     """
     last_active: Optional[str] = None
 
-    def thread_worker():
+    def thread_worker() -> None:
         nonlocal last_active
         from_thread.run_sync(sleep_event.set)
         time.sleep(0.2)
         last_active = 'thread'
         from_thread.run_sync(finish_event.set)
 
-    async def task_worker():
+    async def task_worker() -> None:
         nonlocal last_active
         try:
             await to_thread.run_sync(thread_worker, cancellable=cancellable)
@@ -115,10 +115,10 @@ async def test_cancel_worker_thread(cancellable, expected_last_active):
 
 
 @pytest.mark.parametrize('anyio_backend', ['asyncio'])
-async def test_asyncio_cancel_native_task():
+async def test_asyncio_cancel_native_task() -> None:
     task: "Optional[asyncio.Task[None]]" = None
 
-    async def run_in_thread():
+    async def run_in_thread() -> None:
         nonlocal task
         task = current_task()
         await to_thread.run_sync(time.sleep, 0.2, cancellable=True)
@@ -130,7 +130,7 @@ async def test_asyncio_cancel_native_task():
         task.cancel()
 
 
-def test_asyncio_no_root_task(asyncio_event_loop):
+def test_asyncio_no_root_task(asyncio_event_loop: asyncio.AbstractEventLoop) -> None:
     """
     Regression test for #264.
 
@@ -139,7 +139,7 @@ def test_asyncio_no_root_task(asyncio_event_loop):
     that, uses the current task to set up a shutdown callback.
 
     """
-    async def run_in_thread():
+    async def run_in_thread() -> None:
         try:
             await to_thread.run_sync(time.sleep, 0)
         finally:
@@ -156,17 +156,17 @@ def test_asyncio_no_root_task(asyncio_event_loop):
             assert not t.is_alive()
 
 
-def test_asyncio_future_callback_partial(asyncio_event_loop):
+def test_asyncio_future_callback_partial(asyncio_event_loop: asyncio.AbstractEventLoop) -> None:
     """
     Regression test for #272.
 
     Ensures that futures with partial callbacks are handled correctly when the root task
     cannot be determined.
     """
-    def func(future):
+    def func(future: object) -> None:
         pass
 
-    async def sleep_sync():
+    async def sleep_sync() -> None:
         return await to_thread.run_sync(time.sleep, 0)
 
     task = asyncio_event_loop.create_task(sleep_sync())
@@ -174,9 +174,9 @@ def test_asyncio_future_callback_partial(asyncio_event_loop):
     asyncio_event_loop.run_until_complete(task)
 
 
-def test_asyncio_run_sync_no_asyncio_run(asyncio_event_loop):
+def test_asyncio_run_sync_no_asyncio_run(asyncio_event_loop: asyncio.AbstractEventLoop) -> None:
     """Test that the thread pool shutdown callback does not raise an exception."""
-    def exception_handler(loop, context=None):
+    def exception_handler(loop: object, context: Any = None) -> None:
         exceptions.append(context['exception'])
 
     exceptions: List[BaseException] = []

--- a/tox.ini
+++ b/tox.ini
@@ -35,5 +35,5 @@ skip_install = true
 basepython = python3.8
 deps = mypy
 extras = test
-commands = mypy {posargs} .
+commands = mypy {posargs} src tests docs
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,5 @@ skip_install = true
 basepython = python3.8
 deps = mypy
 extras = test
-    trio
 commands = mypy {posargs} .
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -34,5 +34,7 @@ skip_install = true
 [testenv:mypy]
 basepython = python3.8
 deps = mypy
-commands = mypy {posargs} src
+extras = test
+    trio
+commands = mypy {posargs} .
 skip_install = true


### PR DESCRIPTION
* Fixed the type annotation of open_signal_receiver() as a synchronous context manager
* ~Fixed the type annotations of `AsyncFile.__aiter__`, `readline`, `write` to also accept/return `str`
  and also fixed `AsyncFile.writelines` to take an `Iterable[str|bytes]` rather than `bytes`.~
* Fixed `DeprecatedAwaitable(|List|Float).__await__` to match the `typing.Awaitable` protocol