### PR TITLE
Fix `run_process()` and `open_process().__aexit__` leaking an orphan process when cancelled

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -19,6 +19,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
     standard streams unclosed
 
   (PR by Ganden Schaffner)
+- Fixed ``Process.stdin.aclose()``, ``Process.stdout.aclose()``, and
+  ``Process.stderr.aclose()`` not including a checkpoint on asyncio (PR by Ganden
+  Schaffner)
 
 **4.2.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,6 +10,15 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed passing ``total_tokens`` to ``anyio.CapacityLimiter()`` as a keyword argument
   not working on the ``trio`` backend
   (`#515 <https://github.com/agronholm/anyio/issues/515>`_)
+- Fixed ``Process.aclose()`` not performing the minimum level of necessary cleanup when
+  cancelled. Previously:
+
+  - Cancellation of ``Process.aclose()`` could leak an orphan process
+  - Cancellation of ``run_process()`` could very briefly leak an orphan process.
+  - Cancellation of ``Process.aclose()`` or ``run_process()`` on Trio could leave
+    standard streams unclosed
+
+  (PR by Ganden Schaffner)
 
 **4.2.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -918,6 +918,7 @@ class StreamReaderWrapper(abc.ByteReceiveStream):
 
     async def aclose(self) -> None:
         self._stream.feed_eof()
+        await AsyncIOBackend.checkpoint()
 
 
 @dataclass(eq=False)
@@ -930,6 +931,7 @@ class StreamWriterWrapper(abc.ByteSendStream):
 
     async def aclose(self) -> None:
         self._stream.close()
+        await AsyncIOBackend.checkpoint()
 
 
 @dataclass(eq=False)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -956,6 +956,7 @@ class Process(abc.Process):
             self.kill()
             with CancelScope(shield=True):
                 await self.wait()
+
             raise
 
     async def wait(self) -> int:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -283,14 +283,21 @@ class Process(abc.Process):
     _stderr: abc.ByteReceiveStream | None
 
     async def aclose(self) -> None:
-        if self._stdin:
-            await self._stdin.aclose()
-        if self._stdout:
-            await self._stdout.aclose()
-        if self._stderr:
-            await self._stderr.aclose()
+        with CancelScope(shield=True):
+            if self._stdin:
+                await self._stdin.aclose()
+            if self._stdout:
+                await self._stdout.aclose()
+            if self._stderr:
+                await self._stderr.aclose()
 
-        await self.wait()
+        try:
+            await self.wait()
+        except BaseException:
+            self.kill()
+            with CancelScope(shield=True):
+                await self.wait()
+            raise
 
     async def wait(self) -> int:
         return await self._process.wait()

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -68,8 +68,10 @@ async def run_process(
         async with create_task_group() as tg:
             if process.stdout:
                 tg.start_soon(drain_stream, process.stdout, 0)
+
             if process.stderr:
                 tg.start_soon(drain_stream, process.stderr, 1)
+
             if process.stdin and input:
                 await process.stdin.send(input)
                 await process.stdin.aclose()

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -65,20 +65,16 @@ async def run_process(
         start_new_session=start_new_session,
     ) as process:
         stream_contents: list[bytes | None] = [None, None]
-        try:
-            async with create_task_group() as tg:
-                if process.stdout:
-                    tg.start_soon(drain_stream, process.stdout, 0)
-                if process.stderr:
-                    tg.start_soon(drain_stream, process.stderr, 1)
-                if process.stdin and input:
-                    await process.stdin.send(input)
-                    await process.stdin.aclose()
+        async with create_task_group() as tg:
+            if process.stdout:
+                tg.start_soon(drain_stream, process.stdout, 0)
+            if process.stderr:
+                tg.start_soon(drain_stream, process.stderr, 1)
+            if process.stdin and input:
+                await process.stdin.send(input)
+                await process.stdin.aclose()
 
-                await process.wait()
-        except BaseException:
-            process.kill()
-            raise
+            await process.wait()
 
     output, errors = stream_contents
     if check and process.returncode != 0:

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 
 import pytest
 
-from anyio import CancelScope, open_process, run_process
+from anyio import CancelScope, ClosedResourceError, open_process, run_process
 from anyio.streams.buffered import BufferedByteReceiveStream
 
 pytestmark = pytest.mark.anyio
@@ -194,3 +194,31 @@ async def test_process_aexit_cancellation_doesnt_orphan_process() -> None:
 
     assert process.returncode is not None
     assert process.returncode != 0
+
+
+async def test_process_aexit_cancellation_closes_standard_streams() -> None:
+    """
+    Regression test for #669.
+
+    Ensures that open_process.__aexit__() closes standard streams when cancelled. Also
+    ensures that process.std{in.send,{out,err}.receive}() raise ClosedResourceError on a
+    closed stream.
+
+    """
+    pytest.xfail("#671 needs to be resolved first")
+
+    with CancelScope() as scope:
+        async with await open_process(
+            [sys.executable, "-c", "import time; time.sleep(1)"]
+        ) as process:
+            scope.cancel()
+
+    assert process.stdin is not None
+    with pytest.raises(ClosedResourceError):
+        await process.stdin.send(b"foo")
+    assert process.stdout is not None
+    with pytest.raises(ClosedResourceError):
+        await process.stdout.receive(1)
+    assert process.stderr is not None
+    with pytest.raises(ClosedResourceError):
+        await process.stderr.receive(1)

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -8,6 +8,7 @@ from subprocess import CalledProcessError
 from textwrap import dedent
 
 import pytest
+from _pytest.fixtures import FixtureRequest
 
 from anyio import CancelScope, ClosedResourceError, open_process, run_process
 from anyio.streams.buffered import BufferedByteReceiveStream
@@ -197,6 +198,7 @@ async def test_process_aexit_cancellation_doesnt_orphan_process() -> None:
 
 
 async def test_process_aexit_cancellation_closes_standard_streams(
+    request: FixtureRequest,
     anyio_backend_name: str,
 ) -> None:
     """
@@ -208,7 +210,10 @@ async def test_process_aexit_cancellation_closes_standard_streams(
 
     """
     if anyio_backend_name == "asyncio":
-        pytest.xfail("#671 needs to be resolved first")
+        # Avoid pytest.xfail here due to https://github.com/pytest-dev/pytest/issues/9027
+        request.node.add_marker(
+            pytest.mark.xfail(reason="#671 needs to be resolved first")
+        )
 
     with CancelScope() as scope:
         async with await open_process(

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -196,8 +196,9 @@ async def test_process_aexit_cancellation_doesnt_orphan_process() -> None:
     assert process.returncode != 0
 
 
-@pytest.mark.xfail(reason="#671 needs to be resolved first")
-async def test_process_aexit_cancellation_closes_standard_streams() -> None:
+async def test_process_aexit_cancellation_closes_standard_streams(
+    anyio_backend_name: str,
+) -> None:
     """
     Regression test for #669.
 
@@ -206,6 +207,9 @@ async def test_process_aexit_cancellation_closes_standard_streams() -> None:
     closed stream.
 
     """
+    if anyio_backend_name == "asyncio":
+        pytest.xfail("#671 needs to be resolved first")
+
     with CancelScope() as scope:
         async with await open_process(
             [sys.executable, "-c", "import time; time.sleep(1)"]

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -196,7 +196,7 @@ async def test_process_aexit_cancellation_doesnt_orphan_process() -> None:
     assert process.returncode != 0
 
 
-@pytest.mark.xfail("#671 needs to be resolved first")
+@pytest.mark.xfail(reason="#671 needs to be resolved first")
 async def test_process_aexit_cancellation_closes_standard_streams() -> None:
     """
     Regression test for #669.

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -196,6 +196,7 @@ async def test_process_aexit_cancellation_doesnt_orphan_process() -> None:
     assert process.returncode != 0
 
 
+@pytest.mark.xfail("#671 needs to be resolved first")
 async def test_process_aexit_cancellation_closes_standard_streams() -> None:
     """
     Regression test for #669.
@@ -205,8 +206,6 @@ async def test_process_aexit_cancellation_closes_standard_streams() -> None:
     closed stream.
 
     """
-    pytest.xfail("#671 needs to be resolved first")
-
     with CancelScope() as scope:
         async with await open_process(
             [sys.executable, "-c", "import time; time.sleep(1)"]
@@ -214,11 +213,16 @@ async def test_process_aexit_cancellation_closes_standard_streams() -> None:
             scope.cancel()
 
     assert process.stdin is not None
+
     with pytest.raises(ClosedResourceError):
         await process.stdin.send(b"foo")
+
     assert process.stdout is not None
+
     with pytest.raises(ClosedResourceError):
         await process.stdout.receive(1)
+
     assert process.stderr is not None
+
     with pytest.raises(ClosedResourceError):
         await process.stderr.receive(1)

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 
 import pytest
 
-from anyio import open_process, run_process
+from anyio import CancelScope, open_process, run_process
 from anyio.streams.buffered import BufferedByteReceiveStream
 
 pytestmark = pytest.mark.anyio
@@ -176,3 +176,21 @@ async def test_run_process_inherit_stdout(capfd: pytest.CaptureFixture[str]) -> 
     out, err = capfd.readouterr()
     assert out == "stdout-text" + os.linesep
     assert err == "stderr-text" + os.linesep
+
+
+async def test_process_aexit_cancellation_doesnt_orphan_process() -> None:
+    """
+    Regression test for #669.
+
+    Ensures that open_process.__aexit__() doesn't leave behind an orphan process when
+    cancelled.
+
+    """
+    with CancelScope() as scope:
+        async with await open_process(
+            [sys.executable, "-c", "import time; time.sleep(1)"]
+        ) as process:
+            scope.cancel()
+
+    assert process.returncode is not None
+    assert process.returncode != 0

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -185,6 +185,9 @@ async def test_start_cancelled() -> None:
     assert not finished
 
 
+@pytest.mark.xfail(
+    sys.version_info < (3, 9), reason="Requires a way to detect cancellation source"
+)
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_start_native_host_cancelled() -> None:
     started = finished = False
@@ -198,9 +201,6 @@ async def test_start_native_host_cancelled() -> None:
     async def start_another() -> None:
         async with create_task_group() as tg:
             await tg.start(taskfunc)
-
-    if sys.version_info < (3, 9):
-        pytest.xfail("Requires a way to detect cancellation source")
 
     task = asyncio.get_running_loop().create_task(start_another())
     await wait_all_tasks_blocked()


### PR DESCRIPTION
fixes #669.

## underlying AnyIO bug

currently, cancellation of `async with await open_process()` (i.e. `Process.__aexit__()` in a cancelled scope) can cause the `AsyncResource` to not get fully closed, leaking an orphan process. this is because a cancelled `Process.__aexit__()` is not performing the minimum level of cleanup: Trio's cancellation model states that

> Async cleanup operations–like `__aexit__` methods or async close methods–are cancellable just like anything else except that if they are cancelled, they still perform a minimum level of cleanup before raising `Cancelled`. (https://trio.readthedocs.io/en/stable/reference-core.html#cancellation-and-primitive-operations)

## how it caused #669

#669 is a special case of this bug: in #669, even though `run_process` does call `process.kill` if cancelled, it still (very briefly) leaks an orphan process. this is because when `process.kill()` returns, the process is not necessarily dead yet: `process.kill` (`kill(2)`/`TerminateProcess`) is like `call_soon` and only schedules the kill. so after `process.kill()` we need to wait briefly for the death to occur and for the event loop to learn about it.

so the problem seen in #669 was: an orphan process was leaked briefly. this started a race between
*   the event loop closing and
*   the OS killing the process and the event loop learning about it

note that this race is present on both backends. if the event loop closing happened first and won the race, then:
*   on Trio it caused `Popen.__del__` to emit a `ResourceWarning`
*   on asyncio it _should_ have caused `BaseSubprocessTransport.__del__` to emit a `ResouceWarning`, but due to an asyncio bug (https://github.com/python/cpython/issues/114177) it caused an unraisable error instead of a `ResourceWarning`.

the tests currently added in this PR should cover the underlying AnyIO bug that caused #669 while being deterministic (not flaky). however, if you also want a test that looks more like the original example in #669 (testing asyncio/Trio `close` & `__del__` behavior), here's another test that could be added to this PR:

```python
def test_process_aexit_cancellation_doesnt_orphan_del(
    anyio_backend_name: str, anyio_backend_options: dict[str, Any]
) -> None:
    """
    Regression test for #669.

    Ensure that, when cancelled, open_process.__aexit__() doesn't leave behind any
    __del__() finalizers that emit ResourceWarning (or fail due to
    https://github.com/python/cpython/issues/114177) if there is a race where the event
    loop is closed too soon.

    N.B.: This is a test of asyncio and Trio, not AnyIO: it should pass if
    test_process_aexit_cancellation_doesnt_orphan_process() passes and asyncio/Trio are
    not bugged. This test can also have false negatives (passes when it should fail)
    because it relies on run() finishing either before the OS kills the process or
    before the event loop learns the process died.

    """
    # Don't del process until after run() finishes
    process: Process

    async def main() -> None:
        nonlocal process
        with CancelScope() as scope:
            async with await open_process(
                [sys.executable, "-c", "import time; time.sleep(1)"]
            ) as process:
                scope.cancel()

    run(main, backend=anyio_backend_name, backend_options=anyio_backend_options)
```