### PR TITLE
Uncancel tasks cancelled using CancelScope.cancel()

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -48,6 +48,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   currently active cancel scope has been cancelled (PR by Ganden Schaffner)
 - Fixed the ``OP_IGNORE_UNEXPECTED_EOF`` flag in an SSL context created by default in
   ``TLSStream.wrap()`` being inadvertently set on Python 3.11.3 and 3.10.11
+- Fixed ``CancelScope`` to properly handle asyncio task uncancellation on Python 3.11
+  (PR by Nikolay Bryskin)
 
 **3.6.1**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ target-version = "py37"
 src = ["src"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 strict = true
 ignore_missing_imports = true
 disallow_any_generics = false

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -271,26 +271,28 @@ class CancelScope(BaseCancelScope):
                 exc_val.exceptions if isinstance(exc_val, ExceptionGroup) else [exc_val]
             )
             if all(isinstance(exc, CancelledError) for exc in exceptions):
-
-                def uncancel() -> None:
-                    if sys.version_info >= (3, 11):
-                        # Uncancel all anyio cancellations
-                        for i in range(self._cancel_calls):
-                            self._host_task.uncancel()
-                        self._cancel_calls = 0
-
                 if self._timeout_expired:
-                    uncancel()
-                    return True
+                    return self._uncancel()
                 elif not self._cancel_called:
                     # Task was cancelled natively
                     return None
                 elif not self._parent_cancelled():
                     # This scope was directly cancelled
-                    uncancel()
-                    return True
+                    return self._uncancel()
 
         return None
+
+    def _uncancel(self) -> bool:
+        if sys.version_info < (3, 11) or self._host_task is None:
+            self._cancel_calls = 0
+            return True
+
+        # Uncancel all AnyIO cancellations
+        for i in range(self._cancel_calls):
+            self._host_task.uncancel()
+
+        self._cancel_calls = 0
+        return not self._host_task.cancelling()
 
     def _timeout(self) -> None:
         if self._deadline != math.inf:
@@ -594,7 +596,7 @@ class TaskGroup(abc.TaskGroup):
                 "This task group is not active; no new tasks can be started."
             )
 
-        options = {}
+        options: dict[str, Any] = {}
         name = get_callable_name(func) if name is None else str(name)
         if _native_task_names:
             options["name"] = name
@@ -2116,7 +2118,7 @@ class AsyncIOBackend(AsyncBackend):
 
     @classmethod
     def setup_process_pool_exit_at_shutdown(cls, workers: set[abc.Process]) -> None:
-        kwargs = (
+        kwargs: dict[str, Any] = (
             {"name": "AnyIO process pool shutdown task"} if _native_task_names else {}
         )
         create_task(_shutdown_process_pool_on_exit(workers), **kwargs)

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -123,14 +123,12 @@ def test_wait_generator_based_task_blocked(
 
         event.set()
 
-    @asyncio.coroutine
+    @asyncio.coroutine  # type: ignore[attr-defined]
     def generator_part() -> Generator[object, BaseException, None]:
-        yield from event.wait()
+        yield from event.wait()  # type: ignore[misc]
 
     event = asyncio.Event()
-    gen_task: asyncio.Task[None] = asyncio_event_loop.create_task(
-        generator_part()  # type: ignore[arg-type]
-    )
+    gen_task: asyncio.Task[None] = asyncio_event_loop.create_task(generator_part())
     asyncio_event_loop.run_until_complete(native_coro_part())
 
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1125,3 +1125,4 @@ class TestUncancel:
             await anyio.sleep(0)
 
         assert task.cancelling() == 1
+        task.uncancel()

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -237,7 +237,7 @@ async def test_start_exception_delivery() -> None:
 
     async with anyio.create_task_group() as tg:
         with pytest.raises(TypeError, match="to be synchronous$"):
-            await tg.start(task_fn)
+            await tg.start(task_fn)  # type: ignore[arg-type]
 
 
 async def test_host_exception() -> None:


### PR DESCRIPTION
This patch is needed for correct task canceling when using asyncio backend on Python >= 3.11.
Related discussion https://github.com/encode/httpx/discussions/2506