### PR TITLE
getaddrinfo does not take bytearray

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1563,7 +1563,7 @@ async def create_udp_socket(
         return ConnectedUDPSocket(transport, protocol)
 
 
-async def getaddrinfo(host: Union[bytearray, bytes, str], port: Union[str, int, None], *,
+async def getaddrinfo(host: Union[bytes, str], port: Union[str, int, None], *,
                       family: Union[int, AddressFamily] = 0, type: Union[int, SocketKind] = 0,
                       proto: int = 0, flags: int = 0) -> GetAddrInfoReturnType:
     # https://github.com/python/typeshed/pull/4304


### PR DESCRIPTION
This matches the type in typeshed. asyncio just delegates directly to `socket.getaddrinfo`, which does not take bytearray.