### PR TITLE
🔥 Remove `start_blocking_portal` from `__all__,` as it seems it was removed

### DIFF
--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -58,7 +58,6 @@ __all__ = (
     "get_current_task",
     "get_running_tasks",
     "wait_all_tasks_blocked",
-    "start_blocking_portal",
     "typed_attribute",
     "TypedAttributeSet",
     "TypedAttributeProvider",


### PR DESCRIPTION
🔥 Remove `start_blocking_portal` from `__all__,` as it seems it was removed