### PR TITLE
Fix `connect_tcp()` docstring referencing a nonexistent parameter

### DIFF
--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -136,8 +136,8 @@ async def connect_tcp(
     """
     Connect to a host using the TCP protocol.
 
-    This function implements the stateless version of the Happy Eyeballs algorithm
-    (RFC 6555). If ``address`` is a host name that resolves to multiple IP addresses,
+    This function implements the stateless version of the Happy Eyeballs algorithm (RFC
+    6555). If ``remote_host`` is a host name that resolves to multiple IP addresses,
     each one is tried until one connection attempt succeeds. If the first attempt does
     not connected within 250 milliseconds, a second attempt is started using the next
     address in the list, and so on. On IPv6 enabled systems, an IPv6 address (if


### PR DESCRIPTION
This looks to have been introduced in da0a792c17b840027030289a2566cf5910880d42.