### PR TITLE
Fix task reference count leak

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -465,13 +465,13 @@ class CancelScope(BaseCancelScope):
     def _parent_cancelled(self) -> bool:
         # Check whether any parent has been cancelled
         cancel_scope = self._parent_scope
-        self._parent_scope = None
         while cancel_scope is not None and not cancel_scope._shield:
+            parent_scope = cancel_scope._parent_scope
+            cancel_scope._parent_scope = None
             if cancel_scope._cancel_called:
                 return True
             else:
-                cancel_scope = cancel_scope._parent_scope
-                cancel_scope._parent_scope = None
+                cancel_scope = parent_scope
         return False
 
     def cancel(self) -> DeprecatedAwaitable:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -622,7 +622,7 @@ class TaskGroup(abc.TaskGroup):
         self.cancel_scope: CancelScope = CancelScope()
         self._active = False
         self._exceptions: List[BaseException] = []
-        self._root_id = None
+        self._root_id: Optional[int] = None
 
     async def __aenter__(self) -> "TaskGroup":
         self.cancel_scope.__enter__()

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -386,7 +386,9 @@ class CancelScope(BaseCancelScope):
         try:
             if exc_val is not None:
                 exceptions = (
-                    exc_val.exceptions if isinstance(exc_val, ExceptionGroup) else [exc_val]
+                    exc_val.exceptions
+                    if isinstance(exc_val, ExceptionGroup)
+                    else [exc_val]
                 )
                 if all(isinstance(exc, CancelledError) for exc in exceptions):
                     if self._timeout_expired:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -930,10 +930,10 @@ async def test_cancel_completed_task() -> None:
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_cancel_task_leak() -> None:
     task = None
-    scope_ref = None
-    parent_scope_ref = None
+    scope_ref: weakref.ref = None
+    parent_scope_ref: weakref.ref = None
 
-    async def run():
+    async def run() -> None:
         nonlocal task, scope_ref, parent_scope_ref
         with CancelScope() as parent_scope:
             with CancelScope(shield=True) as scope:


### PR DESCRIPTION
I found it as I'm using `httpx` which used `anyio` as its backend, there is a circle between the scope and parent scope, so the `asyncio.Task` won't be able to be released until the gc called.
Therefore we need to break the reference chain.