### PR TITLE
tests: test_fileio.py: don't follow symlinks in /dev

### DIFF
--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -218,7 +218,7 @@ class TestPath:
         assert not await Path("/btelkbee").is_block_device()
         with os.scandir("/dev") as iterator:
             for entry in iterator:
-                if stat.S_ISBLK(entry.stat().st_mode):
+                if stat.S_ISBLK(entry.stat(follow_symlinks=False).st_mode):
                     assert await Path(entry.path).is_block_device()
                     break
             else:


### PR DESCRIPTION
There might be a broken one like `/dev/log` and this causes the tests to fail.

This is highly is unpredictable, because `os.scandir()` sometimes returns a block device, sometimes the broken link is hit.

So pass `follow_symlinks=False` to `entry.stat()`.