### PR TITLE
Fix broken support for `Callable[..., Awaitable]`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -14,17 +14,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   create UNIX datagram sockets (PR by Jean Hominal)
 - Improved type annotations:
 
-  - Several functions and methods that previously only accepted coroutines as the return
-    type of the callable have been amended to accept any awaitables:
-
-    - ``anyio.run()``
-    - ``anyio.from_thread.run()``
-    - ``TaskGroup.start_soon()``
-    - ``TaskGroup.start()``
-    - ``BlockingPortal.call()``
-    - ``BlockingPortal.start_task_soon()``
-    - ``BlockingPortal.start_task()``
-
   - The ``TaskStatus`` class is now a generic protocol, and should be parametrized to
     indicate the type of the value passed to ``task_status.started()``
   - The ``Listener`` class is now covariant in its stream type
@@ -50,6 +39,18 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``TLSStream.wrap()`` being inadvertently set on Python 3.11.3 and 3.10.11
 - Fixed ``CancelScope`` to properly handle asyncio task uncancellation on Python 3.11
   (PR by Nikolay Bryskin)
+- Several functions and methods that previously only accepted coroutines as the return
+  type of the callable can now accept any awaitables:
+
+  - ``anyio.run()``
+  - ``anyio.from_thread.run()``
+  - ``TaskGroup.start_soon()``
+  - ``TaskGroup.start()``
+  - ``BlockingPortal.call()``
+  - ``BlockingPortal.start_task_soon()``
+  - ``BlockingPortal.start_task()``
+
+  (PRs by Alex Grönholm and Ganden Schaffner)
 
 **3.6.1**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "exceptiongroup; python_version < '3.11'",
     "idna >= 2.8",
     "sniffio >= 1.1",
-    "typing_extensions; python_version < '3.8'",
+    "typing_extensions >= 3.10; python_version < '3.10'",
 ]
 dynamic = ["version"]
 
@@ -49,7 +49,6 @@ test = [
     "pytest >= 7.0",
     "pytest-mock >= 3.6.1",
     "trustme",
-    "typing_extensions >= 3.10; python_version < '3.10'",
     "uvloop >= 0.17; platform_python_implementation == 'CPython' and platform_system != 'Windows'",
 ]
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
     "pytest >= 7.0",
     "pytest-mock >= 3.6.1",
     "trustme",
+    "typing_extensions >= 3.10; python_version < '3.10'",
     "uvloop >= 0.17; platform_python_implementation == 'CPython' and platform_system != 'Windows'",
 ]
 doc = [

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from abc import ABCMeta, abstractmethod
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Awaitable, Callable
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, TypeVar, overload
 
@@ -48,7 +48,7 @@ class TaskGroup(metaclass=ABCMeta):
     @abstractmethod
     def start_soon(
         self,
-        func: Callable[..., Coroutine[Any, Any, Any]],
+        func: Callable[..., Awaitable[Any]],
         *args: object,
         name: object = None,
     ) -> None:

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import sys
+from typing import Any, Awaitable, Callable, Generator, TypeVar
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+def return_non_coro_awaitable(
+    func: Callable[P, Awaitable[T]]
+) -> Callable[P, Awaitable[T]]:
+    class Wrapper:
+        def __init__(self, *args: P.args, **kwargs: P.kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def __await__(self) -> Generator[Any, None, T]:
+            return func(*self.args, **self.kwargs).__await__()
+
+    return Wrapper

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -39,10 +39,12 @@ T_Retval = TypeVar("T_Retval")
 
 async def async_add(a: int, b: int) -> int:
     assert threading.current_thread() is threading.main_thread()
+    await checkpoint()
     return a + b
 
 
 async def asyncgen_add(a: int, b: int) -> AsyncGenerator[int, Any]:
+    await checkpoint()
     yield a + b
 
 
@@ -114,13 +116,6 @@ class TestRunAsyncFromThread:
             await to_thread.run_sync(thread_worker_sync, sync_add, 1, "foo")
 
         exc.match("unsupported operand type")
-
-    async def test_run_anyio_async_func_from_thread(self) -> None:
-        def worker(*args: int) -> Literal[True]:
-            from_thread.run(sleep, *args)
-            return True
-
-        assert await to_thread.run_sync(worker, 0)
 
     def test_run_async_from_unclaimed_thread(self) -> None:
         async def foo() -> None:

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -392,22 +392,22 @@ class TestBlockingPortal:
     def test_start_no_value(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        def taskfunc(*, task_status: TaskStatus) -> None:
+        async def taskfunc(*, task_status: TaskStatus) -> None:
             task_status.started()
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
-            future, value = portal.start_task(taskfunc)  # type: ignore[arg-type]
+            future, value = portal.start_task(taskfunc)
             assert value is None
             assert future.result() is None
 
     def test_start_with_value(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        def taskfunc(*, task_status: TaskStatus) -> None:
+        async def taskfunc(*, task_status: TaskStatus) -> None:
             task_status.started("foo")
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
-            future, value = portal.start_task(taskfunc)  # type: ignore[arg-type]
+            future, value = portal.start_task(taskfunc)
             assert value == "foo"
             assert future.result() is None
 
@@ -437,23 +437,21 @@ class TestBlockingPortal:
     def test_start_no_started_call(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        def taskfunc(*, task_status: TaskStatus) -> None:
+        async def taskfunc(*, task_status: TaskStatus) -> None:
             pass
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
             with pytest.raises(RuntimeError, match="Task exited"):
-                portal.start_task(taskfunc)  # type: ignore[arg-type]
+                portal.start_task(taskfunc)
 
     def test_start_with_name(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        def taskfunc(*, task_status: TaskStatus) -> None:
+        async def taskfunc(*, task_status: TaskStatus) -> None:
             task_status.started(get_current_task().name)
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
-            future, start_value = portal.start_task(
-                taskfunc, name="testname"  # type: ignore[arg-type]
-            )
+            future, start_value = portal.start_task(taskfunc, name="testname")
             assert start_value == "testname"
 
     def test_contextvar_propagation_sync(


### PR DESCRIPTION
the `Callable[..., Awaitable]` support that was added and documented in 538b739b8a33bbdbf305e11d93c8bc34154e50d7 (and in the 3.x backport df9801f0b4d3d4df9e35318450a03c5723864a12)

*   does not work at runtime (for most of the changed functions—see failing tests below)
*   forgot to update the annotation for `start_soon`

closes #493.