### PR TITLE
Add ability to set `Semaphore.max_value` at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 build
 dist
+venv
 docs/_build
 __pycache__
 .coverage

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,6 +8,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed deadlock in synchronization primitives on asyncio which can happen if a task acquiring a
   primitive is hit with a native (not AnyIO) cancellation with just the right timing, leaving the
   next acquiring task waiting forever (`#398 <https://github.com/agronholm/anyio/issues/398>`_)
+- Added ability to set the ``max_value`` of ``Semaphore`` during runtime.
 
 **3.4.0**
 

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -376,7 +376,7 @@ class Semaphore:
             return
 
         if not isinstance(value, int) or value < 0:
-            raise TypeError('max_value must be an integer or None and >= 0')
+            raise TypeError('max_value must be an integer >= 0 or None')
 
         self._value = value - (self._max_value - self._value)
         self._max_value = value

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -350,12 +350,24 @@ class Semaphore:
 
     @property
     def max_value(self) -> Optional[int]:
-        """The maximum value of the semaphore."""
+        """The maximum value of the semaphore.
+
+        The `max_value` can be changed at runtime. When `max_value` is changed, `value` is changed
+        accordingly with equally many acquired tokens.
+
+        An example of this is if `max_value` is set to `10` and `value` is `2`, then if `max_value`
+        is set to `5`, `value` will be changed to `5 - (10 - 2) == -3`.
+
+        A limitation of this is that if `max_value` is None this behavior cannot be guaranteed and
+        will instead raise a `RuntimeError`.
+
+        When `value` is negative and a token is released no other task will be notified until
+        `value` is positive again.
+        """
         return self._max_value
 
     @max_value.setter
     def max_value(self, value: Optional[int]) -> None:
-        """Set the maximum value of the semaphore."""
         if self._max_value is None:
             raise RuntimeError('Cannot safely set max_value with unknown acquired values')
 

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -349,6 +349,27 @@ class TestSemaphore:
         semaphore.release()
         pytest.raises(ValueError, semaphore.release)
 
+    async def test_release_max_value_set(self) -> None:
+        semaphore = Semaphore(3, max_value=3)
+
+        semaphore.acquire_nowait()
+        semaphore.acquire_nowait()
+
+        semaphore.max_value = 1
+        assert semaphore.max_value == 1
+
+        # If max_value wasn't adjusted this would not have blocked
+        pytest.raises(WouldBlock, semaphore.acquire_nowait)
+
+        semaphore.release()
+        semaphore.release()
+
+        # All the acquired tokens have been released,
+        # this should be at max_value and as such fail
+        pytest.raises(ValueError, semaphore.release)
+
+        assert semaphore.value == 1
+
     async def test_statistics(self) -> None:
         async def waiter() -> None:
             async with semaphore:


### PR DESCRIPTION
## Summary

This pull requests adds a setter to `max_value` that will adjust the current- and max value.

## Considerations

Currently ``max_value`` can't be changed if it is set to None, because then the guarantee that all currently acquired tokens can be released will be broken. This *could* be fixed with an internal `_acquired` integer which counts how many tokens are acquired, would that be better than raising `RuntimeError`?