### PR TITLE
Allow passing only `item_type` to `create_memory_object_stream()`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -26,6 +26,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   - The ``TaskStatus`` class is now generic, and should be parametrized to indicate the
     type of the value passed to ``task_status.started()``
   - The ``Listener`` class is now covariant in its stream type
+  - ``create_memory_object_stream()`` now allows passing only ``item_type``
 - Fixed ``CapacityLimiter`` on the asyncio backend to order waiting tasks in the FIFO
   order (instead of LIFO) (PR by Conor Stevenson)
 - Fixed ``CancelScope.cancel()`` not working on asyncio if called before entering the

--- a/src/anyio/_core/_streams.py
+++ b/src/anyio/_core/_streams.py
@@ -14,15 +14,15 @@ T_Item = TypeVar("T_Item")
 
 @overload
 def create_memory_object_stream(
-    max_buffer_size: float, item_type: type[T_Item]
-) -> tuple[MemoryObjectSendStream[T_Item], MemoryObjectReceiveStream[T_Item]]:
+    max_buffer_size: float = 0,
+) -> tuple[MemoryObjectSendStream[Any], MemoryObjectReceiveStream[Any]]:
     ...
 
 
 @overload
 def create_memory_object_stream(
-    max_buffer_size: float = 0,
-) -> tuple[MemoryObjectSendStream[Any], MemoryObjectReceiveStream[Any]]:
+    max_buffer_size: float = 0, item_type: type[T_Item] = ...
+) -> tuple[MemoryObjectSendStream[T_Item], MemoryObjectReceiveStream[T_Item]]:
     ...
 
 


### PR DESCRIPTION
Hi! Calls with a signature like `create_memory_object_stream(item_type=int)` are supported by the implementation but not by the overloads.