### PR TITLE
typing: asyncio backend: fix `TaskGroup.start` mistyping and avoid `Any` returns

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -622,7 +622,7 @@ class TaskGroup(abc.TaskGroup):
 
     async def start(
         self, func: Callable[..., Awaitable[Any]], *args: object, name: object = None
-    ) -> None:
+    ) -> object:
         future: asyncio.Future = asyncio.Future()
         task = self._spawn(func, args, name, future)
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -623,7 +623,7 @@ class TaskGroup(abc.TaskGroup):
     async def start(
         self, func: Callable[..., Awaitable[Any]], *args: object, name: object = None
     ) -> object:
-        future: asyncio.Future = asyncio.Future()
+        future: asyncio.Future[object] = asyncio.Future()
         task = self._spawn(func, args, name, future)
 
         # If the task raises an exception after sending a start value without a switch
@@ -1921,7 +1921,7 @@ class AsyncIOBackend(AsyncBackend):
 
         async with (limiter or cls.current_default_thread_limiter()):
             with CancelScope(shield=not cancellable):
-                future: asyncio.Future = asyncio.Future()
+                future: asyncio.Future[T_Retval] = asyncio.Future()
                 root_task = find_root_task()
                 if not idle_workers:
                     worker = WorkerThread(root_task, workers, idle_workers)


### PR DESCRIPTION
This mistyping isn't user-facing, but it still helps with backend type checking coverage. A couple `asyncio.Future`s can also be parametrized now since `__future__` annotations was recently enabled.