### PR TITLE
Fixed asyncio `CancelScope` not recognizing its own cancellation exception

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -12,6 +12,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   - Removed a checkpoint when exiting a task group
 - Bumped minimum version of trio to v0.23
 - Exposed the ``ResourceGuard`` class in the public API
+- Fixed discrepancy between ``asyncio`` and ``trio`` where reraising a cancellation
+  exception in an ``except*`` block would incorrectly bubble out of its cancel scope
 
 **4.0.0**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ trio = ["trio >= 0.23"]
 test = [
     "anyio[trio]",
     "coverage[toml] >= 7",
+    "exceptiongroup >= 1.2.0",
     "hypothesis >= 4.0",
     "psutil >= 5.9",
     "pytest >= 7.0",

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncGenerator, Coroutine, Generator
 from typing import Any, NoReturn, cast
 
 import pytest
+from exceptiongroup import catch
 
 import anyio
 from anyio import (
@@ -1280,6 +1281,16 @@ async def test_cancel_before_entering_task_group() -> None:
                 pass
         except get_cancelled_exc_class():
             pytest.fail("This should not raise a cancellation exception")
+
+
+async def test_reraise_cancelled_in_excgroup() -> None:
+    def handler(excgrp: BaseExceptionGroup) -> None:
+        raise
+
+    with CancelScope() as scope:
+        scope.cancel()
+        with catch({get_cancelled_exc_class(): handler}):
+            await anyio.sleep_forever()
 
 
 class TestTaskStatusTyping:


### PR DESCRIPTION
...if it comes wrapped in an exception group.
Fixes #634.