### PR TITLE
Improved cancellation semantics

### DIFF
--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -142,3 +142,21 @@ host task that will be copied, but the context of the task that calls
     support for this only landed in v3.7.
 
 .. _context: https://docs.python.org/3/library/contextvars.html
+
+Differences with asyncio.TaskGroup
+----------------------------------
+
+The :class:`asyncio.TaskGroup` class, added in Python 3.11, is very similar in design to
+the AnyIO :class:`~TaskGroup` class. The asyncio counterpart has some important
+differences in its semantics, however:
+
+* Tasks are spawned solely through :meth:`~asyncio.TaskGroup.create_task`; there is no
+  ``start()`` or ``start_soon()`` method
+* The :meth:`~asyncio.TaskGroup.create_task` method returns a task object which can be
+  awaited on (or cancelled)
+* Tasks can only be cancelled individually (there is no ``cancel()`` method or similar
+  in the task group)
+* When a task is cancelled before its coroutine has started running, it will not get a
+  chance to handle the cancellation exception
+* New tasks cannot be started after an exception in one of the tasks has triggered a
+  shutdown

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - **BACKWARDS INCOMPATIBLE** Replaced AnyIO's own ``ExceptionGroup`` class with the PEP
   654 ``BaseExceptionGroup`` and ``ExceptionGroup``
+- **BACKWARDS INCOMPATIBLE** Changes to cancellation semantics:
+
+  - Any exceptions raising out of a task groups are now nested inside an
+    ``ExceptionGroup`` (or ``BaseExceptionGroup`` if one or more ``BaseException`` were
+    included), except when all the exceptions are cancellation exceptions. In that case,
+    a single cancellation exception is raised instead.
 - Bumped minimum version of trio to v0.22
 - Added ``create_unix_datagram_socket`` and ``create_connected_unix_datagram_socket`` to
   create UNIX datagram sockets (PR by Jean Hominal)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -42,6 +42,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   the event loop to be closed
 - Fixed ``current_effective_deadline()`` not returning ``-inf`` on asyncio when the
   currently active cancel scope has been cancelled (PR by Ganden Schaffner)
+- Fixed task group not raising a cancellation exception on asyncio at exit if no child
+  tasks were spawned and an outer cancellation scope had been cancelled before
 
 **3.6.1**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -13,6 +13,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
     ``ExceptionGroup`` (or ``BaseExceptionGroup`` if one or more ``BaseException`` were
     included), except when all the exceptions are cancellation exceptions. In that case,
     a single cancellation exception is raised instead.
+  - ``CancelScope`` now un-cancels its host task on Python 3.11 + asyncio when
+    appropriate, for compatibility with ``asyncio.timeout`` and other context managers
+    that swallow exceptions
 - Bumped minimum version of trio to v0.22
 - Added ``create_unix_datagram_socket`` and ``create_connected_unix_datagram_socket`` to
   create UNIX datagram sockets (PR by Jean Hominal)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">= 3.7"
 dependencies = [
-    "exceptiongroup; python_version < '3.11'",
+    "exceptiongroup >= 1.0.2; python_version < '3.11'",
     "idna >= 2.8",
     "sniffio >= 1.1",
     "typing_extensions; python_version < '3.8'",

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -263,7 +263,6 @@ class CancelScope(BaseCancelScope):
             self._deliver_cancellation_to_parent()
 
         if exc_val is not None and isinstance(exc_val, CancelledError):
-            breakpoint()
             if not self._parent_cancelled():
                 if self._timeout_expired:
                     return True
@@ -474,7 +473,6 @@ class TaskGroup(abc.TaskGroup):
 
         self._active = False
         if self._exceptions:
-            # if self._exceptions and (len(self._exceptions) != 1 or self._exceptions[0] is exc_val):
             exc: BaseException | None
             group = BaseExceptionGroup("multiple tasks failed", self._exceptions)
             matched, unmatched = group.split(CancelledError)

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from anyio import (
@@ -15,6 +17,9 @@ from anyio import (
 )
 from anyio.abc import ObjectReceiveStream, ObjectSendStream
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import ExceptionGroup
 
 pytestmark = pytest.mark.anyio
 

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -230,7 +230,11 @@ class TestTLSStream:
             )
             with client_cm:
                 assert await wrapper.receive() == b"hello"
-                await wrapper.aclose()
+                try:
+                    await wrapper.aclose()
+                except ssl.SSLError:
+                    print("OpenSSL version:", ssl.OPENSSL_VERSION)
+                    raise
 
         server_thread.join()
         server_sock.close()

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -27,6 +27,9 @@ from anyio.abc import TaskStatus
 from anyio.from_thread import BlockingPortal, start_blocking_portal
 from anyio.lowlevel import checkpoint
 
+if sys.version_info < (3, 11):
+    from exceptiongroup import ExceptionGroup
+
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -390,9 +390,12 @@ class TestBlockingPortal:
                 yield
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
-            with pytest.raises(ZeroDivisionError):
+            with pytest.raises(ExceptionGroup) as exc:
                 with portal.wrap_async_context_manager(run_in_context()):
                     pass
+
+            _, unmatched = exc.value.split(ZeroDivisionError)
+            assert not unmatched
 
     def test_start_no_value(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1256,8 +1256,8 @@ class TestConnectedUDPSocket:
             async with await create_connected_udp_socket(
                 host, port, local_host="localhost", family=family
             ) as udp2:
-                host, port = udp2.extra(
-                    SocketAttribute.local_address  # type: ignore[misc]
+                host, port = udp2.extra(  # type: ignore[misc]
+                    SocketAttribute.local_address
                 )
                 await udp2.send(b"blah")
                 request = await udp1.receive()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -657,12 +657,15 @@ class TestTCPListener:
 
     async def test_close_from_other_task(self, family: AnyIPAddressFamily) -> None:
         listener = await create_tcp_listener(local_host="localhost", family=family)
-        with pytest.raises(ClosedResourceError):
+        with pytest.raises(ExceptionGroup) as exc:
             async with create_task_group() as tg:
                 tg.start_soon(listener.serve, lambda stream: None)
                 await wait_all_tasks_blocked()
                 await listener.aclose()
                 tg.cancel_scope.cancel()
+
+        _, unmatched = exc.value.split(ClosedResourceError)
+        assert not unmatched
 
     async def test_send_after_eof(self, family: AnyIPAddressFamily) -> None:
         async def handle(stream: SocketStream) -> None:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -237,7 +237,7 @@ async def test_start_exception_delivery() -> None:
 
     async with anyio.create_task_group() as tg:
         with pytest.raises(TypeError, match="to be synchronous$"):
-            await tg.start(task_fn)  # type: ignore[arg-type]
+            await tg.start(task_fn)
 
 
 async def test_host_exception() -> None:
@@ -862,6 +862,7 @@ async def test_exception_group_filtering() -> None:
 
     assert len(exc.value.exceptions) == 2
     assert str(exc.value.exceptions[0]) == "parent task failed"
+    assert isinstance(exc.value.exceptions[1], ExceptionGroup)
     assert str(exc.value.exceptions[1].exceptions[0]) == "child task failed"
 
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -189,7 +189,7 @@ async def test_start_exception_delivery() -> None:
 
     async with anyio.create_task_group() as tg:
         with pytest.raises(TypeError, match="to be synchronous$"):
-            await tg.start(task_fn)
+            await tg.start(task_fn)  # type: ignore[arg-type]
 
 
 async def test_host_exception() -> None:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1120,3 +1120,15 @@ class TestAsyncio:
             assert exceptions == []
         finally:
             loop.set_exception_handler(old_exception_handler)
+
+    @pytest.mark.skipif(sys.version_info < (3, 11), reason="Requires Python >= 3.11")
+    @pytest.mark.parametrize("anyio_backend", ["asyncio"])
+    async def test_asyncio_timeout(self) -> None:
+        """Test that CancelScope.__exit__ un-cancels the task."""
+        with CancelScope() as scope:
+            scope.cancel()
+            await sleep(2)
+            pytest.fail("Execution should not reach this point")
+
+        task = asyncio.current_task()
+        assert not task.cancelling()


### PR DESCRIPTION
We now use `strict_exception_groups=True` on Trio. Any non-base exceptions raised out of task groups are now wrapped in an exception group. If only cancellation exceptions are raised from an excgroup, they are merged into a single exception. This also takes care of variant 2 at #432.