### PR TITLE
Run asyncgen fixtures in their own tasks

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -138,18 +138,6 @@ For async fixtures with scopes other than ``function``, you will need to define 
         yield
         await server.shutdown()
 
-.. warning:: Higher scoped async fixtures have some gotchas. First, if you start a network server
-  which binds to one or more ports, those ports will stay bound until the fixture is torn down.
-  When you combine such fixtures with multiple backends, you may encounter a situation where the
-  server won't start because of the previous incarnation of the fixture. Even though that previous
-  incarnation of the fixture is not actively running, its port stays bound. The solution to this is
-  to use ephemeral ports (bind to port 0 and then use something like
-  ``listener.extra(SocketAttribute.local_port)`` to retrieve the automatically assigned port
-  number.
-
-  The other is signal handling. Combining multiple backends with higher scoped signal handlers will
-  almost certainly result in very confusing errors, and is thus strongly discouraged.
-
 Technical details
 -----------------
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,9 +5,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-* **BACKWARDS INCOMPATIBLE** Replaced AnyIO's own ``ExceptionGroup`` class with the PEP 654
+- **BACKWARDS INCOMPATIBLE** Replaced AnyIO's own ``ExceptionGroup`` class with the PEP 654
   ``BaseExceptionGroup`` and ``ExceptionGroup``
 - Bumped minimum version of trio to v0.19
+- Changed the pytest plugin to run both the setup and teardown phases of asynchronous generator
+  fixtures within a single task to enable use cases where a context manager straddles the ``yield``
 
 **3.5.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1530,9 +1530,9 @@ class TestRunner(abc.TestRunner):
             self._loop.close()
 
     def run_asyncgen_fixture(self, fixture_func: Callable[..., AsyncGenerator[T_Retval, Any]],
-                             args: tuple[Any, ...], kwargs: dict[str, Any]) -> Iterable[T_Retval]:
+                             kwargs: dict[str, Any]) -> Iterable[T_Retval]:
         async def fixture_runner() -> None:
-            agen = fixture_func(*args, **kwargs)
+            agen = fixture_func(**kwargs)
             try:
                 retval = await agen.asend(None)
                 self._raise_async_exceptions()
@@ -1561,8 +1561,8 @@ class TestRunner(abc.TestRunner):
         self._raise_async_exceptions()
 
     def run_fixture(self, fixture_func: Callable[..., Coroutine[Any, Any, T_Retval]],
-                    args: tuple[Any, ...], kwargs: dict[str, Any]) -> T_Retval:
-        retval = self._loop.run_until_complete(fixture_func(*args, **kwargs))
+                    kwargs: dict[str, Any]) -> T_Retval:
+        retval = self._loop.run_until_complete(fixture_func(**kwargs))
         self._raise_async_exceptions()
         return retval
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -12,6 +12,7 @@ from asyncio import run as native_run
 from asyncio import sleep
 from asyncio.base_events import _run_until_complete_cb  # type: ignore[attr-defined]
 from collections import OrderedDict, deque
+from collections.abc import Iterable
 from concurrent.futures import Future
 from contextvars import Context, copy_context
 from dataclasses import dataclass
@@ -25,8 +26,8 @@ from socket import AddressFamily, SocketKind
 from threading import Thread
 from types import TracebackType
 from typing import (
-    Any, Awaitable, Callable, Collection, ContextManager, Coroutine, Deque, Generator, Iterator,
-    Mapping, Optional, Sequence, Tuple, TypeVar, cast)
+    Any, AsyncGenerator, Awaitable, Callable, Collection, ContextManager, Coroutine, Deque,
+    Generator, Iterator, Mapping, Optional, Sequence, Tuple, TypeVar, cast)
 from weakref import WeakKeyDictionary
 
 import sniffio
@@ -1483,9 +1484,11 @@ def _create_task_info(task: asyncio.Task) -> TaskInfo:
 class TestRunner(abc.TestRunner):
     def __init__(self, debug: bool = False, use_uvloop: bool = False,
                  policy: asyncio.AbstractEventLoopPolicy | None = None):
+        self._exceptions: list[BaseException] = []
         _maybe_set_event_loop_policy(policy, use_uvloop)
         self._loop = asyncio.new_event_loop()
         self._loop.set_debug(debug)
+        self._loop.set_exception_handler(self._exception_handler)
         asyncio.set_event_loop(self._loop)
 
     def _cancel_all_tasks(self) -> None:
@@ -1504,6 +1507,19 @@ class TestRunner(abc.TestRunner):
             if task.exception() is not None:
                 raise cast(BaseException, task.exception())
 
+    def _exception_handler(self, loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        if isinstance(context['exception'], Exception):
+            self._exceptions.append(context['exception'])
+
+    def _raise_async_exceptions(self) -> None:
+        # Re-raise any exceptions raised in asynchronous callbacks
+        if self._exceptions:
+            exceptions, self._exceptions = self._exceptions, []
+            if len(exceptions) == 1:
+                raise exceptions[0]
+            elif exceptions:
+                raise ExceptionGroup(exceptions)
+
     def close(self) -> None:
         try:
             self._cancel_all_tasks()
@@ -1512,27 +1528,51 @@ class TestRunner(abc.TestRunner):
             asyncio.set_event_loop(None)
             self._loop.close()
 
-    def call(self, func: Callable[..., Awaitable[T_Retval]],
-             *args: object, **kwargs: object) -> T_Retval:
-        def exception_handler(loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
-            exceptions.append(context['exception'])
+    def run_asyncgen_fixture(self, fixture_func: Callable[..., AsyncGenerator[T_Retval, Any]],
+                             args: tuple[Any, ...], kwargs: dict[str, Any]) -> Iterable[T_Retval]:
+        async def fixture_runner() -> None:
+            agen = fixture_func(*args, **kwargs)
+            try:
+                retval = await agen.asend(None)
+                self._raise_async_exceptions()
+            except BaseException as exc:
+                f.set_exception(exc)
+                return
+            else:
+                f.set_result(retval)
 
-        exceptions: list[BaseException] = []
-        self._loop.set_exception_handler(exception_handler)
-        try:
-            retval: T_Retval = self._loop.run_until_complete(func(*args, **kwargs))
-        except Exception as exc:
-            retval = None  # type: ignore[assignment]
-            exceptions.append(exc)
-        finally:
-            self._loop.set_exception_handler(None)
+            await event.wait()
+            try:
+                await agen.asend(None)
+            except StopAsyncIteration:
+                pass
+            else:
+                await agen.aclose()
+                raise RuntimeError('Async generator fixture did not stop')
 
-        if len(exceptions) == 1:
-            raise exceptions[0]
-        elif exceptions:
-            raise ExceptionGroup(exceptions)
+        f = self._loop.create_future()
+        event = asyncio.Event()
+        fixture_task = self._loop.create_task(fixture_runner())
+        self._loop.run_until_complete(f)
+        yield f.result()
+        event.set()
+        self._loop.run_until_complete(fixture_task)
+        self._raise_async_exceptions()
 
+    def run_fixture(self, fixture_func: Callable[..., Coroutine[Any, Any, T_Retval]],
+                    args: tuple[Any, ...], kwargs: dict[str, Any]) -> T_Retval:
+        retval = self._loop.run_until_complete(fixture_func(*args, **kwargs))
+        self._raise_async_exceptions()
         return retval
+
+    def run_test(self, test_func: Callable[..., Coroutine[Any, Any, Any]],
+                 kwargs: dict[str, Any]) -> None:
+        try:
+            self._loop.run_until_complete(test_func(**kwargs))
+        except Exception as exc:
+            self._exceptions.append(exc)
+
+        self._raise_async_exceptions()
 
 
 class AsyncIOBackend(AsyncBackend):

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -639,9 +639,9 @@ class TestRunner(abc.TestRunner):
                 self._call_queue.get()()
 
     def run_asyncgen_fixture(self, fixture_func: Callable[..., AsyncGenerator[T_Retval, Any]],
-                             args: tuple[Any, ...], kwargs: dict[str, Any]) -> Iterable[T_Retval]:
+                             kwargs: dict[str, Any]) -> Iterable[T_Retval]:
         async def fixture_runner(*, task_status: TaskStatus) -> None:
-            agen = fixture_func(*args, **kwargs)
+            agen = fixture_func(**kwargs)
             retval = await agen.asend(None)
             task_status.started(retval)
             await teardown_event.wait()
@@ -659,8 +659,8 @@ class TestRunner(abc.TestRunner):
         teardown_event.set()
 
     def run_fixture(self, fixture_func: Callable[..., Coroutine[Any, Any, T_Retval]],
-                    args: tuple[Any, ...], kwargs: dict[str, Any]) -> T_Retval:
-        return self._call(fixture_func, *args, **kwargs)
+                    kwargs: dict[str, Any]) -> T_Retval:
+        return self._call(fixture_func, **kwargs)
 
     def run_test(self, test_func: Callable[..., Coroutine[Any, Any, Any]],
                  kwargs: dict[str, Any]) -> None:

--- a/src/anyio/abc/_testing.py
+++ b/src/anyio/abc/_testing.py
@@ -29,28 +29,28 @@ class TestRunner(metaclass=ABCMeta):
 
     @abstractmethod
     def run_asyncgen_fixture(
-        self, fixture_func: Callable[..., AsyncGenerator[_T, Any]],
-        args: tuple[Any, ...], kwargs: dict[str, Any]
+        self,
+        fixture_func: Callable[..., AsyncGenerator[_T, Any]],
+        kwargs: dict[str, Any]
     ) -> Iterable[_T]:
         """
         Run an async generator fixture.
 
         :param fixture_func: the fixture function
-        :param args:
-        :param kwargs:
-        :param args: positional arguments to call the fixture function with
         :param kwargs: keyword arguments to call the fixture function with
         :return: an iterator yielding the value yielded from the async generator
         """
 
     @abstractmethod
-    def run_fixture(self, fixture_func: Callable[..., Coroutine[Any, Any, _T]],
-                    args: tuple[Any, ...], kwargs: dict[str, Any]) -> _T:
+    def run_fixture(
+        self,
+        fixture_func: Callable[..., Coroutine[Any, Any, _T]],
+        kwargs: dict[str, Any]
+    ) -> _T:
         """
         Run an async fixture.
 
         :param fixture_func: the fixture function
-        :param args: positional arguments to call the fixture function with
         :param kwargs: keyword arguments to call the fixture function with
         :return: the return value of the fixture function
         """

--- a/src/anyio/abc/_testing.py
+++ b/src/anyio/abc/_testing.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import types
 from abc import ABCMeta, abstractmethod
-from typing import Any, Awaitable, Callable, TypeVar
+from collections.abc import AsyncGenerator, Iterable
+from typing import Any, Callable, Coroutine, TypeVar
 
 _T = TypeVar("_T")
 
@@ -27,13 +28,39 @@ class TestRunner(metaclass=ABCMeta):
         """Close the event loop."""
 
     @abstractmethod
-    def call(self, func: Callable[..., Awaitable[_T]],
-             *args: object, **kwargs: dict[str, Any]) -> _T:
+    def run_asyncgen_fixture(
+        self, fixture_func: Callable[..., AsyncGenerator[_T, Any]],
+        args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> Iterable[_T]:
         """
-        Call the given function within the backend's event loop.
+        Run an async generator fixture.
 
-        :param func: a callable returning an awaitable
-        :param args: positional arguments to call ``func`` with
-        :param kwargs: keyword arguments to call ``func`` with
-        :return: the return value of ``func``
+        :param fixture_func: the fixture function
+        :param args:
+        :param kwargs:
+        :param args: positional arguments to call the fixture function with
+        :param kwargs: keyword arguments to call the fixture function with
+        :return: an iterator yielding the value yielded from the async generator
+        """
+
+    @abstractmethod
+    def run_fixture(self, fixture_func: Callable[..., Coroutine[Any, Any, _T]],
+                    args: tuple[Any, ...], kwargs: dict[str, Any]) -> _T:
+        """
+        Run an async fixture.
+
+        :param fixture_func: the fixture function
+        :param args: positional arguments to call the fixture function with
+        :param kwargs: keyword arguments to call the fixture function with
+        :return: the return value of the fixture function
+        """
+
+    @abstractmethod
+    def run_test(self, test_func: Callable[..., Coroutine[Any, Any, Any]],
+                 kwargs: dict[str, Any]) -> None:
+        """
+        Run an async test function.
+
+        :param test_func: the test function
+        :param kwargs: keyword arguments to call the test function with
         """

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, Tuple, cast
 
 import pytest
 import sniffio
+from _pytest.fixtures import FixtureRequest
 
 from ._core._eventloop import get_all_backends, get_async_backend
 from .abc import TestRunner
@@ -55,7 +56,7 @@ def pytest_configure(config: Config) -> None:
                                        'asynchronously via anyio.')
 
 
-def pytest_fixture_setup(fixturedef: Any, request: Any) -> None:
+def pytest_fixture_setup(fixturedef: Any, request: FixtureRequest) -> None:
     def wrapper(*args, anyio_backend, **kwargs):  # type: ignore[no-untyped-def]
         backend_name, backend_options = extract_backend_and_options(anyio_backend)
         if has_backend_arg:
@@ -63,23 +64,9 @@ def pytest_fixture_setup(fixturedef: Any, request: Any) -> None:
 
         with get_runner(backend_name, backend_options) as runner:
             if isasyncgenfunction(func):
-                gen = func(*args, **kwargs)
-                try:
-                    value = runner.call(gen.asend, None)
-                except StopAsyncIteration:
-                    raise RuntimeError('Async generator did not yield')
-
-                yield value
-
-                try:
-                    runner.call(gen.asend, None)
-                except StopAsyncIteration:
-                    pass
-                else:
-                    runner.call(gen.aclose)
-                    raise RuntimeError('Async generator fixture did not stop')
+                yield from runner.run_asyncgen_fixture(func, args, kwargs)
             else:
-                yield runner.call(func, *args, **kwargs)
+                yield runner.run_fixture(func, args, kwargs)
 
     # Only apply this to coroutine functions and async generator functions in requests that involve
     # the anyio_backend fixture
@@ -107,7 +94,7 @@ def pytest_pycollect_makeitem(collector: Any, name: Any, obj: Any) -> None:
 def pytest_pyfunc_call(pyfuncitem: Any) -> bool | None:
     def run_with_hypothesis(**kwargs: Any) -> None:
         with get_runner(backend_name, backend_options) as runner:
-            runner.call(original_func, **kwargs)
+            runner.run_test(original_func, kwargs)
 
     backend = pyfuncitem.funcargs.get('anyio_backend')
     if backend:
@@ -126,14 +113,14 @@ def pytest_pyfunc_call(pyfuncitem: Any) -> bool | None:
             funcargs = pyfuncitem.funcargs
             testargs = {arg: funcargs[arg] for arg in pyfuncitem._fixtureinfo.argnames}
             with get_runner(backend_name, backend_options) as runner:
-                runner.call(pyfuncitem.obj, **testargs)
+                runner.run_test(pyfuncitem.obj, testargs)
 
             return True
 
     return None
 
 
-@pytest.fixture(params=get_all_backends())
+@pytest.fixture(scope="module", params=get_all_backends())
 def anyio_backend(request: Any) -> Any:
     return request.param
 

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -64,9 +64,9 @@ def pytest_fixture_setup(fixturedef: Any, request: FixtureRequest) -> None:
 
         with get_runner(backend_name, backend_options) as runner:
             if isasyncgenfunction(func):
-                yield from runner.run_asyncgen_fixture(func, args, kwargs)
+                yield from runner.run_asyncgen_fixture(func, kwargs)
             else:
-                yield runner.run_fixture(func, args, kwargs)
+                yield runner.run_fixture(func, kwargs)
 
     # Only apply this to coroutine functions and async generator functions in requests that involve
     # the anyio_backend fixture

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -33,8 +33,6 @@ def test_plugin(testdir: Pytester) -> None:
 
     testdir.makepyfile(
         """
-        import asyncio
-
         import pytest
         import sniffio
         from hypothesis import strategies, given
@@ -83,7 +81,7 @@ def test_asyncio(testdir: Pytester) -> None:
             def callback():
                 raise RuntimeError('failing fixture setup')
 
-            asyncio.get_event_loop().call_soon(callback)
+            asyncio.get_running_loop().call_soon(callback)
             await asyncio.sleep(0)
             yield None
 
@@ -93,7 +91,7 @@ def test_asyncio(testdir: Pytester) -> None:
                 raise RuntimeError('failing fixture teardown')
 
             yield None
-            asyncio.get_event_loop().call_soon(callback)
+            asyncio.get_running_loop().call_soon(callback)
             await asyncio.sleep(0)
         """
     )
@@ -124,7 +122,7 @@ def test_asyncio(testdir: Pytester) -> None:
                 raise Exception('foo')
 
             started = False
-            asyncio.get_event_loop().call_soon(callback)
+            asyncio.get_running_loop().call_soon(callback)
             await asyncio.sleep(0)
             assert started
 
@@ -197,6 +195,53 @@ def test_cancel_scope_in_asyncgen_fixture(testdir: Pytester) -> None:
         @pytest.mark.anyio
         async def test_cancel_in_asyncgen_fixture(asyncgen_fixture):
             assert asyncgen_fixture == 1
+        """
+    )
+
+    result = testdir.runpytest_subprocess(*pytest_args)
+    result.assert_outcomes(passed=len(get_all_backends()))
+
+
+def test_module_scoped_task_group_fixture(testdir: Pytester) -> None:
+    testdir.makeconftest(
+        """
+        import pytest
+
+        from anyio import CancelScope, create_memory_object_stream, create_task_group
+
+
+        @pytest.fixture(scope="module")
+        async def task_group():
+            async with create_task_group() as tg:
+                yield tg
+
+
+        @pytest.fixture
+        async def streams(task_group):
+            async def echo_messages(*, task_status):
+                with CancelScope() as cancel_scope:
+                    task_status.started(cancel_scope)
+                    async for obj in receive1:
+                        await send2.send(obj)
+
+            send1, receive1 = create_memory_object_stream()
+            send2, receive2 = create_memory_object_stream()
+            cancel_scope = await task_group.start(echo_messages)
+            yield send1, receive2
+            cancel_scope.cancel()
+        """
+    )
+
+    testdir.makepyfile(
+        """
+        import pytest
+
+
+        @pytest.mark.anyio
+        async def test_task_group(streams):
+            send1, receive2 = streams
+            await send1.send("hello")
+            assert await receive2.receive() == "hello"
         """
     )
 


### PR DESCRIPTION
This lets async context managers like cancel scopes straddle the "yield" in the fixture function.
Fixes #345.