### PR TITLE
Remove conditionals and workarounds for Python interpreter versions 3.7 and older

### DIFF
--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import socket
 import ssl
-import sys
 from contextlib import ExitStack
 from threading import Thread
 from typing import ContextManager, NoReturn

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -350,10 +350,7 @@ class TestTLSStream:
         ca.configure_trust(client_context)
         if force_tlsv12:
             expected_pattern = r"send_eof\(\) requires at least TLSv1.3"
-            if hasattr(ssl, "TLSVersion"):
-                client_context.maximum_version = ssl.TLSVersion.TLSv1_2
-            else:  # Python 3.6
-                client_context.options |= ssl.OP_NO_TLSv1_3
+            client_context.maximum_version = ssl.TLSVersion.TLSv1_2
         else:
             expected_pattern = (
                 r"send_eof\(\) has not yet been implemented for TLS streams"

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -26,10 +26,6 @@ from anyio.streams.stapled import StapledObjectStream
 from anyio.streams.tls import TLSAttribute, TLSListener, TLSStream
 
 pytestmark = pytest.mark.anyio
-skip_on_broken_openssl = pytest.mark.skipif(
-    (ssl.OPENSSL_VERSION_INFO[0] > 1 and sys.version_info < (3, 8)),
-    reason="Python 3.7 does not work with OpenSSL versions higher than 1.X",
-)
 
 
 class TestTLSStream:
@@ -193,7 +189,6 @@ class TestTLSStream:
             pytest.param(False, False, id="neither_standard"),
         ],
     )
-    @skip_on_broken_openssl
     async def test_ragged_eofs(
         self,
         server_context: ssl.SSLContext,
@@ -250,7 +245,6 @@ class TestTLSStream:
         else:
             assert server_exc is None
 
-    @skip_on_broken_openssl
     async def test_ragged_eof_on_receive(
         self, server_context: ssl.SSLContext, client_context: ssl.SSLContext
     ) -> None:
@@ -394,7 +388,6 @@ class TestTLSStream:
 
 
 class TestTLSListener:
-    @skip_on_broken_openssl
     async def test_handshake_fail(
         self, server_context: ssl.SSLContext, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -220,9 +220,6 @@ class TestRunAsyncFromThread:
         exc.match("This function can only be run from an AnyIO worker thread")
 
     async def test_contextvar_propagation(self, anyio_backend_name: str) -> None:
-        if anyio_backend_name == "asyncio" and sys.version_info < (3, 7):
-            pytest.skip("Asyncio does not propagate context before Python 3.7")
-
         var = ContextVar("var", default=1)
 
         async def async_func() -> int:
@@ -572,9 +569,6 @@ class TestBlockingPortal:
     def test_contextvar_propagation_sync(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        if anyio_backend_name == "asyncio" and sys.version_info < (3, 7):
-            pytest.skip("Asyncio does not propagate context before Python 3.7")
-
         var = ContextVar("var", default=1)
         var.set(6)
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
@@ -585,9 +579,6 @@ class TestBlockingPortal:
     def test_contextvar_propagation_async(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        if anyio_backend_name == "asyncio" and sys.version_info < (3, 7):
-            pytest.skip("Asyncio does not propagate context before Python 3.7")
-
         var = ContextVar("var", default=1)
         var.set(6)
 

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -16,16 +16,6 @@ from anyio.streams.buffered import BufferedByteReceiveStream
 pytestmark = pytest.mark.anyio
 
 
-@pytest.fixture(autouse=True)
-def check_compatibility(anyio_backend_name: str) -> None:
-    if anyio_backend_name == "asyncio":
-        if platform.system() == "Windows" and sys.version_info < (3, 8):
-            pytest.skip(
-                "Python < 3.8 uses SelectorEventLoop by default and it does not "
-                "support subprocesses"
-            )
-
-
 @pytest.mark.parametrize(
     "shell, command",
     [

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -21,16 +21,6 @@ from anyio.abc import Process
 pytestmark = pytest.mark.anyio
 
 
-@pytest.fixture(autouse=True)
-def check_compatibility(anyio_backend_name: str) -> None:
-    if anyio_backend_name == "asyncio":
-        if platform.system() == "Windows" and sys.version_info < (3, 8):
-            pytest.skip(
-                "Python < 3.8 uses SelectorEventLoop by default and it does not "
-                "support subprocesses"
-            )
-
-
 async def test_run_sync_in_process_pool() -> None:
     """
     Test that the function runs in a different process, and the same process in both

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import platform
 import sys
 import time
 from functools import partial


### PR DESCRIPTION
Since `anyio` already requires Python 3.8 or later, these conditionals and workarounds are no longer needed.