### PR TITLE
Replace flake8 by ruff 🚀

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,21 +12,28 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
-        args: [ "--fix=lf" ]
+        args: ["--fix=lf"]
       - id: trailing-whitespace
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.121
+    hooks:
+      - id: ruff
+        args:
+          - --fix
 
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
       - id: isort
-        args: [ "-a", "from __future__ import annotations" ]
+        args: ["-a", "from __future__ import annotations"]
         exclude: "docs/conf.py"
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.2.2
     hooks:
       - id: pyupgrade
-        args: [ "--py37-plus", "--keep-mock" ]
+        args: ["--py37-plus", "--keep-mock"]
         exclude: "docs/conf.py"
 
   - repo: https://github.com/psf/black
@@ -34,16 +41,11 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/csachs/pyproject-flake8
-    rev: v5.0.4a1.post1
-    hooks:
-      - id: pyproject-flake8
-
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.991
     hooks:
       - id: mypy
-        additional_dependencies: [ "pytest", "trio-typing", "packaging" ]
+        additional_dependencies: ["pytest", "trio-typing", "packaging"]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 # * Run "pre-commit install".
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -16,7 +16,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.121
+    rev: v0.0.139
     hooks:
       - id: ruff
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,13 @@
 [build-system]
-requires = [
-    "setuptools >= 64",
-    "setuptools_scm >= 6.4"
-]
+requires = ["setuptools >= 64", "setuptools_scm >= 6.4"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "anyio"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 readme = "README.rst"
-authors = [{name = "Alex Grönholm", email = "alex.gronholm@nextday.fi"}]
-license = {text = "MIT"}
+authors = [{ name = "Alex Grönholm", email = "alex.gronholm@nextday.fi" }]
+license = { text = "MIT" }
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -51,14 +48,10 @@ test = [
     "trustme",
     "uvloop >= 0.17; platform_python_implementation == 'CPython' and platform_system != 'Windows'",
 ]
-doc = [
-    "packaging",
-    "sphinx_rtd_theme",
-    "sphinx-autodoc-typehints >= 1.2.0",
-]
+doc = ["packaging", "sphinx_rtd_theme", "sphinx-autodoc-typehints >= 1.2.0"]
 
 [project.entry-points]
-pytest11 = {anyio = "anyio.pytest_plugin"}
+pytest11 = { anyio = "anyio.pytest_plugin" }
 
 [tool.setuptools_scm]
 version_scheme = "post-release"
@@ -68,9 +61,27 @@ local_scheme = "dirty-tag"
 skip_gitignore = true
 profile = "black"
 
-[tool.flake8]
-max-line-length = 88
-ignore = ["E203", "W503"]
+[tool.ruff]
+select = [
+    "B", # bugbear
+    "C", # comprehensions
+    "E", # style errors
+    "F", # flakes
+    # "I",   # import sorting
+    "M", # meta
+    "N", # naming
+    "Q", # quotes
+    "S", # bandit
+    # "U",   # upgrade
+    "W",   # style warnings
+    "YTT", # sys.version
+]
+ignore = [
+    "E731", # Do not assign a lambda expression, use a def
+    "N818", # Exception name should be named with an Error suffix
+    "S101", # Use of `assert` detected
+    "S104", # Possible binding to all interfaces
+]
 
 [tool.mypy]
 python_version = "3.10"
@@ -92,11 +103,9 @@ filterwarnings = [
     "ignore:unclosed transport <_ProactorSocketTransport.*:ResourceWarning",
     # Workaround for Python 3.9.7 (see https://bugs.python.org/issue45097)
     "ignore:The loop argument is deprecated since Python 3\\.8, and scheduled for removal in Python 3\\.10\\.:DeprecationWarning:asyncio",
-    "ignore:Python 3.6 is no longer supported*"
+    "ignore:Python 3.6 is no longer supported*",
 ]
-markers = [
-    "network: marks tests as requiring Internet access",
-]
+markers = ["network: marks tests as requiring Internet access"]
 
 [tool.coverage.run]
 source = ["anyio"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,10 @@ profile = "black"
 
 [tool.ruff]
 select = [
-    "B", # bugbear
-    "C", # comprehensions
-    "E", # style errors
-    "F", # flakes
+    "B",  # bugbear
+    "C4", # comprehensions
+    "E",  # style errors
+    "F",  # flakes
     # "I",   # import sorting
     "M", # meta
     "N", # naming

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -135,6 +135,6 @@ from ._core._typedattr import TypedAttributeProvider, TypedAttributeSet, typed_a
 # Re-export imports so they look like they live directly in this package
 key: str
 value: Any
-for key, value in list(locals().items()):
+for value in list(locals().values()):
     if getattr(value, "__module__", "").startswith("anyio."):
         value.__module__ = __name__

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -155,7 +155,7 @@ def _task_started(task: asyncio.Task) -> bool:
         return getcoroutinestate(coro) in (CORO_RUNNING, CORO_SUSPENDED)
     except AttributeError:
         # task coro is async_genenerator_asend https://bugs.python.org/issue37771
-        raise Exception(f"Cannot determine if task {task} has started or not")
+        raise Exception(f"Cannot determine if task {task} has started or not") from None
 
 
 def _maybe_set_event_loop_policy(

--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -153,4 +153,4 @@ def get_async_backend(asynclib_name: str | None = None) -> AsyncBackend:
     except KeyError:
         module = import_module(modulename)
 
-    return getattr(module, "backend_class")
+    return module.backend_class

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -206,7 +206,7 @@ async def connect_tcp(
         # and the second one is an IPv4 addresses. The rest can be in whatever order.
         v6_found = v4_found = False
         target_addrs: list[tuple[socket.AddressFamily, str]] = []
-        for af, *rest, sa in gai_res:
+        for af, *_, sa in gai_res:
             if af == socket.AF_INET6 and not v6_found:
                 v6_found = True
                 target_addrs.insert(0, (af, sa[0]))
@@ -223,7 +223,7 @@ async def connect_tcp(
 
     oserrors: list[OSError] = []
     async with create_task_group() as tg:
-        for i, (af, addr) in enumerate(target_addrs):
+        for _, addr in target_addrs:
             event = Event()
             tg.start_soon(try_connect, addr, event)
             with move_on_after(happy_eyeballs_delay):

--- a/src/anyio/abc/__init__.py
+++ b/src/anyio/abc/__init__.py
@@ -93,6 +93,6 @@ from ..from_thread import BlockingPortal
 # Re-export imports so they look like they live directly in this package
 key: str
 value: Any
-for key, value in list(locals().items()):
+for value in list(locals().values()):
     if getattr(value, "__module__", "").startswith("anyio.abc."):
         value.__module__ = __name__

--- a/src/anyio/abc/_streams.py
+++ b/src/anyio/abc/_streams.py
@@ -34,7 +34,7 @@ class UnreliableObjectReceiveStream(
         try:
             return await self.receive()
         except EndOfStream:
-            raise StopAsyncIteration
+            raise StopAsyncIteration from None
 
     @abstractmethod
     async def receive(self) -> T_co:
@@ -130,7 +130,7 @@ class ByteReceiveStream(AsyncResource, TypedAttributeProvider):
         try:
             return await self.receive()
         except EndOfStream:
-            raise StopAsyncIteration
+            raise StopAsyncIteration from None
 
     @abstractmethod
     async def receive(self, max_bytes: int = 65536) -> bytes:

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -96,7 +96,7 @@ class _BlockingAsyncContextManager(Generic[T_co], AbstractContextManager):
             # `_BlockingAsyncContextManager.__exit__` is called, and an
             # `_exit_exc_info` has been set.
             result = await self._async_cm.__aexit__(*self._exit_exc_info)
-            return result
+        return result
 
     def __enter__(self) -> T_co:
         self._enter_future = Future()

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -96,6 +96,7 @@ class _BlockingAsyncContextManager(Generic[T_co], AbstractContextManager):
             # `_BlockingAsyncContextManager.__exit__` is called, and an
             # `_exit_exc_info` has been set.
             result = await self._async_cm.__aexit__(*self._exit_exc_info)
+
         return result
 
     def __enter__(self) -> T_co:

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -40,7 +40,9 @@ def run(func: Callable[..., Awaitable[T_Retval]], *args: object) -> T_Retval:
         async_backend = threadlocals.current_async_backend
         token = threadlocals.current_token
     except AttributeError:
-        raise RuntimeError("This function can only be run from an AnyIO worker thread")
+        raise RuntimeError(
+            "This function can only be run from an AnyIO worker thread"
+        ) from None
 
     return async_backend.run_async_from_thread(func, args, token=token)
 
@@ -58,7 +60,9 @@ def run_sync(func: Callable[..., T_Retval], *args: object) -> T_Retval:
         async_backend = threadlocals.current_async_backend
         token = threadlocals.current_token
     except AttributeError:
-        raise RuntimeError("This function can only be run from an AnyIO worker thread")
+        raise RuntimeError(
+            "This function can only be run from an AnyIO worker thread"
+        ) from None
 
     return async_backend.run_sync_from_thread(func, args, token=token)
 

--- a/src/anyio/streams/memory.py
+++ b/src/anyio/streams/memory.py
@@ -236,7 +236,7 @@ class MemoryObjectSendStream(Generic[T_contra], ObjectSendStream[T_contra]):
             if self._state.waiting_senders.pop(
                 send_event, None  # type: ignore[arg-type]
             ):
-                raise BrokenResourceError
+                raise BrokenResourceError from None
 
     def clone(self) -> MemoryObjectSendStream[T_contra]:
         """

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -265,14 +265,14 @@ class TLSListener(Listener[TLSStream]):
 
     @staticmethod
     async def handle_handshake_error(exc: BaseException, stream: AnyByteStream) -> None:
-        f"""
+        """
         Handle an exception raised during the TLS handshake.
 
         This method does 3 things:
 
         #. Forcefully closes the original stream
         #. Logs the exception (unless it was a cancellation exception) using the
-          ``{__name__}`` logger
+          ``anyio.streams.tls`` logger
         #. Reraises the exception if it was a base exception or a cancellation exception
 
         :param exc: the exception

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.anyio
 
 class TestAsyncFile:
     @pytest.fixture(scope="class")
-    def testdata(cls) -> bytes:
+    def testdata(cls) -> bytes:  # noqa: N805
         return b"".join(bytes([i] * 1000) for i in range(10))
 
     @pytest.fixture

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -35,7 +35,7 @@ async def test_receive_signals() -> None:
 async def test_task_group_cancellation_open() -> None:
     async def signal_handler() -> None:
         with open_signal_receiver(signal.SIGUSR1) as sigiter:
-            async for v in sigiter:
+            async for _ in sigiter:
                 pytest.fail("SIGUSR1 should not be sent")
 
             pytest.fail("signal_handler should have been cancelled")
@@ -49,7 +49,7 @@ async def test_task_group_cancellation_open() -> None:
 
 async def test_task_group_cancellation_consume() -> None:
     async def consume(sigiter: AsyncIterable[int]) -> None:
-        async for v in sigiter:
+        async for _ in sigiter:
             pytest.fail("SIGUSR1 should not be sent")
 
         pytest.fail("consume should have been cancelled")

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -335,7 +335,7 @@ async def test_cancel_propagation() -> None:
         async with create_task_group():
             await sleep(1)
 
-        assert False
+        raise AssertionError()
 
     async with create_task_group() as tg:
         tg.start_soon(g)
@@ -829,7 +829,7 @@ async def test_cancel_propagation_with_inner_spawn() -> None:
             tg2.start_soon(anyio.sleep, 10)
             await anyio.sleep(1)
 
-        assert False
+        raise AssertionError()
 
     async with anyio.create_task_group() as tg:
         tg.start_soon(g)


### PR DESCRIPTION
[Ruff](https://github.com/charliermarsh/ruff) is equivalent to flake8 but much faster.
I recommend reading the [launch blog article](https://notes.crmarsh.com/python-tooling-could-be-much-much-faster)

- [x] Fix f-string used as docstring. This would have been interpreted by python as a joined string rather than a docstring.
- [x] Rename and remove, if possible, unused loop control variables
- [x] Fix `return` inside finally blocks cause exceptions to be silenced
- [x] Fix Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.
- [x] Fix Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
- [x] Update configuration for the new release of `ruff`