### PR TITLE
Remove usage of socket.SocketType

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1268,8 +1268,10 @@ class UNIXSocketStream(abc.SocketStream):
                 try:
                     # The ignore can be removed after mypy picks up
                     # https://github.com/python/typeshed/pull/5545
-                    self.__raw_socket.sendmsg([message],
-                                              [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fdarray)])  # type: ignore
+                    self.__raw_socket.sendmsg(
+                        [message],
+                        [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fdarray)]  # type: ignore
+                    )
                     break
                 except BlockingIOError:
                     await self._wait_until_writable(loop)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -14,7 +14,7 @@ from inspect import (
 from io import IOBase
 from os import PathLike
 from queue import Queue
-from socket import AddressFamily, SocketKind, SocketType
+from socket import AddressFamily, SocketKind
 from threading import Thread
 from types import TracebackType
 from typing import (
@@ -1139,14 +1139,14 @@ class UNIXSocketStream(abc.SocketStream):
     _send_future: Optional[asyncio.Future] = None
     _closing = False
 
-    def __init__(self, raw_socket: socket.SocketType):
+    def __init__(self, raw_socket: socket.socket):
         self.__raw_socket = raw_socket
         self._loop = get_running_loop()
         self._receive_guard = ResourceGuard('reading from')
         self._send_guard = ResourceGuard('writing to')
 
     @property
-    def _raw_socket(self) -> SocketType:
+    def _raw_socket(self) -> socket.socket:
         return self.__raw_socket
 
     def _wait_until_readable(self, loop: asyncio.AbstractEventLoop) -> asyncio.Future:
@@ -1293,7 +1293,7 @@ class TCPSocketListener(abc.SocketListener):
     _accept_scope: Optional[CancelScope] = None
     _closed = False
 
-    def __init__(self, raw_socket: socket.SocketType):
+    def __init__(self, raw_socket: socket.socket):
         self.__raw_socket = raw_socket
         self._loop = cast(asyncio.BaseEventLoop, get_running_loop())
         self._accept_guard = ResourceGuard('accepting connections from')
@@ -1348,7 +1348,7 @@ class TCPSocketListener(abc.SocketListener):
 
 
 class UNIXSocketListener(abc.SocketListener):
-    def __init__(self, raw_socket: socket.SocketType):
+    def __init__(self, raw_socket: socket.socket):
         self.__raw_socket = raw_socket
         self._loop = get_running_loop()
         self._accept_guard = ResourceGuard('accepting connections from')
@@ -1377,7 +1377,7 @@ class UNIXSocketListener(abc.SocketListener):
         self.__raw_socket.close()
 
     @property
-    def _raw_socket(self) -> SocketType:
+    def _raw_socket(self) -> socket.socket:
         return self.__raw_socket
 
 
@@ -1390,7 +1390,7 @@ class UDPSocket(abc.UDPSocket):
         self._closed = False
 
     @property
-    def _raw_socket(self) -> SocketType:
+    def _raw_socket(self) -> socket.socket:
         return self._transport.get_extra_info('socket')
 
     async def aclose(self) -> None:
@@ -1436,7 +1436,7 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
         self._closed = False
 
     @property
-    def _raw_socket(self) -> SocketType:
+    def _raw_socket(self) -> socket.socket:
         return self._transport.get_extra_info('socket')
 
     async def aclose(self) -> None:
@@ -1541,7 +1541,7 @@ _read_events: RunVar[Dict[Any, asyncio.Event]] = RunVar('read_events')
 _write_events: RunVar[Dict[Any, asyncio.Event]] = RunVar('write_events')
 
 
-async def wait_socket_readable(sock: socket.SocketType) -> None:
+async def wait_socket_readable(sock: socket.socket) -> None:
     await checkpoint()
     try:
         read_events = _read_events.get()
@@ -1568,7 +1568,7 @@ async def wait_socket_readable(sock: socket.SocketType) -> None:
         raise ClosedResourceError
 
 
-async def wait_socket_writable(sock: socket.SocketType) -> None:
+async def wait_socket_writable(sock: socket.socket) -> None:
     await checkpoint()
     try:
         write_events = _write_events.get()

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1240,7 +1240,7 @@ class UNIXSocketStream(abc.SocketStream):
 
         for cmsg_level, cmsg_type, cmsg_data in ancdata:
             if cmsg_level != socket.SOL_SOCKET or cmsg_type != socket.SCM_RIGHTS:
-                raise RuntimeError(f'Received unexpected ancillary data; message = {message}, '
+                raise RuntimeError(f'Received unexpected ancillary data; message = {message!r}, '
                                    f'cmsg_level = {cmsg_level}, cmsg_type = {cmsg_type}')
 
             fds.frombytes(cmsg_data[:len(cmsg_data) - (len(cmsg_data) % fds.itemsize)])
@@ -1266,8 +1266,10 @@ class UNIXSocketStream(abc.SocketStream):
         with self._send_guard:
             while True:
                 try:
+                    # The ignore can be removed after mypy picks up
+                    # https://github.com/python/typeshed/pull/5545
                     self.__raw_socket.sendmsg([message],
-                                              [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fdarray)])
+                                              [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fdarray)])  # type: ignore
                     break
                 except BlockingIOError:
                     await self._wait_until_writable(loop)

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -443,7 +443,7 @@ class UNIXSocketStream(SocketStream, abc.UNIXSocketStream):
 
 
 class TCPSocketListener(_TrioSocketMixin, abc.SocketListener):
-    def __init__(self, raw_socket: socket.SocketType):
+    def __init__(self, raw_socket: socket.socket):
         super().__init__(trio.socket.from_stdlib_socket(raw_socket))
         self._accept_guard = ResourceGuard('accepting connections from')
 
@@ -459,7 +459,7 @@ class TCPSocketListener(_TrioSocketMixin, abc.SocketListener):
 
 
 class UNIXSocketListener(_TrioSocketMixin, abc.SocketListener):
-    def __init__(self, raw_socket: socket.SocketType):
+    def __init__(self, raw_socket: socket.socket):
         super().__init__(trio.socket.from_stdlib_socket(raw_socket))
         self._accept_guard = ResourceGuard('accepting connections from')
 
@@ -569,7 +569,7 @@ getaddrinfo = trio.socket.getaddrinfo
 getnameinfo = trio.socket.getnameinfo
 
 
-async def wait_socket_readable(sock: socket.SocketType) -> None:
+async def wait_socket_readable(sock: socket.socket) -> None:
     try:
         await wait_readable(sock)
     except trio.ClosedResourceError as exc:
@@ -578,7 +578,7 @@ async def wait_socket_readable(sock: socket.SocketType) -> None:
         raise BusyResourceError('reading from') from None
 
 
-async def wait_socket_writable(sock: socket.SocketType) -> None:
+async def wait_socket_writable(sock: socket.socket) -> None:
     try:
         await wait_writable(sock)
     except trio.ClosedResourceError as exc:

--- a/src/anyio/_core/_typedattr.py
+++ b/src/anyio/_core/_typedattr.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Callable, Mapping, TypeVar, Union, overload
+from typing import Any, Callable, Dict, Mapping, TypeVar, Union, overload
 
 from ._exceptions import TypedAttributeLookupError
 
@@ -26,7 +26,7 @@ class TypedAttributeSet:
     """
 
     def __init_subclass__(cls) -> None:
-        annotations = getattr(cls, '__annotations__', {})
+        annotations: Dict[str, Any] = getattr(cls, '__annotations__', {})
         for attrname in dir(cls):
             if not attrname.startswith('_') and attrname not in annotations:
                 raise TypeError(f'Attribute {attrname!r} is missing its type annotation')

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -1,11 +1,12 @@
 from abc import abstractmethod
 from io import IOBase
 from ipaddress import IPv4Address, IPv6Address
-from socket import AddressFamily, SocketType
+import socket
+from socket import AddressFamily
 from types import TracebackType
 from typing import (
-    Any, AsyncContextManager, Callable, Collection, List, Mapping, Optional, Tuple, Type, TypeVar,
-    Union)
+    Any, AsyncContextManager, Callable, Collection, Dict, List, Mapping, Optional, Tuple, Type,
+    TypeVar, Union)
 
 from .._core._typedattr import TypedAttributeProvider, TypedAttributeSet, typed_attribute
 from ._streams import ByteStream, Listener, T_Stream, UnreliableObjectStream
@@ -36,7 +37,7 @@ class SocketAttribute(TypedAttributeSet):
     #: for IP addresses, the local port the underlying socket is bound to
     local_port: int = typed_attribute()
     #: the underlying stdlib socket object
-    raw_socket: SocketType = typed_attribute()
+    raw_socket: socket.socket = typed_attribute()
     #: the remote address the underlying socket is connected to
     remote_address: SockAddrType = typed_attribute()
     #: for IP addresses, the remote port the underlying socket is connected to
@@ -48,7 +49,7 @@ class _SocketProvider(TypedAttributeProvider):
     def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         from .._core._sockets import convert_ipv6_sockaddr as convert
 
-        attributes = {
+        attributes: Dict[Any, Callable[[], Any]] = {
             SocketAttribute.family: lambda: self._raw_socket.family,
             SocketAttribute.local_address: lambda: convert(self._raw_socket.getsockname()),
             SocketAttribute.raw_socket: lambda: self._raw_socket
@@ -73,7 +74,7 @@ class _SocketProvider(TypedAttributeProvider):
 
     @property
     @abstractmethod
-    def _raw_socket(self) -> SocketType:
+    def _raw_socket(self) -> socket.socket:
         pass
 
 

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -1,7 +1,7 @@
+import socket
 from abc import abstractmethod
 from io import IOBase
 from ipaddress import IPv4Address, IPv6Address
-import socket
 from socket import AddressFamily
 from types import TracebackType
 from typing import (


### PR DESCRIPTION
SocketType is an alias for the private `_socket.socket` class, a superclass of `socket.socket`. It is better to just always use `socket.socket` in types. See https://bugs.python.org/issue44261 and python/typeshed#5545 for some context.