### PR TITLE
propagate native cancel during task group exit

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -547,8 +547,9 @@ class TaskGroup(abc.TaskGroup):
         while self.cancel_scope._tasks:
             try:
                 await asyncio.wait(self.cancel_scope._tasks)
-            except asyncio.CancelledError:
+            except asyncio.CancelledError as e:
                 self.cancel_scope.cancel()
+                self._exceptions.append(e)
 
         self._active = False
         if not self.cancel_scope._parent_cancelled():


### PR DESCRIPTION
Fixes #374 