### PR TITLE
Fix silent in asyncio if python dev-mode enabled

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1990,7 +1990,7 @@ class AsyncIOBackend(AsyncBackend):
             finally:
                 del _task_states[task]
 
-        debug = options.get("debug", False)
+        debug = options.get("debug", None)
         loop_factory = options.get("loop_factory", None)
         if loop_factory is None and options.get("use_uvloop", False):
             import uvloop


### PR DESCRIPTION
Example
```python
import time
import anyio

async def main():
    time.sleep(10)

anyio.run(main)
```
If you run this script with dev mode enabled using `PYTHONDEVMODE=1` env var then you don't got any warning because anyio call `asyncio.run` with `debug=False`