### PR TITLE
Python 3.11: @asyncio.coroutine decorator no longer available

### DIFF
--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -83,6 +83,8 @@ async def test_get_running_tasks() -> None:
         assert repr(task) == f'TaskInfo(id={task.id}, name={expected_name!r})'
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 11),
+                    reason='Generator based coroutines have been removed in Python 3.11')
 @pytest.mark.filterwarnings('ignore:"@coroutine" decorator is deprecated:DeprecationWarning')
 def test_wait_generator_based_task_blocked(asyncio_event_loop: asyncio.AbstractEventLoop) -> None:
     async def native_coro_part() -> None:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -807,6 +807,8 @@ async def test_escaping_cancelled_error_from_cancelled_task() -> None:
         scope.cancel()
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 11),
+                    reason='Generator based coroutines have been removed in Python 3.11')
 @pytest.mark.filterwarnings('ignore:"@coroutine" decorator is deprecated:DeprecationWarning')
 def test_cancel_generator_based_task() -> None:
     from asyncio import coroutine


### PR DESCRIPTION
Fixes https://github.com/agronholm/anyio/issues/430