### PR TITLE
Fix minor mistyping of `_trio._shutdown_process_pool`

### DIFF
--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -304,8 +304,7 @@ current_default_worker_process_limiter: trio.lowlevel.RunVar = RunVar(
 )
 
 
-async def _shutdown_process_pool(workers: set[Process]) -> None:
-    process: Process
+async def _shutdown_process_pool(workers: set[abc.Process]) -> None:
     try:
         await trio.sleep(math.inf)
     except trio.Cancelled:


### PR DESCRIPTION
Mypy only finds this when using `trio_typing.plugin`, since without it the call

https://github.com/agronholm/anyio/blob/eaac4de83886c1487afa96aa83f1b4eacaa11dbf/src/anyio/_backends/_trio.py#L914

is not fully typed.