### PR TITLE
Also consider cancel counts for swallowing CancelledError on asyncio

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,6 +8,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Added documentation on how to migrate from AnyIO 3 to 4
 - Fixed the type annotation of ``TaskGroup.start_soon()`` to accept any awaitables
   (already in v3.7.0 but was missing from 4.0.0rc1)
+- Changed ``CancelScope`` to also consider the cancellation count (in addition to the cancel
+  message) on asyncio to determine if a cancellation exception should be swallowed on scope exit,
+  to combat issues where third party libraries catch the ``CancelledError`` and raise another, thus
+  erasing the original cancel message
 
 **4.0.0rc1**
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1255,15 +1255,21 @@ class TestUncancel:
         task.uncancel()
 
     async def test_cancel_message_replaced(self) -> None:
+        task = asyncio.current_task()
+        assert task
         try:
-            with CancelScope() as scope:
-                scope.cancel()
-                try:
-                    await anyio.sleep(0)
-                except asyncio.CancelledError:
-                    raise asyncio.CancelledError
+            task.cancel()
+            await anyio.sleep(0)
         except asyncio.CancelledError:
-            pytest.fail("Should have swallowed the CancelledError")
+            try:
+                with CancelScope() as scope:
+                    scope.cancel()
+                    try:
+                        await anyio.sleep(0)
+                    except asyncio.CancelledError:
+                        raise asyncio.CancelledError
+            except asyncio.CancelledError:
+                pytest.fail("Should have swallowed the CancelledError")
 
 
 async def test_cancel_before_entering_task_group() -> None:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1254,6 +1254,17 @@ class TestUncancel:
         assert task.cancelling() == 1
         task.uncancel()
 
+    async def test_cancel_message_replaced(self) -> None:
+        try:
+            with CancelScope() as scope:
+                scope.cancel()
+                try:
+                    await anyio.sleep(0)
+                except asyncio.CancelledError:
+                    raise asyncio.CancelledError
+        except asyncio.CancelledError:
+            pytest.fail("Should have swallowed the CancelledError")
+
 
 async def test_cancel_before_entering_task_group() -> None:
     with CancelScope() as scope:


### PR DESCRIPTION
This fixes cases on Python 3.11+ where a third party library catches a `CancelledError` and raises another one without including the original message. At least asyncpg is [known to do this](https://github.com/MagicStack/asyncpg/blob/7cb4e70d88d165273997d914280c6d109fbbc8f6/asyncpg/compat.py#L62-L63).