### PR TITLE
Fix `TASK_STATUS_IGNORED`'s generic inheritance

### DIFF
--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import math
 from types import TracebackType
+from typing import Any
 
 from ..abc._tasks import TaskGroup, TaskStatus
 from ._eventloop import get_async_backend
 
 
-class _IgnoredTaskStatus(TaskStatus[object]):
+class _IgnoredTaskStatus(TaskStatus[Any]):
     def started(self, value: object = None) -> None:
         pass
 


### PR DESCRIPTION
the following currently fails type checking on the 4.0 dev branch:

```python
from anyio import TASK_STATUS_IGNORED
from anyio.abc import TaskStatus


async def foo(*, task_status: TaskStatus[None] = TASK_STATUS_IGNORED) -> None:
    # error: Incompatible default for argument "task_status" (default has type "_IgnoredTaskStatus", argument has type "TaskStatus[None]")  [assignment]
    raise NotImplementedError()
```