### PR TITLE
allow non-coroutine awaitbales in to_thread

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,11 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Added support for non-coroutine awaitables in BlockingPortal
+  (`#416 <https://github.com/agronholm/anyio/issues/416>`_)
+
 **3.5.0**
 
 - Added ``start_new_session`` keyword argument to ``run_process()`` and ``open_process()``

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -1,6 +1,5 @@
 import sys
 import threading
-from asyncio import iscoroutine
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import AbstractContextManager, contextmanager
 from inspect import isawaitable
@@ -195,9 +194,7 @@ class BlockingPortal:
 
         try:
             retval = func(*args, **kwargs)
-            if iscoroutine(retval) or (
-                isawaitable(retval) and not isinstance(retval, DeprecatedAwaitable)
-            ):
+            if isawaitable(retval) and not isinstance(retval, DeprecatedAwaitable):
                 with CancelScope() as scope:
                     if future.cancelled():
                         scope.cancel()


### PR DESCRIPTION
For [#1453](https://github.com/encode/starlette/pull/1453), specifically allowing `starlette.endpoints.HTTPEndpoint` to be returned as the object to be `await`ed