### PR TITLE
Fixed to_thread.run_sync() hanging on asyncio with run_until_complete()

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed ``to_thread.run_sync()`` hanging on the second call on asyncio when used with
+  ``loop.run_until_complete()``
 - Fixed the type annotation of ``open_signal_receiver()`` as a synchronous context manager
 - Fixed the type annotation of ``DeprecatedAwaitable(|List|Float).__await__`` to match the ``typing.Awaitable`` protocol
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -136,7 +136,7 @@ _root_task: RunVar[Optional[asyncio.Task]] = RunVar('_root_task')
 
 
 def find_root_task() -> asyncio.Task:
-    root_task: Optional[asyncio.Task] = _root_task.get(None)  # type: ignore[arg-type]
+    root_task = _root_task.get(None)
     if root_task is not None and not root_task.done():
         return root_task
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -136,21 +136,18 @@ _root_task: RunVar[Optional[asyncio.Task]] = RunVar('_root_task')
 
 
 def find_root_task() -> asyncio.Task:
-    try:
-        root_task = _root_task.get()
-    except LookupError:
-        for task in all_tasks():
-            if task._callbacks:
-                for cb in _get_task_callbacks(task):
-                    if (cb is _run_until_complete_cb
-                            or getattr(cb, '__module__', None) == 'uvloop.loop'):
-                        _root_task.set(task)
-                        return task
+    root_task: Optional[asyncio.Task] = _root_task.get(None)  # type: ignore[arg-type]
+    if root_task is not None and not root_task.done():
+        return root_task
 
-        _root_task.set(None)
-    else:
-        if root_task is not None:
-            return root_task
+    # Look for a task that has been started via run_until_complete()
+    for task in all_tasks():
+        if task._callbacks and not task.done():
+            for cb in _get_task_callbacks(task):
+                if (cb is _run_until_complete_cb
+                        or getattr(cb, '__module__', None) == 'uvloop.loop'):
+                    _root_task.set(task)
+                    return task
 
     # Look up the topmost task in the AnyIO task tree, if possible
     task = cast(asyncio.Task, current_task())
@@ -791,6 +788,7 @@ async def run_sync_in_worker_thread(
             try:
                 return await future
             finally:
+                assert worker.is_alive()
                 worker.idle_since = current_time()
                 idle_workers.append(worker)
 

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -190,3 +190,8 @@ def test_asyncio_run_sync_multiple(asyncio_event_loop: asyncio.AbstractEventLoop
     asyncio_event_loop.call_later(0.5, asyncio_event_loop.stop)
     for _ in range(3):
         asyncio_event_loop.run_until_complete(to_thread.run_sync(time.sleep, 0))
+
+    for t in threading.enumerate():
+        if t.name == 'AnyIO worker thread':
+            t.join(2)
+            assert not t.is_alive()

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -183,3 +183,10 @@ def test_asyncio_run_sync_no_asyncio_run(asyncio_event_loop: asyncio.AbstractEve
     asyncio_event_loop.set_exception_handler(exception_handler)
     asyncio_event_loop.run_until_complete(to_thread.run_sync(time.sleep, 0))
     assert not exceptions
+
+
+def test_asyncio_run_sync_multiple(asyncio_event_loop: asyncio.AbstractEventLoop) -> None:
+    """Regression test for #304."""
+    asyncio_event_loop.call_later(0.5, asyncio_event_loop.stop)
+    for _ in range(3):
+        asyncio_event_loop.run_until_complete(to_thread.run_sync(time.sleep, 0))


### PR DESCRIPTION
This was due to find_root_task() returning a finished task.

Fixes #304.