### PR TITLE
Spawn worker threads with daemon=True on asyncio

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -704,7 +704,7 @@ class WorkerThread(Thread):
 
     def __init__(self, root_task: asyncio.Task, workers: Set['WorkerThread'],
                  idle_workers: Deque['WorkerThread'],):
-        super().__init__(name='AnyIO worker thread')
+        super().__init__(name='AnyIO worker thread', daemon=True)
         self.root_task = root_task
         self.workers = workers
         self.idle_workers = idle_workers


### PR DESCRIPTION
This was added in https://github.com/agronholm/anyio/pull/81/commits/635e25adf8e35b920110cdc0f0c07112c2ade8ff:
https://github.com/agronholm/anyio/blob/635e25adf8e35b920110cdc0f0c07112c2ade8ff/anyio/_backends/_asyncio.py#L413
And removed in #227:
https://github.com/agronholm/anyio/blob/77759c8bc303b70934c423bea2ef0267795b182b/src/anyio/_backends/_asyncio.py#L717

Fixes https://github.com/jupyterlab/jupyterlab/issues/10442