### PR TITLE
Fix more `Path` typing that doesn't match Typeshed

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -44,7 +44,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   - ``anyio.Path.hardlink_to()``
   - ``anyio.Path.samefile()``
   - ``anyio.Path.symlink_to()``
-  - ``anyio.Path.with_segments()`` (PR by Ganden Schaffner)
+  - ``anyio.Path.with_segments()``
+
+  (PR by Ganden Schaffner)
 
 **4.1.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -33,7 +33,18 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed cancellation propagating on asyncio from a task group to child tasks if the task
   hosting the task group is in a shielded cancel scope
   (`#642 <https://github.com/agronholm/anyio/issues/642>`_)
-- Fixed the type annotation of ``anyio.Path.samefile()`` to match Typeshed
+- Fixed various type annotations of ``anyio.Path`` to match Typeshed:
+
+  - ``anyio.Path.__lt__()``
+  - ``anyio.Path.__le__()``
+  - ``anyio.Path.__gt__()``
+  - ``anyio.Path.__ge__()``
+  - ``anyio.Path.__truediv__()``
+  - ``anyio.Path.__rtruediv__()``
+  - ``anyio.Path.hardlink_to()``
+  - ``anyio.Path.samefile()``
+  - ``anyio.Path.symlink_to()``
+  - ``anyio.Path.with_segments()`` (PR by Ganden Schaffner)
 
 **4.1.0**
 

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -292,26 +292,26 @@ class Path:
         target = other._path if isinstance(other, Path) else other
         return self._path.__eq__(target)
 
-    def __lt__(self, other: Path) -> bool:
+    def __lt__(self, other: pathlib.PurePath | Path) -> bool:
         target = other._path if isinstance(other, Path) else other
         return self._path.__lt__(target)
 
-    def __le__(self, other: Path) -> bool:
+    def __le__(self, other: pathlib.PurePath | Path) -> bool:
         target = other._path if isinstance(other, Path) else other
         return self._path.__le__(target)
 
-    def __gt__(self, other: Path) -> bool:
+    def __gt__(self, other: pathlib.PurePath | Path) -> bool:
         target = other._path if isinstance(other, Path) else other
         return self._path.__gt__(target)
 
-    def __ge__(self, other: Path) -> bool:
+    def __ge__(self, other: pathlib.PurePath | Path) -> bool:
         target = other._path if isinstance(other, Path) else other
         return self._path.__ge__(target)
 
-    def __truediv__(self, other: Any) -> Path:
+    def __truediv__(self, other: str | PathLike[str]) -> Path:
         return Path(self._path / other)
 
-    def __rtruediv__(self, other: Any) -> Path:
+    def __rtruediv__(self, other: str | PathLike[str]) -> Path:
         return Path(other) / self
 
     @property
@@ -401,7 +401,9 @@ class Path:
     async def group(self) -> str:
         return await to_thread.run_sync(self._path.group, abandon_on_cancel=True)
 
-    async def hardlink_to(self, target: str | pathlib.Path | Path) -> None:
+    async def hardlink_to(
+        self, target: str | bytes | PathLike[str] | PathLike[bytes]
+    ) -> None:
         if isinstance(target, Path):
             target = target._path
 
@@ -558,7 +560,7 @@ class Path:
 
     async def symlink_to(
         self,
-        target: str | pathlib.Path | Path,
+        target: str | bytes | PathLike[str] | PathLike[bytes],
         target_is_directory: bool = False,
     ) -> None:
         if isinstance(target, Path):
@@ -608,7 +610,7 @@ class Path:
     def with_suffix(self, suffix: str) -> Path:
         return Path(self._path.with_suffix(suffix))
 
-    def with_segments(self, *pathsegments: str) -> Path:
+    def with_segments(self, *pathsegments: str | PathLike[str]) -> Path:
         return Path(*pathsegments)
 
     async def write_bytes(self, data: bytes) -> int:


### PR DESCRIPTION
fixes some more mismatches from Typeshed. i compared every attr of `anyio.Path` to `pathlib.Path` and these are all of the discrepancies that i found. the changelog entry is probably overly verbose; feel free to shorten it.

I did not include this in #652 review because it's not at all related to `Callable[...`.
