### PR TITLE
✨ Add alternative APIs that improve typing and tooling support (e.g. autocompletion)

### DIFF
--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -1,14 +1,21 @@
+import functools
 import typing
 from abc import ABCMeta, abstractmethod
 from types import TracebackType
 from typing import Any, Callable, Coroutine, Optional, Type, TypeVar
 from warnings import warn
+import sys
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
 
 if typing.TYPE_CHECKING:
     from anyio._core._tasks import CancelScope
 
 T_Retval = TypeVar('T_Retval')
-
+T_ParamSpec = ParamSpec("T_ParamSpec")
 
 class TaskStatus(metaclass=ABCMeta):
     @abstractmethod
@@ -47,6 +54,36 @@ class TaskGroup(metaclass=ABCMeta):
         warn('spawn() is deprecated -- use start_soon() (without the "await") instead',
              DeprecationWarning)
         self.start_soon(func, *args, name=name)
+
+    def soonify(self, func: Callable[T_ParamSpec, Coroutine[Any, Any, Any]],
+                name: object = None) -> Callable[T_ParamSpec, None]:
+        """
+        Create and return a function that when called will start a new task in this
+        task group.
+
+        Internally it uses the same ``task_group.start_soon()`` method. But 
+        ``task_group.soonify()`` supports keyword arguments additional to positional
+        arguments and it adds better support for autocompletion and inline errors
+        for the arguments of the function called.
+
+        Use it like this:
+
+            async def do_work(arg1, arg2, kwarg1="", kwarg2=""):
+                # Do work
+
+            task_group.soonify(some_async_func)("spam", "ham", kwarg1="a", kwarg2="b")
+
+        :param func: a coroutine function
+        :param name: name of the task, for the purposes of introspection and debugging
+        :return: a function that takes positional and keyword arguments and when called
+            uses task_group.start_soon() to start the task in this task group.
+
+        .. versionadded:: 3.4.1
+        """
+        def wrapper(*args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs) -> None:
+            partial_f = functools.partial(func, *args, **kwargs)
+            return self.start_soon(partial_f, name=name)
+        return wrapper
 
     @abstractmethod
     def start_soon(self, func: Callable[..., Coroutine[Any, Any, Any]],

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -71,7 +71,7 @@ class TaskGroup(metaclass=ABCMeta):
             async def do_work(arg1, arg2, kwarg1="", kwarg2=""):
                 # Do work
 
-            task_group.soonify(some_async_func)("spam", "ham", kwarg1="a", kwarg2="b")
+            task_group.soonify(do_work)("spam", "ham", kwarg1="a", kwarg2="b")
 
         :param func: a coroutine function
         :param name: name of the task, for the purposes of introspection and debugging

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -1,10 +1,10 @@
 import functools
+import sys
 import typing
 from abc import ABCMeta, abstractmethod
 from types import TracebackType
 from typing import Any, Callable, Coroutine, Optional, Type, TypeVar
 from warnings import warn
-import sys
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
@@ -16,6 +16,7 @@ if typing.TYPE_CHECKING:
 
 T_Retval = TypeVar('T_Retval')
 T_ParamSpec = ParamSpec("T_ParamSpec")
+
 
 class TaskStatus(metaclass=ABCMeta):
     @abstractmethod
@@ -61,7 +62,7 @@ class TaskGroup(metaclass=ABCMeta):
         Create and return a function that when called will start a new task in this
         task group.
 
-        Internally it uses the same ``task_group.start_soon()`` method. But 
+        Internally it uses the same ``task_group.start_soon()`` method. But
         ``task_group.soonify()`` supports keyword arguments additional to positional
         arguments and it adds better support for autocompletion and inline errors
         for the arguments of the function called.

--- a/src/anyio/to_thread.py
+++ b/src/anyio/to_thread.py
@@ -1,10 +1,59 @@
-from typing import Callable, Optional, TypeVar
+import functools
+import sys
+from typing import Awaitable, Callable, Optional, TypeVar
 from warnings import warn
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
 
 from ._core._eventloop import get_asynclib
 from .abc import CapacityLimiter
 
-T_Retval = TypeVar('T_Retval')
+T_Retval = TypeVar("T_Retval")
+T_ParamSpec = ParamSpec("T_ParamSpec")
+
+
+def asyncify(
+    func: Callable[T_ParamSpec, T_Retval],
+    *,
+    cancellable: bool = False,
+    limiter: Optional[CapacityLimiter] = None
+) -> Callable[T_ParamSpec, Awaitable[T_Retval]]:
+    """
+    Take the given blocking function and create an async one that receives the same
+    positional and keyword arguments, and that when called, calls the original function
+    in a worker thread using ``to_thread.run_sync()``. Internally,
+    ``to_thread.asyncify()`` uses the same ``to_thread.run_sync()``, but it supports
+    keyword arguments additional to positional arguments and it adds better support for
+    autocompletion and inline errors for the arguments of the function called.
+
+
+    If the ``cancellable`` option is enabled and the task waiting for its completion is cancelled,
+    the thread will still run its course but its return value (or any raised exception) will be
+    ignored.
+
+    Use it like this:
+
+        def do_work(arg1, arg2, kwarg1="", kwarg2=""):
+            # Do work
+
+        result = await to_thread.asyncify(do_work)("spam", "ham", kwarg1="a", kwarg2="b")
+
+    :param func: a callable
+    :param cancellable: ``True`` to allow cancellation of the operation
+    :param limiter: capacity limiter to use to limit the total amount of threads running
+        (if omitted, the default limiter is used)
+    :return: an async function that takes the same positional and keyword arguments
+        as the original one, that when called runs the same original function in a
+        thread worker and returns the result.
+
+    """
+    async def wrapper(*args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs) -> T_Retval:
+        partial_f = functools.partial(func, *args, **kwargs)
+        return await run_sync(partial_f, cancellable=cancellable, limiter=limiter)
+    return wrapper
 
 
 async def run_sync(


### PR DESCRIPTION
✨ Add alternative APIs that improve typing and tooling support (e.g. autocompletion in editors)

## Description

I want to propose adding a new API style for three functions (additional to the current API) that would take advantage of new type annotations ([PEP 612 - Parameter Specification Variables](https://www.python.org/dev/peps/pep-0612/)), to get better tooling and editor support.

In particular, this would allow/support **mypy** checks, **inline editor errors**, and ✨ **autocompletion** ✨ for positional and **keyword arguments** for:

* Sending async tasks in a task group (equivalent to `tg.start_soon()`)
* Sending blocking tasks to a worker thread (equivalent to `to_thread.run_sync()`)
* Sending async tasks to the main async loop from a worker thread (equivalent to `from_thread.run()`)

This would also allow mypy and editors to provide type checks, autocompletion, etc. for the **return values** received when sending tasks to a worker thread and when receiving them from a worker thread:

* Equivalent to `to_thread.run_sync()`
* Equivalent to `from_thread.run()`

## Usage

The main difference is that instead of having a function that takes the function to call plus:

* positional arguments (and that requires using partials for keyword arguments)
* configs (like task name)

```Python
anyio_function(worker_function, arg1, arg2)
```

...this new API only takes the function to call plus configs (like the task name), and then *returns* another function that takes the positional and keyword arguments. And when that function is called, it does the actual work. So it's used like this:

```Python
anyio_functionify(worker_function)(arg1, arg2)
```

And now it also supports keyword arguments, not only positional ones, so it's not necessary to use (and understand) partials to use keyword arguments:

```Python
anyio_functionify(worker_function)(arg1, arg2, kwarg1="a", kwarg2="b")
```

## Examples

### Task Groups

```Python
from typing import Any
import anyio


async def program() -> Any:
    async def worker(i: int, message: str = "Default worker"):
        print(f"{message} - worker {i}")

    async with anyio.create_task_group() as tg:
        for i in range(3):
            tg.soonify(worker)(i=i, message="Hello ")


anyio.run(program)
```

* Autocompletion for task group:

![Selection_009](https://user-images.githubusercontent.com/1326112/147146908-a8ec0b99-a4c3-40bc-9d9a-f3b32d90cb7e.png)

* Inline errors for task group:

![Selection_010](https://user-images.githubusercontent.com/1326112/147147410-9ac56f17-62e2-4f4c-83ed-c13838fa3de8.png)

* Mypy error detection:

```
main.py:11: error: Too few arguments
Found 1 error in 1 file (checked 1 source file)
```

### To Thread (asyncify)

```Python
import time
import anyio


def run_slow(i: int, message: str = "Hello ") -> str:
    time.sleep(i)
    return message + str(i)


async def program() -> None:
    for i in range(3):
        result = await anyio.to_thread.asyncify(run_slow)(i=i)
        result + 3
        print(result)


anyio.run(program)
```

* Autocompletion for sending to worker thread:

![Selection_019](https://user-images.githubusercontent.com/1326112/147149090-f65871e2-f633-431d-9702-6ab9d9ffc2e0.png)

* Inline errors for sending to worker thread:

![Selection_020](https://user-images.githubusercontent.com/1326112/147149111-3d3bbfc3-4bff-4c88-bf44-bd376e962b11.png)

* Autocompletion for result value:

![Selection_021](https://user-images.githubusercontent.com/1326112/147149233-0a97c532-3787-4acc-9eca-1ae495e6b2dd.png)

* Inline errors for result value:

![Selection_022](https://user-images.githubusercontent.com/1326112/147149294-5bb0d360-c473-4282-a487-fde9cbb11ee1.png)

* Mypy error detection:

```
main.py:12: error: Too few arguments
main.py:13: error: Unsupported operand types for + ("str" and "int")
```

### From Thread (syncify)

```Python
import anyio


async def aio_run_slow(i: int, message: str = "Async Hello ") -> str:
    await anyio.sleep(i)
    return message + str(i)


def run_slow_embed(i: int) -> str:
    result = anyio.from_thread.syncify(aio_run_slow)(i=i, message="Hello sincify ")
    return result


async def program() -> None:
    for i in range(3):
        result = await anyio.to_thread.asyncify(run_slow_embed)(i=i)
        result + 3
        print(result)


anyio.run(program)
```

* Autocompletion for sending from worker thread:

![Selection_027](https://user-images.githubusercontent.com/1326112/147149871-d2c6d537-2bfe-47e6-99e4-743ae9f68fee.png)

* Inline errors for sending from worker thread:

![Selection_028](https://user-images.githubusercontent.com/1326112/147149911-f9abb7ee-dce2-42cd-a30b-7cc0ea2153f8.png)

* Autocompletion for result value:

![Selection_030](https://user-images.githubusercontent.com/1326112/147150092-222aad09-b6fc-4521-a79a-714c18c716e0.png)

* Inline errors for result value:

![Selection_031](https://user-images.githubusercontent.com/1326112/147150121-907df4f2-dfe3-41e7-81f2-ef71a9ff53e5.png)

* Mypy error detection:

```
main.py:10: error: Too few arguments
main.py:17: error: Unsupported operand types for + ("str" and "int")
```

## Function names Bikeshedding

I wanted to have short function names that were descriptive enough, that's why the "somethingify".

I thought any more descriptive variant like `generate_async_function_that_calls_run_sync` would be too long. :sweat_smile: 

My rationale is that if a user wants to call a blocking function while inside async stuff, the user might want to have a way to "asyncify" that blocking function. And also the "somethingify" doesn't imply it is being executed/called right away, but that something is "converted" in some way. I would hope that would help with the intuition that it just returns another function that is then called, so it's necessary to add the extra chained parenthesis with any possible needed arguments.

But of course, I can change the names if there's another preference.

## Tests and Docs

I want to gather feedback first before writing tests and docs, but I'll add them if this or something like this is acceptable.

## Note on FastAPI

I want to have this type of interface for users and myself, I use autocompletion and tooling/types a lot. I thought of adding something like this to FastAPI itself, but I think this would really belong here, not in FastAPI.

I also intend to add it to the FastAPI docs to explain "advanced" use cases with concurrency and blocking code in threads run from async code, etc. I would like to **document** all those things **in FastAPI** referring to and explaining **AnyIO directly**, instead of writing wrappers in FastAPI or anything else. :nerd_face: 

**2022-01-08 Edit**

I see this (in particular taking kwargs) is quite debated, even more in Trio. And I know this is a somewhat drastic change, so I built a small package ([Asyncer](https://github.com/tiangolo/asyncer)) just with these functions and a couple of extra things. I documented it as temporary (in case these things land here) and very subjective (to my point of view).

Maybe that could help gauge how useful that API style is for Trio and AnyIO before making any commitments, in a safer way. I don't like the feel of "yet another library", but it might help separate what is more stable (Trio and AnyIO) and what is a Frankenstein temporary experiment (this idea(s) I'm proposing). I'm mentioning it here just for completeness, just in case.