### PR TITLE
Add the network marker to some tests that need DNS

### DIFF
--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -512,6 +512,7 @@ class TestTCPStream:
         assert not caplog.text
 
 
+@pytest.mark.network
 class TestTCPListener:
     async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:
         async with await create_tcp_listener(
@@ -1180,6 +1181,7 @@ async def test_multi_listener(tmp_path_factory: TempPathFactory) -> None:
         assert client_addresses == expected_addresses
 
 
+@pytest.mark.network
 @pytest.mark.usefixtures("check_asyncio_bug")
 class TestUDPSocket:
     async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:
@@ -1305,6 +1307,7 @@ class TestUDPSocket:
             assert local_address[1] > 0
 
 
+@pytest.mark.network
 @pytest.mark.usefixtures("check_asyncio_bug")
 class TestConnectedUDPSocket:
     async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:


### PR DESCRIPTION
Testing in Fedora Linux (building distribution packages in an offline environment) shows that – even though they might not require *Internet* access – the following test classes require at least DNS, and fail in a fully offline environment:

- `TestConnectedUDPSocket`
- `TestTCPListener`
- `TestUDPSocket` (except `test_create_unbound_socket`)

This PR adds the `network` mark to each of the test classes listed above. (I chose to mark the entire `TestUDPSocket` class rather than trying to mark every method except `test_create_unbound_socket`.)