### PR TITLE
Fix `Event.wait()` cancellation race causing failure to notify all waiting tasks

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -44,6 +44,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   the event loop to be closed
 - Fixed ``current_effective_deadline()`` not returning ``-inf`` on asyncio when the
   currently active cancel scope has been cancelled (PR by Ganden Schaffner)
+- Fixed ``Event.set()`` failing to notify a waiter on asyncio if an ``Event.wait()``'s
+  scope was cancelled after ``Event.set()`` but before the scheduler resumed the waiting
+  task. This also fixed a race condition where ``MemoryObjectSendStream.send()`` could
+  raise a ``CancelledError`` on asyncio after successfully delivering an item to a
+  receiver (PR by Ganden Schaffner)
 
 **3.6.1**
 

--- a/src/anyio/streams/memory.py
+++ b/src/anyio/streams/memory.py
@@ -5,13 +5,7 @@ from dataclasses import dataclass, field
 from types import TracebackType
 from typing import Generic, NamedTuple, TypeVar
 
-from .. import (
-    BrokenResourceError,
-    ClosedResourceError,
-    EndOfStream,
-    WouldBlock,
-    get_cancelled_exc_class,
-)
+from .. import BrokenResourceError, ClosedResourceError, EndOfStream, WouldBlock
 from ..abc import Event, ObjectReceiveStream, ObjectSendStream
 from ..lowlevel import checkpoint
 
@@ -104,11 +98,6 @@ class MemoryObjectReceiveStream(Generic[T_co], ObjectReceiveStream[T_co]):
 
             try:
                 await receive_event.wait()
-            except get_cancelled_exc_class():
-                # Ignore the immediate cancellation if we already received an item, so
-                # as not to lose it
-                if not container:
-                    raise
             finally:
                 self._state.waiting_receivers.pop(receive_event, None)
 

--- a/tests/_backends/test_asyncio.py
+++ b/tests/_backends/test_asyncio.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+from _pytest.fixtures import getfixturemarker
+
+from anyio import create_task_group
+from anyio._backends._asyncio import cancelling
+from anyio.abc import TaskStatus
+from anyio.lowlevel import cancel_shielded_checkpoint, checkpoint
+from anyio.pytest_plugin import anyio_backend_name
+
+try:
+    from .conftest import anyio_backend as parent_anyio_backend
+except ImportError:
+    from ..conftest import anyio_backend as parent_anyio_backend
+
+pytestmark = pytest.mark.anyio
+
+# Use the inherited anyio_backend, but filter out non-asyncio
+anyio_backend = pytest.fixture(
+    params=[
+        param
+        for param in cast(Any, getfixturemarker(parent_anyio_backend)).params
+        if any(
+            "asyncio"
+            in anyio_backend_name.__wrapped__(backend)  # type: ignore[attr-defined]
+            for backend in param.values
+        )
+    ]
+)(parent_anyio_backend.__wrapped__)
+
+
+async def test_cancelling() -> None:
+    async def func(*, task_status: TaskStatus[asyncio.Task]) -> None:
+        task = cast(asyncio.Task, asyncio.current_task())
+        task_status.started(task)
+        try:
+            await checkpoint()
+        finally:
+            await cancel_shielded_checkpoint()
+
+    async with create_task_group() as tg:
+        task = cast(asyncio.Task, await tg.start(func))
+        assert not cancelling(task)
+        tg.cancel_scope.cancel()
+        assert cancelling(task)


### PR DESCRIPTION
fixes #536!