### PR TITLE
Adding prettier formatting

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,20 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.x
-    - name: Install dependencies
-      run: pip install build
-    - name: Create packages
-      run: python -m build
-    - name: Archive packages
-      uses: actions/upload-artifact@v3
-      with:
-        name: dist
-        path: dist
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: pip install build
+      - name: Create packages
+        run: python -m build
+      - name: Archive packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist
 
   publish:
     name: Publish build artifacts to the PyPI
@@ -37,10 +37,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - name: Retrieve packages
-      uses: actions/download-artifact@v3
-    - name: Upload packages
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Retrieve packages
+        uses: actions/download-artifact@v3
+      - name: Upload packages
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   release:
     name: Create a GitHub release
@@ -49,11 +49,11 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v4
-    - id: changelog
-      uses: agronholm/release-notes@v1
-      with:
-        path: docs/versionhistory.rst
-    - uses: ncipollo/release-action@v1
-      with:
-        body: ${{ steps.changelog.outputs.changelog }}
+      - uses: actions/checkout@v4
+      - id: changelog
+        uses: agronholm/release-notes@v1
+        with:
+          path: docs/versionhistory.rst
+      - uses: ncipollo/release-action@v1
+        with:
+          body: ${{ steps.changelog.outputs.changelog }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,23 +15,23 @@ jobs:
       tests-changed: ${{ steps.changed-files.outputs.tests_any_changed }}
       docs-changed: ${{ steps.changed-files.outputs.doc_any_changed }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Get changed files by category
-      id: changed-files
-      uses: tj-actions/changed-files@v37
-      with:
-        files_yaml: |
-          workflow:
-          - .github/workflows/test.yml
-          pyproject:
-          - pyproject.toml
-          src:
-          - src/**
-          tests:
-          - tests/**
-          doc:
-          - README.rst
-          - docs/**
+      - uses: actions/checkout@v4
+      - name: Get changed files by category
+        id: changed-files
+        uses: tj-actions/changed-files@v37
+        with:
+          files_yaml: |
+            workflow:
+            - .github/workflows/test.yml
+            pyproject:
+            - pyproject.toml
+            src:
+            - src/**
+            tests:
+            - tests/**
+            doc:
+            - README.rst
+            - docs/**
 
   pyright:
     runs-on: ubuntu-latest
@@ -42,19 +42,19 @@ jobs:
         || (needs.changed-files.outputs.src-changed == 'true')
       }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.x
-    - uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: pip-pyright
-    - name: Install dependencies
-      run: pip install -e . pyright pytest
-    - name: Run pyright
-      run: pyright --verifytypes anyio
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: pip-pyright
+      - name: Install dependencies
+        run: pip install -e . pyright pytest
+      - name: Run pyright
+        run: pyright --verifytypes anyio
 
   test:
     strategy:
@@ -63,14 +63,14 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", pypy-3.10]
         include:
-        - os: macos-latest
-          python-version: "3.8"
-        - os: macos-latest
-          python-version: "3.11"
-        - os: windows-latest
-          python-version: "3.8"
-        - os: windows-latest
-          python-version: "3.11"
+          - os: macos-latest
+            python-version: "3.8"
+          - os: macos-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.8"
+          - os: windows-latest
+            python-version: "3.11"
     runs-on: ${{ matrix.os }}
     needs: changed-files
     if: |
@@ -81,28 +81,28 @@ jobs:
         || (needs.changed-files.outputs.tests-changed == 'true')
       }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
-        cache: pip
-        cache-dependency-path: pyproject.toml
-    - name: Install dependencies
-      run: pip install -e .[test]
-    - name: Test with pytest
-      run: |
-        coverage run -m pytest -v
-        coverage xml
-      timeout-minutes: 5
-      env:
-        PYTEST_DISABLE_PLUGIN_AUTOLOAD: 1
-    - name: Upload Coverage
-      uses: coverallsapp/github-action@v2
-      with:
-        parallel: true
-        file: coverage.xml
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install dependencies
+        run: pip install -e .[test]
+      - name: Test with pytest
+        run: |
+          coverage run -m pytest -v
+          coverage xml
+        timeout-minutes: 5
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: 1
+      - name: Upload Coverage
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel: true
+          file: coverage.xml
 
   docs:
     runs-on: ubuntu-latest
@@ -115,24 +115,24 @@ jobs:
         || (needs.changed-files.outputs.docs-changed == 'true')
       }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
-        cache: pip
-        cache-dependency-path: pyproject.toml
-    - name: Install dependencies
-      run: pip install -e .[doc]
-    - name: Build documentation
-      run: sphinx-build -W docs build/sphinx
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install dependencies
+        run: pip install -e .[doc]
+      - name: Build documentation
+        run: sphinx-build -W docs build/sphinx
 
   coveralls:
     name: Finish Coveralls
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - name: Finished
-      uses: coverallsapp/github-action@v2
-      with:
-        parallel-finished: true
+      - name: Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
-        args: [ "--fix=lf" ]
+        args: [--fix=lf]
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -21,6 +21,11 @@ repos:
       - id: ruff
         args: [--fix, --show-fixes]
       - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0
@@ -34,6 +39,6 @@ repos:
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
-    - id: rst-backticks
-    - id: rst-directive-colons
-    - id: rst-inline-touching-normal
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+# macOS resource forks
+._*
+.DS_Store
+
+# Build artifacts
+/build
+/dist
+
+# Generated environments
+/venv
+
+# Cache files
+/.hypothesis
+/.mypy_cache
+/.pytest_cache
+/.ruff_cache

--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -1,0 +1,4 @@
+trailingComma = "none"
+tabWidth = 2
+semi = false
+printWidth = 100

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
   fail_on_warning: true
 
 python:
-   install:
-      - method: pip
-        path: .
-        extra_requirements: [doc]
+  install:
+    - method: pip
+      path: .
+      extra_requirements: [doc]

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -1,6 +1,11 @@
 Version history
 ===============
 
+**UNRELEASED**
+
+- Add `Prettier <https://prettier.io/>`_ to the pre-commit configuration to enforce
+  consistent formatting of non-python files (PR by Colin Taylor)
+
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**


### PR DESCRIPTION
*Lets handle the yaml formatting changes properly* 😉

Adding prettier for consistent formatting of non-python files. Ruff format only applies to python files, however, other files in the repo still have similar concerns (consistency, whitespace thrashing, etc). Prettier addresses this concern in the same way as ruff; minimal configurability to prevent bikeshedding.

Prettier is written in javascript but is a generalized tool, handling several other source types (`markdown`, `yaml`, `json`, etc). While a tool in the python ecosystem would be preferrable, AFAIK no such tool exists. This appears to be why `pre-commit` itself directly hosts a [prettier integration](https://github.com/pre-commit/mirrors-prettier).