### PR TITLE
Implemented contextvars isolation in test runner using distinct tasks for each scope

### DIFF
--- a/src/anyio/abc/_testing.py
+++ b/src/anyio/abc/_testing.py
@@ -31,12 +31,14 @@ class TestRunner(metaclass=ABCMeta):
         self,
         fixture_func: Callable[..., AsyncGenerator[_T, Any]],
         kwargs: dict[str, Any],
+        scope: str = "function",
     ) -> Iterable[_T]:
         """
         Run an async generator fixture.
 
         :param fixture_func: the fixture function
         :param kwargs: keyword arguments to call the fixture function with
+        :param scope: the pytest scope in which the fixture is defined
         :return: an iterator yielding the value yielded from the async generator
         """
 
@@ -45,12 +47,14 @@ class TestRunner(metaclass=ABCMeta):
         self,
         fixture_func: Callable[..., Coroutine[Any, Any, _T]],
         kwargs: dict[str, Any],
+        scope: str = "function",
     ) -> _T:
         """
         Run an async fixture.
 
         :param fixture_func: the fixture function
         :param kwargs: keyword arguments to call the fixture function with
+        :param scope: the pytest scope in which the fixture is defined
         :return: the return value of the fixture function
         """
 
@@ -63,4 +67,11 @@ class TestRunner(metaclass=ABCMeta):
 
         :param test_func: the test function
         :param kwargs: keyword arguments to call the test function with
+        """
+
+    def close_scope(self, scope: str) -> None:
+        """
+        Close the context associated to a scope
+
+        :param scope: the scope to close
         """


### PR DESCRIPTION
This is an implementation of contextvars isolation between tests, using distinct tasks and queues for each pytest scope.

I am sure that there is a lot to review (e.g. the `_TaskManager` name is not very inspired ;)), but it seems that the basic functionality works. (The documentation should also be updated to document this new behaviour of the test runner)

I am going to implement the solution to issue #614 on top of the implementation in this branch, when I have a bit more time, but in the meantime I welcome any and all feedback.