### PR TITLE
Make `create_memory_object_stream` generic

### DIFF
--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -49,16 +49,20 @@ The loop exits when all clones of the send stream have been closed.
 Example::
 
     from anyio import create_task_group, create_memory_object_stream, run
+    from anyio.streams.memory import MemoryObjectReceiveStream
 
 
-    async def process_items(receive_stream):
+    async def process_items(receive_stream: MemoryObjectReceiveStream[str]) -> None:
         async with receive_stream:
             async for item in receive_stream:
                 print('received', item)
 
 
     async def main():
-        send_stream, receive_stream = create_memory_object_stream()
+        # The [str] specifies the type of the objects being passed through the
+        # memory object stream. This is a bit of trick, as create_memory_object_stream
+        # is actually a class masquerading as a function.
+        send_stream, receive_stream = create_memory_object_stream[str]()
         async with create_task_group() as tg:
             tg.start_soon(process_items, receive_stream)
             async with send_stream:
@@ -71,7 +75,10 @@ In contrast to other AnyIO streams (but in line with trio's Channels), memory ob
 closed synchronously, using either the ``close()`` method or by using the stream as a context
 manager::
 
-    def synchronous_callback(send_stream: MemoryObjectSendStream) -> None:
+    from anyio.streams.memory import MemoryObjectSendStream
+
+
+    def synchronous_callback(send_stream: MemoryObjectSendStream[str]) -> None:
         with send_stream:
             send_stream.send_nowait('hello')
 

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -109,7 +109,7 @@ Example::
 
 
     async def main():
-        send, receive = create_memory_object_stream(4)
+        send, receive = create_memory_object_stream[bytes](4)
         buffered = BufferedByteReceiveStream(receive)
         for part in b'hel', b'lo, ', b'wo', b'rld!':
             await send.send(part)
@@ -139,7 +139,7 @@ Example::
 
 
     async def main():
-        bytes_send, bytes_receive = create_memory_object_stream(1)
+        bytes_send, bytes_receive = create_memory_object_stream[bytes](1)
         text_send = TextSendStream(bytes_send)
         await text_send.send('åäö')
         result = await bytes_receive.receive()

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -12,6 +12,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   create UNIX datagram sockets (PR by Jean Hominal)
 - Improved type annotations:
 
+  - **BACKWARDS INCOMPATIBLE** ``create_memory_object_stream`` no longer accepts an
+    ``item_type`` argument for static typing. Use
+    ``create_memory_object_stream[T_Item]()`` instead. Type checking should no longer
+    fail when annotating memory object streams with uninstantiable item types (PR by
+    Ganden Schaffner)
   - Several functions and methods that previously only accepted coroutines as the return
     type of the callable have been amended to accept any awaitables:
 
@@ -26,7 +31,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   - The ``TaskStatus`` class is now generic, and should be parametrized to indicate the
     type of the value passed to ``task_status.started()``
   - The ``Listener`` class is now covariant in its stream type
-  - ``create_memory_object_stream()`` now allows passing only ``item_type``
   - Object receive streams are now covariant and object send streams are correspondingly
     contravariant
 - Fixed ``CapacityLimiter`` on the asyncio backend to order waiting tasks in the FIFO

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1765,7 +1765,7 @@ class TestRunner(abc.TestRunner):
     @staticmethod
     async def _run_tests_and_fixtures(
         receive_stream: MemoryObjectReceiveStream[
-            tuple[Coroutine[Any, Any, T_Retval], Future[T_Retval]]
+            tuple[Awaitable[T_Retval], asyncio.Future[T_Retval]]
         ],
     ) -> None:
         with receive_stream:
@@ -1783,7 +1783,9 @@ class TestRunner(abc.TestRunner):
         self, func: Callable[..., Awaitable[T_Retval]], *args: object, **kwargs: object
     ) -> T_Retval:
         if not self._runner_task:
-            self._send_stream, receive_stream = create_memory_object_stream(1)
+            self._send_stream, receive_stream = create_memory_object_stream[
+                Tuple[Awaitable[Any], asyncio.Future]
+            ](1)
             self._runner_task = self._loop.create_task(
                 self._run_tests_and_fixtures(receive_stream)
             )

--- a/src/anyio/_core/_streams.py
+++ b/src/anyio/_core/_streams.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, TypeVar, overload
+from typing import Tuple, TypeVar
 
 from ..streams.memory import (
     MemoryObjectReceiveStream,
@@ -12,37 +12,28 @@ from ..streams.memory import (
 T_Item = TypeVar("T_Item")
 
 
-@overload
-def create_memory_object_stream(
-    max_buffer_size: float = 0,
-) -> tuple[MemoryObjectSendStream[Any], MemoryObjectReceiveStream[Any]]:
-    ...
-
-
-@overload
-def create_memory_object_stream(
-    max_buffer_size: float = 0, item_type: type[T_Item] = ...
-) -> tuple[MemoryObjectSendStream[T_Item], MemoryObjectReceiveStream[T_Item]]:
-    ...
-
-
-def create_memory_object_stream(
-    max_buffer_size: float = 0, item_type: type[T_Item] | None = None
-) -> tuple[MemoryObjectSendStream[Any], MemoryObjectReceiveStream[Any]]:
+class create_memory_object_stream(
+    Tuple[MemoryObjectSendStream[T_Item], MemoryObjectReceiveStream[T_Item]],
+):
     """
     Create a memory object stream.
 
+    The stream's item type can be annotated like
+    :func:`create_memory_object_stream[T_Item]`.
+
     :param max_buffer_size: number of items held in the buffer until ``send()`` starts
         blocking
-    :param item_type: type of item, for marking the streams with the right generic type
-        for static typing (not used at run time)
     :return: a tuple of (send stream, receive stream)
 
     """
-    if max_buffer_size != math.inf and not isinstance(max_buffer_size, int):
-        raise ValueError("max_buffer_size must be either an integer or math.inf")
-    if max_buffer_size < 0:
-        raise ValueError("max_buffer_size cannot be negative")
 
-    state: MemoryObjectStreamState = MemoryObjectStreamState(max_buffer_size)
-    return MemoryObjectSendStream(state), MemoryObjectReceiveStream(state)
+    def __new__(  # type: ignore[misc]
+        cls, max_buffer_size: float = 0
+    ) -> tuple[MemoryObjectSendStream[T_Item], MemoryObjectReceiveStream[T_Item]]:
+        if max_buffer_size != math.inf and not isinstance(max_buffer_size, int):
+            raise ValueError("max_buffer_size must be either an integer or math.inf")
+        if max_buffer_size < 0:
+            raise ValueError("max_buffer_size cannot be negative")
+
+        state = MemoryObjectStreamState[T_Item](max_buffer_size)
+        return (MemoryObjectSendStream(state), MemoryObjectReceiveStream(state))

--- a/tests/streams/test_buffered.py
+++ b/tests/streams/test_buffered.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.anyio
 
 
 async def test_receive_exactly() -> None:
-    send_stream, receive_stream = create_memory_object_stream(2)
+    send_stream, receive_stream = create_memory_object_stream[bytes](2)
     buffered_stream = BufferedByteReceiveStream(receive_stream)
     await send_stream.send(b"abcd")
     await send_stream.send(b"efgh")
@@ -19,7 +19,7 @@ async def test_receive_exactly() -> None:
 
 
 async def test_receive_exactly_incomplete() -> None:
-    send_stream, receive_stream = create_memory_object_stream(1)
+    send_stream, receive_stream = create_memory_object_stream[bytes](1)
     buffered_stream = BufferedByteReceiveStream(receive_stream)
     await send_stream.send(b"abcd")
     await send_stream.aclose()
@@ -28,7 +28,7 @@ async def test_receive_exactly_incomplete() -> None:
 
 
 async def test_receive_until() -> None:
-    send_stream, receive_stream = create_memory_object_stream(2)
+    send_stream, receive_stream = create_memory_object_stream[bytes](2)
     buffered_stream = BufferedByteReceiveStream(receive_stream)
     await send_stream.send(b"abcd")
     await send_stream.send(b"efgh")
@@ -43,7 +43,7 @@ async def test_receive_until() -> None:
 
 
 async def test_receive_until_incomplete() -> None:
-    send_stream, receive_stream = create_memory_object_stream(1)
+    send_stream, receive_stream = create_memory_object_stream[bytes](1)
     buffered_stream = BufferedByteReceiveStream(receive_stream)
     await send_stream.send(b"abcd")
     await send_stream.aclose()

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import NoReturn
+
 import pytest
 
 from anyio import (
@@ -36,7 +38,7 @@ async def test_receive_then_send() -> None:
         received_objects.append(await receive.receive())
         received_objects.append(await receive.receive())
 
-    send, receive = create_memory_object_stream(0)
+    send, receive = create_memory_object_stream[str](0)
     received_objects: list[str] = []
     async with create_task_group() as tg:
         tg.start_soon(receiver)
@@ -51,7 +53,7 @@ async def test_receive_then_send_nowait() -> None:
     async def receiver() -> None:
         received_objects.append(await receive.receive())
 
-    send, receive = create_memory_object_stream(0)
+    send, receive = create_memory_object_stream[str](0)
     received_objects: list[str] = []
     async with create_task_group() as tg:
         tg.start_soon(receiver)
@@ -64,7 +66,7 @@ async def test_receive_then_send_nowait() -> None:
 
 
 async def test_send_then_receive_nowait() -> None:
-    send, receive = create_memory_object_stream(0)
+    send, receive = create_memory_object_stream[str](0)
     async with create_task_group() as tg:
         tg.start_soon(send.send, "hello")
         await wait_all_tasks_blocked()
@@ -72,7 +74,7 @@ async def test_send_then_receive_nowait() -> None:
 
 
 async def test_send_is_unblocked_after_receive_nowait() -> None:
-    send, receive = create_memory_object_stream(1)
+    send, receive = create_memory_object_stream[str](1)
     send.send_nowait("hello")
 
     with fail_after(1):
@@ -85,7 +87,7 @@ async def test_send_is_unblocked_after_receive_nowait() -> None:
 
 
 async def test_send_nowait_then_receive_nowait() -> None:
-    send, receive = create_memory_object_stream(2)
+    send, receive = create_memory_object_stream[str](2)
     send.send_nowait("hello")
     send.send_nowait("anyio")
     assert receive.receive_nowait() == "hello"
@@ -97,7 +99,7 @@ async def test_iterate() -> None:
         async for item in receive:
             received_objects.append(item)
 
-    send, receive = create_memory_object_stream()
+    send, receive = create_memory_object_stream[str]()
     received_objects: list[str] = []
     async with create_task_group() as tg:
         tg.start_soon(receiver)
@@ -109,7 +111,7 @@ async def test_iterate() -> None:
 
 
 async def test_receive_send_closed_send_stream() -> None:
-    send, receive = create_memory_object_stream()
+    send, receive = create_memory_object_stream[None]()
     await send.aclose()
     with pytest.raises(EndOfStream):
         receive.receive_nowait()
@@ -119,7 +121,7 @@ async def test_receive_send_closed_send_stream() -> None:
 
 
 async def test_receive_send_closed_receive_stream() -> None:
-    send, receive = create_memory_object_stream()
+    send, receive = create_memory_object_stream[None]()
     await receive.aclose()
     with pytest.raises(ClosedResourceError):
         receive.receive_nowait()
@@ -129,7 +131,7 @@ async def test_receive_send_closed_receive_stream() -> None:
 
 
 async def test_cancel_receive() -> None:
-    send, receive = create_memory_object_stream()
+    send, receive = create_memory_object_stream[str]()
     async with create_task_group() as tg:
         tg.start_soon(receive.receive)
         await wait_all_tasks_blocked()
@@ -140,7 +142,7 @@ async def test_cancel_receive() -> None:
 
 
 async def test_cancel_send() -> None:
-    send, receive = create_memory_object_stream()
+    send, receive = create_memory_object_stream[str]()
     async with create_task_group() as tg:
         tg.start_soon(send.send, "hello")
         await wait_all_tasks_blocked()
@@ -151,7 +153,7 @@ async def test_cancel_send() -> None:
 
 
 async def test_clone() -> None:
-    send1, receive1 = create_memory_object_stream(1)
+    send1, receive1 = create_memory_object_stream[str](1)
     send2 = send1.clone()
     receive2 = receive1.clone()
     await send1.aclose()
@@ -161,7 +163,7 @@ async def test_clone() -> None:
 
 
 async def test_clone_closed() -> None:
-    send, receive = create_memory_object_stream(1)
+    send, receive = create_memory_object_stream[NoReturn](1)
     await send.aclose()
     await receive.aclose()
     pytest.raises(ClosedResourceError, send.clone)
@@ -169,7 +171,7 @@ async def test_clone_closed() -> None:
 
 
 async def test_close_send_while_receiving() -> None:
-    send, receive = create_memory_object_stream(1)
+    send, receive = create_memory_object_stream[NoReturn](1)
     with pytest.raises(EndOfStream):
         async with create_task_group() as tg:
             tg.start_soon(receive.receive)
@@ -178,7 +180,7 @@ async def test_close_send_while_receiving() -> None:
 
 
 async def test_close_receive_while_sending() -> None:
-    send, receive = create_memory_object_stream(0)
+    send, receive = create_memory_object_stream[str](0)
     with pytest.raises(BrokenResourceError):
         async with create_task_group() as tg:
             tg.start_soon(send.send, "hello")
@@ -187,7 +189,7 @@ async def test_close_receive_while_sending() -> None:
 
 
 async def test_receive_after_send_closed() -> None:
-    send, receive = create_memory_object_stream(1)
+    send, receive = create_memory_object_stream[str](1)
     await send.send("hello")
     await send.aclose()
     assert await receive.receive() == "hello"
@@ -199,7 +201,7 @@ async def test_receive_when_cancelled() -> None:
     the operation.
 
     """
-    send, receive = create_memory_object_stream()
+    send, receive = create_memory_object_stream[str]()
     async with create_task_group() as tg:
         tg.start_soon(send.send, "hello")
         await wait_all_tasks_blocked()
@@ -225,7 +227,7 @@ async def test_send_when_cancelled() -> None:
         received.append(await receive.receive())
 
     received: list[str] = []
-    send, receive = create_memory_object_stream()
+    send, receive = create_memory_object_stream[str]()
     async with create_task_group() as tg:
         tg.start_soon(receiver)
         with CancelScope() as scope:
@@ -253,7 +255,7 @@ async def test_cancel_during_receive() -> None:
         assert receiver_scope.cancel_called
 
     received: list[str] = []
-    send, receive = create_memory_object_stream()
+    send, receive = create_memory_object_stream[str]()
     async with create_task_group() as tg:
         tg.start_soon(scoped_receiver)
         await wait_all_tasks_blocked()
@@ -273,15 +275,15 @@ async def test_close_receive_after_send() -> None:
         async with receive_stream:
             assert await receive_stream.receive() == "test"
 
-    send_stream, receive_stream = create_memory_object_stream()
+    send_stream, receive_stream = create_memory_object_stream[str]()
     async with create_task_group() as tg:
         tg.start_soon(send)
         tg.start_soon(receive)
 
 
 async def test_statistics() -> None:
-    send_stream, receive_stream = create_memory_object_stream(1)
-    streams: list[MemoryObjectReceiveStream[int] | MemoryObjectSendStream[int]] = [
+    send_stream, receive_stream = create_memory_object_stream[None](1)
+    streams: list[MemoryObjectReceiveStream[None] | MemoryObjectSendStream[None]] = [
         send_stream,
         receive_stream,
     ]
@@ -337,7 +339,7 @@ async def test_statistics() -> None:
 
 
 async def test_sync_close() -> None:
-    send_stream, receive_stream = create_memory_object_stream(1)
+    send_stream, receive_stream = create_memory_object_stream[None](1)
     with send_stream, receive_stream:
         pass
 
@@ -356,7 +358,7 @@ async def test_type_variance() -> None:
     reassignments will trip the type checker.
 
     """
-    send, receive = create_memory_object_stream(item_type=float)
+    send, receive = create_memory_object_stream[float]()
     receive1: MemoryObjectReceiveStream[complex] = receive  # noqa: F841
     receive2: ObjectReceiveStream[complex] = receive  # noqa: F841
     send1: MemoryObjectSendStream[int] = send  # noqa: F841

--- a/tests/streams/test_text.py
+++ b/tests/streams/test_text.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.anyio
 
 
 async def test_receive() -> None:
-    send_stream, receive_stream = create_memory_object_stream(1)
+    send_stream, receive_stream = create_memory_object_stream[bytes](1)
     text_stream = TextReceiveStream(receive_stream)
     await send_stream.send(b"\xc3\xa5\xc3\xa4\xc3")  # ends with half of the "ö" letter
     assert await text_stream.receive() == "åä"
@@ -24,7 +24,7 @@ async def test_receive() -> None:
 
 
 async def test_send() -> None:
-    send_stream, receive_stream = create_memory_object_stream(1)
+    send_stream, receive_stream = create_memory_object_stream[bytes](1)
     text_stream = TextSendStream(send_stream)
     await text_stream.send("åäö")
     assert await receive_stream.receive() == b"\xc3\xa5\xc3\xa4\xc3\xb6"
@@ -36,21 +36,21 @@ async def test_send() -> None:
     reason="PyPy has a bug in its incremental UTF-8 decoder (#3274)",
 )
 async def test_receive_encoding_error() -> None:
-    send_stream, receive_stream = create_memory_object_stream(1)
+    send_stream, receive_stream = create_memory_object_stream[bytes](1)
     text_stream = TextReceiveStream(receive_stream, errors="replace")
     await send_stream.send(b"\xe5\xe4\xf6")  # "åäö" in latin-1
     assert await text_stream.receive() == "���"
 
 
 async def test_send_encoding_error() -> None:
-    send_stream, receive_stream = create_memory_object_stream(1)
+    send_stream, receive_stream = create_memory_object_stream[bytes](1)
     text_stream = TextSendStream(send_stream, encoding="iso-8859-1", errors="replace")
     await text_stream.send("€")
     assert await receive_stream.receive() == b"?"
 
 
 async def test_bidirectional_stream() -> None:
-    send_stream, receive_stream = create_memory_object_stream(1)
+    send_stream, receive_stream = create_memory_object_stream[bytes](1)
     stapled_stream = StapledObjectStream(send_stream, receive_stream)
     text_stream = TextStream(stapled_stream)
 

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -388,7 +388,7 @@ class TestTLSStream:
     async def test_default_context_ignore_unexpected_eof_flag_off(
         self, mocker: MockerFixture
     ) -> None:
-        send1, receive1 = create_memory_object_stream()
+        send1, receive1 = create_memory_object_stream[bytes]()
         client_stream = StapledObjectStream(send1, receive1)
         mocker.patch.object(TLSStream, "_call_sslobject_method")
         tls_stream = await TLSStream.wrap(client_stream)


### PR DESCRIPTION
This supports annotating memory object streams with uninstantiable types that the current `item_type` hack currently does not work for, e.g.

```python
create_memory_object_stream(item_type=Callable)
# error: No overload variant of "create_memory_object_stream" matches argument type
# "_SpecialForm"  [call-overload]
```

(See also the discussion around https://matrix.to/#/!JfFIjeKHlqEVmAsxYP:gitter.im/$sGb5WyohiQVFuiPdfb0GZ54h-CqN76sxeKKiCWovCdY?via=gitter.im&via=matrix.org)

@agronholm it turns out I was mistaken—due to a bug(?) in mypy, what I thought was a way to do this in a backwards compatible way isn't quite backwards compatible. While c93f3ec6951982a360d1aad23e7f2bd68d93cbe4 (note: not in this PR) is backwards-compatible at runtime (emitting a deprecation warning currently, but v3 could skip this) and backwards compatible in the sense that mypy will correctly infer types for e.g.

```python
s0, r0 = create_memory_object_stream(item_type=float)
s1, r1 = create_memory_object_stream()
```

it would be a breaking change since it makes unannotated calls emit

```python
s1, r1 = create_memory_object_stream()
# error: Need type annotation for "s1"  [var-annotated]
# error: Need type annotation for "r1"  [var-annotated]
```

on mypy. Note that mypy *does* infer a default item type of `Any` for `s1` and `r1`, but it still wants a type annotation. This is not affected by `--allow-any-generic` or `--disallow-any-generic`. It appears to be a known problem, see https://github.com/python/mypy/issues/3737#issuecomment-322778284.

Given that c93f3ec6951982a360d1aad23e7f2bd68d93cbe4 would produce spurious `var-annotated` on anyio 4 too, I think you are right that this has to be a breaking change in v4.