### PR TITLE
Upgrade pyproject-flake8 for compatibility with the latest flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/csachs/pyproject-flake8
-    rev: v0.0.1a4
+    rev: v5.0.4.post1
     hooks:
       - id: pyproject-flake8
 


### PR DESCRIPTION
`tox -e lint` and all CI builds end with an error: "AttributeError: module 'flake8.options.config' has no attribute 'ConfigFileFinder'."  This was reported and fixed in https://github.com/csachs/pyproject-flake8/issues/13.