### PR TITLE
Turned TaskStatus into a protocol

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -25,8 +25,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
     - ``BlockingPortal.start_task_soon()``
     - ``BlockingPortal.start_task()``
 
-  - The ``TaskStatus`` class is now generic, and should be parametrized to indicate the
-    type of the value passed to ``task_status.started()``
+  - The ``TaskStatus`` class is now a generic protocol, and should be parametrized to
+    indicate the type of the value passed to ``task_status.started()``
   - The ``Listener`` class is now covariant in its stream type
   - ``create_memory_object_stream()`` now allows passing only ``item_type``
   - Object receive streams are now covariant and object send streams are correspondingly

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -77,6 +77,7 @@ from ..abc import (
     UDPPacketType,
     UNIXDatagramPacketType,
 )
+from ..abc._tasks import T_contra
 from ..lowlevel import RunVar
 from ..streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
@@ -428,7 +429,7 @@ class _AsyncioTaskStatus(abc.TaskStatus):
         self._future = future
         self._parent_id = parent_id
 
-    def started(self, value: object = None) -> None:
+    def started(self, value: T_contra | None = None) -> None:
         try:
             self._future.set_result(value)
         except asyncio.InvalidStateError:

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -1,19 +1,34 @@
 from __future__ import annotations
 
+import sys
 from abc import ABCMeta, abstractmethod
 from collections.abc import Awaitable, Callable, Coroutine
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, overload
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 if TYPE_CHECKING:
     from .._core._tasks import CancelScope
 
 T_Retval = TypeVar("T_Retval")
+T_contra = TypeVar("T_contra", contravariant=True)
+T_co = TypeVar("T_co", covariant=True)
 
 
-class TaskStatus(Generic[T_Retval]):
-    @abstractmethod
-    def started(self, value: T_Retval | None = None) -> None:
+class TaskStatus(Protocol[T_contra]):
+    @overload
+    def started(self) -> None:
+        ...
+
+    @overload
+    def started(self, value: T_contra) -> None:
+        ...
+
+    def started(self, value: T_contra | None = None) -> None:
         """
         Signal that the task has started.
 
@@ -54,7 +69,7 @@ class TaskGroup(metaclass=ABCMeta):
         func: Callable[..., Awaitable[Any]],
         *args: object,
         name: object = None,
-    ) -> object:
+    ) -> Any:
         """
         Start a new task and wait until it signals for readiness.
 


### PR DESCRIPTION
As the Trio version of TaskStatus does not inherit from anyio.abc.TaskStatus, this is the right call.