### PR TITLE
Added .close() to memory streams

### DIFF
--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -67,6 +67,14 @@ Example::
 
     run(main)
 
+In contrast to other AnyIO streams (but in line with trio's Channels), memory object streams can be
+closed synchronously, using either the ``close()`` method or by using the stream as a context
+manager::
+
+    def synchronous_callback(send_stream: MemoryObjectSendStream) -> None:
+        with stream:
+            stream.send_nowait('hello')
+
 Stapled streams
 ---------------
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added the ability to close memory object streams synchronously (including support for use as a
+  synchronous context manager)
 - Fixed ``to_thread.run_sync()`` hanging on the second call on asyncio when used with
   ``loop.run_until_complete()``
 - Fixed the type annotation of ``open_signal_receiver()`` as a synchronous context manager

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -320,3 +320,15 @@ async def test_statistics() -> None:
         assert stream.statistics().current_buffer_used == 0
         assert stream.statistics().tasks_waiting_send == 0
         assert stream.statistics().tasks_waiting_receive == 0
+
+
+async def test_sync_close():
+    send_stream, receive_stream = create_memory_object_stream(1)
+    with send_stream, receive_stream:
+        pass
+
+    with pytest.raises(ClosedResourceError):
+        send_stream.send_nowait(None)
+
+    with pytest.raises(ClosedResourceError):
+        receive_stream.receive_nowait()

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -322,7 +322,7 @@ async def test_statistics() -> None:
         assert stream.statistics().tasks_waiting_receive == 0
 
 
-async def test_sync_close():
+async def test_sync_close() -> None:
     send_stream, receive_stream = create_memory_object_stream(1)
     with send_stream, receive_stream:
         pass


### PR DESCRIPTION
Trio's channels can be closed synchronously, so it would be reasonable for memory object streams to have the same ability.