### PR TITLE
Order the waiting queue for asyncio ConcurrencyLimiter

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,9 +3,10 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
-**3.6.2**
+**UNRELEASED**
 
-- Fixed ``asyncio`` ``ConcurrencyLimiter`` to correctly order waiting tasks.
+- Fixed ``ConcurrencyLimiter`` on the asyncio backend to order waiting tasks in the FIFO
+  order (instead of LIFO) (PR by Conor Stevenson)
 
 **3.6.1**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,10 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**3.6.2**
+
+- Fixed ``asyncio`` ``ConcurrencyLimiter`` to correctly order waiting tasks.
+
 **3.6.1**
 
 - Fixed exception handler in the asyncio test runner not properly handling a context

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1952,7 +1952,7 @@ class CapacityLimiter(BaseCapacityLimiter):
 
     def __init__(self, total_tokens: float):
         self._borrowers: Set[Any] = set()
-        self._wait_queue: Dict[Any, asyncio.Event] = OrderedDict()
+        self._wait_queue: OrderedDict[Any, asyncio.Event] = OrderedDict()
         self.total_tokens = total_tokens
 
     async def __aenter__(self) -> None:
@@ -2053,7 +2053,7 @@ class CapacityLimiter(BaseCapacityLimiter):
 
         # Notify the next task in line if this limiter has free capacity now
         if self._wait_queue and len(self._borrowers) < self._total_tokens:
-            event = self._wait_queue.popitem()[1]
+            event = self._wait_queue.popitem(last=False)[1]
             event.set()
 
     def statistics(self) -> CapacityLimiterStatistics:

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -524,3 +524,21 @@ class TestCapacityLimiter:
         await asyncio.sleep(0)
         task1.cancel()
         await asyncio.wait_for(task2, 1)
+
+    async def test_ordered_queue(self) -> None:
+        limiter = CapacityLimiter(1)
+        results = []
+        event = Event()
+
+        async def append(x: int, task_status: TaskStatus) -> None:
+            task_status.started()
+            async with limiter:
+                await event.wait()
+                results.append(x)
+
+        async with create_task_group() as tg:
+            for i in [0, 1, 2]:
+                await tg.start(append, i)
+            event.set()
+
+        assert results == [0, 1, 2]

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -539,6 +539,7 @@ class TestCapacityLimiter:
         async with create_task_group() as tg:
             for i in [0, 1, 2]:
                 await tg.start(append, i)
+
             event.set()
 
         assert results == [0, 1, 2]


### PR DESCRIPTION
Previously we were using a LIFO, which is unfair and doesn't match `trio`'s implementation.