### PR TITLE
Fix cancel scope stack corruption when combining @asynccontextmanager and wrap_async_context_manager.

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,6 +8,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed race condition in ``Lock`` and ``Semaphore`` classes when a task waiting on ``acquire()``
   is cancelled while another task is waiting to acquire the same primitive
   (`#387 <https://github.com/agronholm/anyio/issues/387>`_)
+- Fixed async context manager's ``__aexit__()`` method not being called in
+  ``BlockingPortal.wrap_async_context_manager()`` if the host task is cancelled
+  (`#381 <https://github.com/agronholm/anyio/issues/381>`_)
 
 **3.3.4**
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ anyio = py.typed
 [options.extras_require]
 test =
     mock >= 4; python_version < '3.8'
+    contextlib2; python_version < '3.7'
     coverage[toml] >= 4.5
     hypothesis >= 4.0
     pytest >= 6.0

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -335,8 +335,8 @@ class TestBlockingPortal:
                 tg.start_soon(failing_func)
                 yield
 
-        with pytest.raises(ZeroDivisionError):
-            with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
+        with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
+            with pytest.raises(ZeroDivisionError):
                 with portal.wrap_async_context_manager(run_in_context()):
                     pass
 


### PR DESCRIPTION

See: https://github.com/agronholm/anyio/issues/381