### PR TITLE
docs: run_sync_in_worker_thread -> run_sync

### DIFF
--- a/docs/threads.rst
+++ b/docs/threads.rst
@@ -50,8 +50,8 @@ If you need to call a coroutine function from a worker thread, you can do this::
 
     run(main)
 
-.. note:: The worker thread must have been spawned using :func:`~run_sync`
-   for this to work.
+.. note:: The worker thread must have been spawned using :func:`~to_thread.run_sync` for this to
+   work.
 
 Calling synchronous code from a worker thread
 ---------------------------------------------

--- a/docs/threads.rst
+++ b/docs/threads.rst
@@ -50,7 +50,7 @@ If you need to call a coroutine function from a worker thread, you can do this::
 
     run(main)
 
-.. note:: The worker thread must have been spawned using :func:`~run_sync_in_worker_thread`
+.. note:: The worker thread must have been spawned using :func:`~run_sync`
    for this to work.
 
 Calling synchronous code from a worker thread


### PR DESCRIPTION
Hi,

I think this is changed in version 3.0, but was missed in the docs.
Nice library, solves a lot of issues that I usually hand crafted.

Regards,

Maarten Breddels