### PR TITLE
Make Listener covariant in the stream type variable

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -25,6 +25,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
   - The ``TaskStatus`` class is now generic, and should be parametrized to indicate the
     type of the value passed to ``task_status.started()``
+  - The ``Listener`` class is now covariant in its stream type
 - Fixed ``CapacityLimiter`` on the asyncio backend to order waiting tasks in the FIFO
   order (instead of LIFO) (PR by Conor Stevenson)
 - Fixed ``CancelScope.cancel()`` not working on asyncio if called before entering the

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -14,7 +14,7 @@ from .._core._typedattr import (
     TypedAttributeSet,
     typed_attribute,
 )
-from ._streams import ByteStream, Listener, T_Stream, UnreliableObjectStream
+from ._streams import ByteStream, Listener, UnreliableObjectStream
 from ._tasks import TaskGroup
 
 IPAddressType = Union[str, IPv4Address, IPv6Address]
@@ -133,7 +133,9 @@ class SocketListener(Listener[SocketStream], _SocketProvider):
         """Accept an incoming connection."""
 
     async def serve(
-        self, handler: Callable[[T_Stream], Any], task_group: TaskGroup | None = None
+        self,
+        handler: Callable[[SocketStream], Any],
+        task_group: TaskGroup | None = None,
     ) -> None:
         from .. import create_task_group
 

--- a/src/anyio/abc/_streams.py
+++ b/src/anyio/abc/_streams.py
@@ -10,7 +10,7 @@ from ._resources import AsyncResource
 from ._tasks import TaskGroup
 
 T_Item = TypeVar("T_Item")
-T_Stream = TypeVar("T_Stream")
+T_Stream_co = TypeVar("T_Stream_co", covariant=True)
 
 
 class UnreliableObjectReceiveStream(
@@ -186,12 +186,12 @@ AnyByteSendStream = Union[ObjectSendStream[bytes], ByteSendStream]
 AnyByteStream = Union[ObjectStream[bytes], ByteStream]
 
 
-class Listener(Generic[T_Stream], AsyncResource, TypedAttributeProvider):
+class Listener(Generic[T_Stream_co], AsyncResource, TypedAttributeProvider):
     """An interface for objects that let you accept incoming connections."""
 
     @abstractmethod
     async def serve(
-        self, handler: Callable[[T_Stream], Any], task_group: TaskGroup | None = None
+        self, handler: Callable[[T_Stream_co], Any], task_group: TaskGroup | None = None
     ) -> None:
         """
         Accept incoming connections as they come in and start tasks to handle them.


### PR DESCRIPTION
This changes allows to properly annotate return type in a function like:

```python
import ssl
from typing import Optional

import anyio
from anyio.abc import ByteStream, Listener
from anyio.streams.tls import TLSListener


async def create_listener(
    local_host: str,
    local_port: int,
    ssl_context: Optional[ssl.SSLContext],
) -> Listener[ByteStream]:
    listener = await anyio.create_tcp_listener(
        local_host=local_host, local_port=local_port
    )
    if ssl_context is not None:
        return TLSListener(listener, ssl_context=ssl_context)
    else:
        return listener
```

Without this change, the function has to be annotated as returning `Union[Listener[SocketStream], TLSListener]`, which is long and it depends on specific implementation.

The stream type of the listeners acts [covariantly](https://peps.python.org/pep-0484/#covariance-and-contravariance). When I have a handler that expects `ByteStream`, I need `Listener[ByteStream]`. But the handler won't mind if it gets `TLSStream`, so I should not mind if I have `Listener[TLSStream]`. 

For comparison, [callables are covariant in the return type](https://peps.python.org/pep-0483/#covariance-and-contravariance). For the listeners, the socket acts similar as the return value of the callable - it is an output, just passed to the handler callback instead of returned directly.

Note that I did not propagate the change to `anyio.streams.stapled.MultiListener`. The reason is similar why mutable collections are not covariant. The following function should not accept `MultiListener[TLSStream]`:

```python
def replace_listeners(multi_listener: MultiListener[ByteStream]):
    multi_listener.listeners = [anyio.create_tcp_listener(...)]
```

I also did a small change to `anyio.abc.SocketListener`. Its use of `T_Stream` seems unnecessary, so I got rid of it instead of replacing it by `T_Stream_co`.