### PR TITLE
Document calling non-threadsafe primitives from threads

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -8,6 +8,8 @@ against your modified code. Before making a pull request, you should ensure that
 passes tests locally. To that end, the use of tox_ is recommended. The default tox run first runs
 code style fixing tools and then the actual test suite. To only run the code style fixers, run
 ``tox -e lint``. To run the checks on all environments in parallel, invoke tox with ``tox -p``.
+To build the documentation, run ``tox -e docs`` which will generate a directory named ``build``
+in which you may view the formatted HTML documentation.
 
 The use of pre-commit_ is also highly recommended. You can find a sample configuration file at the
 root of the repository.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -8,6 +8,7 @@ against your modified code. Before making a pull request, you should ensure that
 passes tests locally. To that end, the use of tox_ is recommended. The default tox run first runs
 code style fixing tools and then the actual test suite. To only run the code style fixers, run
 ``tox -e lint``. To run the checks on all environments in parallel, invoke tox with ``tox -p``.
+
 To build the documentation, run ``tox -e docs`` which will generate a directory named ``build``
 in which you may view the formatted HTML documentation.
 

--- a/docs/synchronization.rst
+++ b/docs/synchronization.rst
@@ -7,6 +7,9 @@ Synchronization primitives are objects that are used by tasks to communicate and
 each other. They are useful for things like distributing workload, notifying other tasks and
 guarding access to shared resources.
 
+.. note:: AnyIO primitives are not thread-safe, therefore they should not be used directly from
+          worker threads.  Use :func:`~from_thread.run_sync` for that.
+
 Events
 ------
 

--- a/docs/threads.rst
+++ b/docs/threads.rst
@@ -53,6 +53,28 @@ If you need to call a coroutine function from a worker thread, you can do this::
 .. note:: The worker thread must have been spawned using :func:`~run_sync_in_worker_thread`
    for this to work.
 
+Calling synchronous code from a worker thread
+---------------------------------------------
+
+AnyIO primitives should not be assumed thread-safe, therefore they should not be used directly
+from worker threads.  It is important to call synchronous code using :func:`~from_thread.run_sync`
+when inside a worker thread::
+
+    import time
+
+    from anyio import Event, from_thread, to_thread, run
+
+    def worker(event):
+        time.sleep(1)
+        from_thread.run_sync(event.set)
+
+    async def main():
+        event = Event()
+        await to_thread.run_sync(worker, event)
+        await event.wait()
+
+    run(main)
+
 Calling asynchronous code from an external thread
 -------------------------------------------------
 

--- a/docs/threads.rst
+++ b/docs/threads.rst
@@ -56,7 +56,10 @@ If you need to call a coroutine function from a worker thread, you can do this::
 Calling synchronous code from a worker thread
 ---------------------------------------------
 
-Occasionally you may need to call synchronous code in the event loop thread from a worker thread. Common cases include setting asynchronous events or sending data to a memory object stream. Because these methods aren't thread safe, you need to arrange them to be called inside the event loop thread using :func:`~from_thread.run_sync`::
+Occasionally you may need to call synchronous code in the event loop thread from a worker thread.
+Common cases include setting asynchronous events or sending data to a memory object stream.
+Because these methods aren't thread safe, you need to arrange them to be called inside the event
+loop thread using :func:`~from_thread.run_sync`::
 
     import time
 

--- a/docs/threads.rst
+++ b/docs/threads.rst
@@ -56,9 +56,7 @@ If you need to call a coroutine function from a worker thread, you can do this::
 Calling synchronous code from a worker thread
 ---------------------------------------------
 
-AnyIO primitives should not be assumed thread-safe, therefore they should not be used directly
-from worker threads.  It is important to call synchronous code using :func:`~from_thread.run_sync`
-when inside a worker thread::
+Occasionally you may need to call synchronous code in the event loop thread from a worker thread. Common cases include setting asynchronous events or sending data to a memory object stream. Because these methods aren't thread safe, you need to arrange them to be called inside the event loop thread using :func:`~from_thread.run_sync`::
 
     import time
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,4 +40,4 @@ skip_install = true
 
 [testenv:docs]
 extras = doc
-commands = sphinx-build docs docs/_build
+commands = sphinx-build docs

--- a/tox.ini
+++ b/tox.ini
@@ -37,3 +37,7 @@ deps = mypy >= 0.900
 extras = test
 commands = mypy --install-types {posargs} src tests
 skip_install = true
+
+[testenv:docs]
+extras = doc
+commands = sphinx-build docs docs/_build

--- a/tox.ini
+++ b/tox.ini
@@ -40,4 +40,4 @@ skip_install = true
 
 [testenv:docs]
 extras = doc
-commands = sphinx-build docs
+commands = sphinx-build docs build

--- a/tox.ini
+++ b/tox.ini
@@ -40,4 +40,4 @@ skip_install = true
 
 [testenv:docs]
 extras = doc
-commands = sphinx-build docs build
+commands = sphinx-build docs build/sphinx


### PR DESCRIPTION
This also adds a `docs` environment to tox so that the documentation can easily be built locally with `tox -e docs`