### PR TITLE
Adding mypy argument to ignore comment error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
+        args: [--no-warn-unused-ignores]
         additional_dependencies:
           - pytest
           - trio >= 0.23

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -1,6 +1,11 @@
 Version history
 ===============
 
+**UNRELEASED**
+
+- Update mypy pre-commit hook to use ``--no-warn-unused-ignores`` argument to bypass
+  ``Unused "type: ignore" comment`` errors (PR by Colin Taylor)
+
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **4.2.0**


### PR DESCRIPTION
The `mypy` hook in pre-commit fails with `error: Unused "type: ignore" comment` on several test files. Assuming that these comments are necessary, this flag configures mypy to ignore these errors and allows the hook to pass. 

Alternatively, the offending comments could be removed if that solution is acceptable/preferable; doing so would also allow the hook to pass. Please let me know if this would be the case.