### PR TITLE
Add note for UNIX datagram sockets

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added ``create_unix_datagram_socket`` and ``create_connected_unix_datagram_socket`` to
+  create UNIX datagram sockets (PR by Jean Hominal)
 - Fixed ``ConcurrencyLimiter`` on the asyncio backend to order waiting tasks in the FIFO
   order (instead of LIFO) (PR by Conor Stevenson)
 


### PR DESCRIPTION
After checking back on anyio recent changes, I realized that I did not add a note for the new feature of UNIX datagram sockets to versionhistory.rst.