### PR TITLE
Don't try to document removed APIs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,7 +30,6 @@ Typed attributes
 Timeouts and cancellation
 -------------------------
 
-.. autofunction:: anyio.open_cancel_scope
 .. autofunction:: anyio.move_on_after
 .. autofunction:: anyio.fail_after
 .. autofunction:: anyio.current_effective_deadline
@@ -62,7 +61,6 @@ Running asynchronous code from other threads
 
 .. autofunction:: anyio.from_thread.run
 .. autofunction:: anyio.from_thread.run_sync
-.. autofunction:: anyio.from_thread.create_blocking_portal
 .. autofunction:: anyio.from_thread.start_blocking_portal
 
 .. autoclass:: anyio.abc.BlockingPortal
@@ -158,12 +156,6 @@ Synchronization
 .. autoclass:: anyio.ConditionStatistics
 .. autoclass:: anyio.CapacityLimiterStatistics
 
-.. autofunction:: anyio.create_event
-.. autofunction:: anyio.create_lock
-.. autofunction:: anyio.create_condition
-.. autofunction:: anyio.create_semaphore
-.. autofunction:: anyio.create_capacity_limiter
-
 Operating system signals
 ------------------------
 
@@ -177,12 +169,6 @@ Low level operations
 .. autofunction:: anyio.lowlevel.cancel_shielded_checkpoint
 
 .. autoclass:: anyio.lowlevel.RunVar
-
-Compatibility
--------------
-
-.. autofunction:: anyio.maybe_async
-.. autofunction:: anyio.maybe_async_cm
 
 Testing and debugging
 ---------------------
@@ -200,7 +186,6 @@ Exceptions
 .. autoexception:: anyio.ClosedResourceError
 .. autoexception:: anyio.DelimiterNotFound
 .. autoexception:: anyio.EndOfStream
-.. autoexception:: anyio.ExceptionGroup
 .. autoexception:: anyio.IncompleteRead
 .. autoexception:: anyio.TypedAttributeLookupError
 .. autoexception:: anyio.WouldBlock


### PR DESCRIPTION
2cd27f149631d59a7f06a1fcb66c1ec52ccb69f6 removed a bunch of deprecated APIs[^1], but since they weren't removed from `api.rst`, `tox -re docs` is failing now (on my laptop, as well as in a clean OCI container using the Python version used by Read the Docs).

[^1]: and `anyio.ExceptionGroup` was removed later too