### PR TITLE
Add opt-in fuller typing for callables accepting `(func, *args, ...)`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -31,6 +31,25 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   - ``create_memory_object_stream()`` now allows passing only ``item_type``
   - Object receive streams are now covariant and object send streams are correspondingly
     contravariant
+
+  - Several functions and methods that accept a function and positional arguments for it now have opt-in fuller typing for those using Mypy:
+
+    - ``anyio.run()``
+    - ``anyio.to_thread.run_sync()``
+    - ``anyio.from_thread.run()``
+    - ``anyio.from_thread.run_sync()``
+    - ``anyio.to_process.run_sync()``
+    - ``TaskGroup.start_soon()``
+    - ``TaskGroup.start()``
+    - ``BlockingPortal.call()``
+    - ``BlockingPortal.start_task_soon()``
+    - ``BlockingPortal.start_task()``
+
+    Opt-in by enabling the Mypy plugin ``trio_typing.plugin``. Note that the 5-argument
+    limitation of ``trio_typing.takes_callable_and_args`` applies. For those not using
+    ``trio_typing.plugin``, ``TaskGroup.start``'s return type has been changed from
+    ``object`` to ``Any`` (PR by Ganden Schaffner)
+
 - Fixed ``CapacityLimiter`` on the asyncio backend to order waiting tasks in the FIFO
   order (instead of LIFO) (PR by Conor Stevenson)
 - Fixed ``CancelScope.cancel()`` not working on asyncio if called before entering the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ warn_return_any = false
 disallow_untyped_decorators = false
 disallow_subclassing_any = false
 show_error_codes = true
+plugins = ["trio_typing.plugin"]
 
 [tool.pytest.ini_options]
 addopts = "-rsx --tb=short --strict-config --strict-markers -p anyio -p no:asyncio -p no:trio"

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -649,7 +649,7 @@ class TaskGroup(abc.TaskGroup):
         *args: Any,
         name: object = None,
     ) -> T_Retval:
-        future: asyncio.Future = asyncio.Future()
+        future: asyncio.Future[T_Retval] = asyncio.Future()
         task = self._spawn(func, args, name, future)
 
         # If the task raises an exception after sending a start value without a switch
@@ -2020,7 +2020,7 @@ class AsyncIOBackend(AsyncBackend):
 
         async with (limiter or cls.current_default_thread_limiter()):
             with CancelScope(shield=not cancellable):
-                future: asyncio.Future = asyncio.Future()
+                future: asyncio.Future[T_Retval] = asyncio.Future()
                 root_task = find_root_task()
                 if not idle_workers:
                     worker = WorkerThread(root_task, workers, idle_workers)

--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -11,7 +11,15 @@ from typing import TYPE_CHECKING, Any, TypeVar
 import sniffio
 
 if TYPE_CHECKING:
+    from mypy_extensions import VarArg
+    from trio_typing import takes_callable_and_args
+
     from ..abc import AsyncBackend
+else:
+
+    def takes_callable_and_args(fn):
+        return fn
+
 
 # This must be updated when new backends are introduced
 BACKENDS = "asyncio", "trio"
@@ -20,9 +28,11 @@ T_Retval = TypeVar("T_Retval")
 threadlocals = threading.local()
 
 
+@takes_callable_and_args
 def run(
-    func: Callable[..., Awaitable[T_Retval]],
-    *args: object,
+    func: Callable[..., Awaitable[T_Retval]]
+    | Callable[[VarArg()], Awaitable[T_Retval]],
+    *args: Any,
     backend: str = "asyncio",
     backend_options: dict[str, Any] | None = None,
 ) -> T_Retval:

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -187,7 +187,7 @@ async def open_file(
     :return: an asynchronous file object
 
     """
-    fp = await to_thread.run_sync(
+    fp = await to_thread.run_sync(  # type: ignore[call-overload,misc]
         open, file, mode, buffering, encoding, errors, newline, closefd, opener
     )
     return AsyncFile(fp)

--- a/src/anyio/to_thread.py
+++ b/src/anyio/to_thread.py
@@ -1,17 +1,27 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from ._core._eventloop import get_async_backend
 from .abc import CapacityLimiter
 
+if TYPE_CHECKING:
+    from mypy_extensions import VarArg
+    from trio_typing import takes_callable_and_args
+else:
+
+    def takes_callable_and_args(fn):
+        return fn
+
+
 T_Retval = TypeVar("T_Retval")
 
 
+@takes_callable_and_args
 async def run_sync(
-    func: Callable[..., T_Retval],
-    *args: object,
+    func: Callable[..., T_Retval] | Callable[[VarArg()], T_Retval],
+    *args: Any,
     cancellable: bool = False,
     limiter: CapacityLimiter | None = None,
 ) -> T_Retval:

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -397,22 +397,22 @@ class TestBlockingPortal:
     def test_start_no_value(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        def taskfunc(*, task_status: TaskStatus) -> None:
+        async def taskfunc(*, task_status: TaskStatus) -> None:
             task_status.started()
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
-            future, value = portal.start_task(taskfunc)  # type: ignore[arg-type]
+            future, value = portal.start_task(taskfunc)
             assert value is None
             assert future.result() is None
 
     def test_start_with_value(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        def taskfunc(*, task_status: TaskStatus) -> None:
+        async def taskfunc(*, task_status: TaskStatus) -> None:
             task_status.started("foo")
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
-            future, value = portal.start_task(taskfunc)  # type: ignore[arg-type]
+            future, value = portal.start_task(taskfunc)
             assert value == "foo"
             assert future.result() is None
 
@@ -429,7 +429,7 @@ class TestBlockingPortal:
     def test_start_crash_after_started_call(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        def taskfunc(*, task_status: TaskStatus) -> NoReturn:
+        async def taskfunc(*, task_status: TaskStatus) -> NoReturn:
             task_status.started(2)
             raise Exception("foo")
 
@@ -442,23 +442,21 @@ class TestBlockingPortal:
     def test_start_no_started_call(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        def taskfunc(*, task_status: TaskStatus) -> None:
+        async def taskfunc(*, task_status: TaskStatus) -> None:
             pass
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
             with pytest.raises(RuntimeError, match="Task exited"):
-                portal.start_task(taskfunc)  # type: ignore[arg-type]
+                portal.start_task(taskfunc)
 
     def test_start_with_name(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        def taskfunc(*, task_status: TaskStatus) -> None:
+        async def taskfunc(*, task_status: TaskStatus) -> None:
             task_status.started(get_current_task().name)
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
-            future, start_value = portal.start_task(
-                taskfunc, name="testname"  # type: ignore[arg-type]
-            )
+            future, start_value = portal.start_task(taskfunc, name="testname")
             assert start_value == "testname"
 
     def test_contextvar_propagation_sync(


### PR DESCRIPTION
this follows up discussion in #491. this uses `trio_typing.plugin` to add opt-in fuller typing to callables accepting `(func, *args, unrelated_kwarg0, ...)`. see `versionhistory.rst` for more detailed info.

all of the errors that Mypy currently produces when checking AnyIO with this PR are due to either #510 or https://github.com/python/mypy/issues/14337, I believe.

even with this Mypy bug, this PR is quite useful for typed AnyIO-dependent works as-is, but the Mypy bug does limit its usefulness to (for the most part) only non-generic functions.

if there is interest in this work, I'd be happy to add some typing tests to this PR.