### PR TITLE
Updated cancellation semantics to better match the new trio and asyncio ones

### DIFF
--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -139,3 +139,21 @@ host task that will be copied, but the context of the task that calls
 :meth:`TaskGroup.start_soon() <.abc.TaskGroup.start_soon>`.
 
 .. _context: https://docs.python.org/3/library/contextvars.html
+
+Differences with asyncio.TaskGroup
+----------------------------------
+
+The :class:`asyncio.TaskGroup` class, added in Python 3.11, is very similar in design to
+the AnyIO :class:`~TaskGroup` class. The asyncio counterpart has some important
+differences in its semantics, however:
+
+* Tasks are spawned solely through :meth:`~asyncio.TaskGroup.create_task`; there is no
+  ``start()`` or ``start_soon()`` method
+* The :meth:`~asyncio.TaskGroup.create_task` method returns a task object which can be
+  awaited on (or cancelled)
+* Tasks can only be cancelled individually (there is no ``cancel()`` method or similar
+  in the task group)
+* When a task is cancelled before its coroutine has started running, it will not get a
+  chance to handle the cancellation exception
+* New tasks cannot be started after an exception in one of the tasks has triggered a
+  shutdown

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -151,9 +151,10 @@ differences in its semantics, however:
   ``start()`` or ``start_soon()`` method
 * The :meth:`~asyncio.TaskGroup.create_task` method returns a task object which can be
   awaited on (or cancelled)
-* Tasks can only be cancelled individually (there is no ``cancel()`` method or similar
-  in the task group)
-* When a task is cancelled before its coroutine has started running, it will not get a
-  chance to handle the cancellation exception
-* New tasks cannot be started after an exception in one of the tasks has triggered a
-  shutdown
+* Tasks spawned via :meth:`~asyncio.TaskGroup.create_task` can only be cancelled
+  individually (there is no ``cancel()`` method or similar in the task group)
+* When a task spawned via :meth:`~asyncio.TaskGroup.create_task` is cancelled before its
+  coroutine has started running, it will not get a chance to handle the cancellation
+  exception
+* :class:`asyncio.TaskGroup` does not allow starting new tasks after an exception in
+  one of the tasks has triggered a shutdown of the task group

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,13 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - **BACKWARDS INCOMPATIBLE** Replaced AnyIO's own ``ExceptionGroup`` class with the PEP
   654 ``BaseExceptionGroup`` and ``ExceptionGroup``
+- **BACKWARDS INCOMPATIBLE** Changes to cancellation semantics:
+
+  - Any exceptions raising out of a task groups are now nested inside an
+    ``ExceptionGroup`` (or ``BaseExceptionGroup`` if one or more ``BaseException`` were
+    included)
+  - Fixed task group not raising a cancellation exception on asyncio at exit if no child
+    tasks were spawned and an outer cancellation scope had been cancelled before
 - **BACKWARDS INCOMPATIBLE** Changes the pytest plugin to run all tests and fixtures in
   the same task, allowing fixtures to set context variables for tests and other fixtures
 - **BACKWARDS INCOMPATIBLE** Changed ``anyio.Path.relative_to()`` and

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -14,6 +14,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
     included)
   - Fixed task group not raising a cancellation exception on asyncio at exit if no child
     tasks were spawned and an outer cancellation scope had been cancelled before
+  - Ensured that exiting a ``TaskGroup`` always hits a yield point, regardless of
+    whether there are running child tasks to be waited on
 - **BACKWARDS INCOMPATIBLE** Changes the pytest plugin to run all tests and fixtures in
   the same task, allowing fixtures to set context variables for tests and other fixtures
 - **BACKWARDS INCOMPATIBLE** Changed ``anyio.Path.relative_to()`` and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 requires-python = ">= 3.8"
 dependencies = [
-    "exceptiongroup; python_version < '3.11'",
+    "exceptiongroup >= 1.0.2; python_version < '3.11'",
     "idna >= 2.8",
     "sniffio >= 1.1",
 ]

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -510,7 +510,9 @@ class TaskGroup(abc.TaskGroup):
 
         self._active = False
         if self._exceptions:
-            group = BaseExceptionGroup("multiple tasks failed", self._exceptions)
+            group = BaseExceptionGroup(
+                "unhandled errors in a TaskGroup", self._exceptions
+            )
             _, errors = group.split(CancelledError)
             if errors is not None:
                 raise errors

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -499,11 +499,15 @@ class TaskGroup(abc.TaskGroup):
             )
 
         # Raise the CancelledError received while waiting for child tasks to exit,
-        # unless the context manager itself was previously exited with another exception
+        # unless the context manager itself was previously exited with another
+        # exception, or if any of the  child tasks raised an exception other than
+        # CancelledError
         if cancelled_exc_while_waiting_tasks:
             if exc_val is None or ignore_exception:
                 raise cancelled_exc_while_waiting_tasks
 
+        # Yield control to the event loop here to ensure that there is at least one
+        # yield point within __aexit__() (trio does the same)
         if not waited_for_tasks_to_finish:
             await AsyncIOBackend.checkpoint()
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -513,6 +513,7 @@ class TaskGroup(abc.TaskGroup):
             group = BaseExceptionGroup(
                 "unhandled errors in a TaskGroup", self._exceptions
             )
+            # Remove cancellation errors from the group
             _, errors = group.split(CancelledError)
             if errors is not None:
                 raise errors

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -499,7 +499,7 @@ class TaskGroup(abc.TaskGroup):
         while self.cancel_scope._tasks:
             try:
                 await asyncio.wait(self.cancel_scope._tasks)
-            except asyncio.CancelledError as exc:
+            except CancelledError as exc:
                 # This task was cancelled natively; reraise the CancelledError later
                 # unless this task was already interrupted by another exception
                 self.cancel_scope.cancel()

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -46,7 +46,6 @@ from typing import (
     Collection,
     ContextManager,
     Coroutine,
-    Iterator,
     Mapping,
     Optional,
     Sequence,
@@ -460,18 +459,6 @@ def collapse_exception_group(excgroup: BaseExceptionGroup) -> BaseException:
         return excgroup.derive(exceptions)
     else:
         return excgroup
-
-
-def walk_exception_group(excgroup: BaseExceptionGroup) -> Iterator[BaseException]:
-    for exc in excgroup.exceptions:
-        if isinstance(exc, BaseExceptionGroup):
-            yield from walk_exception_group(exc)
-        else:
-            yield exc
-
-
-def is_anyio_cancelled_exc(exc: BaseException) -> bool:
-    return isinstance(exc, CancelledError) and not exc.args
 
 
 class TaskGroup(abc.TaskGroup):

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -498,6 +498,7 @@ class TaskGroup(abc.TaskGroup):
                 self._exceptions.append(exc_val)
 
         cancelled_exc_while_waiting_tasks: CancelledError | None = None
+        waited_for_tasks_to_finish = bool(self.cancel_scope._tasks)
         while self.cancel_scope._tasks:
             try:
                 await asyncio.wait(self.cancel_scope._tasks)
@@ -519,6 +520,9 @@ class TaskGroup(abc.TaskGroup):
         if cancelled_exc_while_waiting_tasks:
             if exc_val is None or ignore_exception:
                 raise cancelled_exc_while_waiting_tasks
+
+        if not waited_for_tasks_to_finish:
+            await AsyncIOBackend.checkpoint()
 
         return ignore_exception
 

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -134,7 +134,7 @@ class CancelScope(BaseCancelScope):
 class TaskGroup(abc.TaskGroup):
     def __init__(self) -> None:
         self._active = False
-        self._nursery_manager = trio.open_nursery()
+        self._nursery_manager = trio.open_nursery(strict_exception_groups=True)
         self.cancel_scope = None  # type: ignore[assignment]
 
     async def __aenter__(self) -> TaskGroup:

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from anyio import (
@@ -15,6 +17,9 @@ from anyio import (
 )
 from anyio.abc import ObjectReceiveStream, ObjectSendStream
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import ExceptionGroup
 
 pytestmark = pytest.mark.anyio
 
@@ -170,20 +175,26 @@ async def test_clone_closed() -> None:
 
 async def test_close_send_while_receiving() -> None:
     send, receive = create_memory_object_stream(1)
-    with pytest.raises(EndOfStream):
+    with pytest.raises(ExceptionGroup) as exc:
         async with create_task_group() as tg:
             tg.start_soon(receive.receive)
             await wait_all_tasks_blocked()
             await send.aclose()
 
+    assert len(exc.value.exceptions) == 1
+    assert isinstance(exc.value.exceptions[0], EndOfStream)
+
 
 async def test_close_receive_while_sending() -> None:
     send, receive = create_memory_object_stream(0)
-    with pytest.raises(BrokenResourceError):
+    with pytest.raises(ExceptionGroup) as exc:
         async with create_task_group() as tg:
             tg.start_soon(send.send, "hello")
             await wait_all_tasks_blocked()
             await receive.aclose()
+
+    assert len(exc.value.exceptions) == 1
+    assert isinstance(exc.value.exceptions[0], BrokenResourceError)
 
 
 async def test_receive_after_send_closed() -> None:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1170,6 +1170,15 @@ class TestUncancel:
         task.uncancel()
 
 
+async def test_cancel_before_entering_task_group() -> None:
+    with CancelScope() as scope:
+        scope.cancel()
+        async with create_task_group():
+            pass
+
+        pytest.fail("Execution should never reach this point")
+
+
 class TestTaskStatusTyping:
     """
     These tests do not do anything at run time, but since the test suite is also checked

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -231,6 +231,19 @@ async def test_start_native_child_cancelled() -> None:
     assert not finished
 
 
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_propagate_native_cancellation_from_taskgroup() -> None:
+    async def taskfunc() -> None:
+        async with create_task_group() as tg:
+            tg.start_soon(asyncio.sleep, 2)
+
+    task = asyncio.create_task(taskfunc())
+    await wait_all_tasks_blocked()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
 async def test_start_exception_delivery(anyio_backend_name: str) -> None:
     def task_fn(*, task_status: TaskStatus = TASK_STATUS_IGNORED) -> None:
         task_status.started("hello")


### PR DESCRIPTION
This is a lighter version of #496 which I could never get right.

Fixes #374.