### PR TITLE
Fixed cancellation propagation when task group host is in a shielded scope

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -13,6 +13,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   from Egor Blagov)
 - Fixed ``loop_factory`` and ``use_uvloop`` options not being used on the asyncio
   backend (`#643 <https://github.com/agronholm/anyio/issues/643>`_)
+- Fixed cancellation propagating on asyncio from a task group to child tasks if the task
+  hosting the task group is in a shielded cancel scope
+  (`#642 <https://github.com/agronholm/anyio/issues/642>`_)
 
 **4.1.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -503,7 +503,10 @@ class CancelScope(BaseCancelScope):
         return should_retry
 
     def _restart_cancellation_in_parent(self) -> None:
-        """Restart the cancellation effort in the closest directly cancelled parent scope"""
+        """
+        Restart the cancellation effort in the closest directly cancelled parent scope.
+
+        """
         scope = self._parent_scope
         while scope is not None:
             if scope._cancel_called:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -505,18 +505,8 @@ class CancelScope(BaseCancelScope):
     def _restart_cancellation_in_parent(self) -> None:
         """Start cancellation effort in the closest directly cancelled parent scope"""
         scope = self._parent_scope
-        while scope is not None:
-            if scope._cancel_called:
-                if scope._cancel_handle is None:
-                    scope._deliver_cancellation(scope)
-
-                break
-
-            # No point in looking beyond any shielded scope
-            if scope._shield:
-                break
-
-            scope = scope._parent_scope
+        if scope is not None and scope._cancel_called and scope._cancel_handle is None:
+            scope._deliver_cancellation(scope)
 
     def _parent_cancelled(self) -> bool:
         # Check whether any parent has been cancelled

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -503,7 +503,7 @@ class CancelScope(BaseCancelScope):
         return should_retry
 
     def _restart_cancellation_in_parent(self) -> None:
-        """Start cancellation effort in the closest directly cancelled parent scope"""
+        """Restart the cancellation effort in the closest directly cancelled parent scope"""
         scope = self._parent_scope
         while scope is not None:
             if scope._cancel_called:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -419,7 +419,7 @@ class CancelScope(BaseCancelScope):
 
         host_task_state.cancel_scope = self._parent_scope
 
-        # Restart the cancellation effort in the farthest directly cancelled parent
+        # Restart the cancellation effort in the closest directly cancelled parent
         # scope if this one was shielded
         self._restart_cancellation_in_parent()
 


### PR DESCRIPTION
This makes the following changes:

1. Cancel scopes now track their child scopes
1. When entering a cancel scope, it moves its host task from the parent scope's task set to its own, and returns it when exiting
1. Cancel scopes propagate cancellation directly to any child scope that isn't shielded or explicitly cancelled (as explicitly cancelled scopes would have their own cancel callbacks)
1. Task groups now track their tasks separately from their cancel scopes

Fixes #642.