### PR TITLE
Fixed handling of KeyError raised by a typed attribute getter

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,11 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed erroneous ``TypedAttributeLookupError`` if a typed attribute getter raises
+  ``KeyError``
+
 **4.3.0**
 
 - Added support for the Python 3.12 ``walk_up`` keyword argument in

--- a/src/anyio/_core/_typedattr.py
+++ b/src/anyio/_core/_typedattr.py
@@ -73,9 +73,11 @@ class TypedAttributeProvider:
 
         """
         try:
-            return self.extra_attributes[attribute]()
+            getter = self.extra_attributes[attribute]
         except KeyError:
             if default is undefined:
                 raise TypedAttributeLookupError("Attribute not found") from None
             else:
                 return default
+
+        return getter()

--- a/tests/test_typedattr.py
+++ b/tests/test_typedattr.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+import pytest
+
+from anyio import TypedAttributeProvider
+
+
+class DummyAttributeProvider(TypedAttributeProvider):
+    def get_dummyattr(self) -> str:
+        raise KeyError("foo")
+
+    @property
+    def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
+        return {str: self.get_dummyattr}
+
+
+def test_typedattr_keyerror() -> None:
+    """
+    Test that if the extra attribute getter raises KeyError, it won't be confused for a
+    missing attribute.
+
+    """
+    with pytest.raises(KeyError, match="^'foo'$"):
+        DummyAttributeProvider().extra(str)


### PR DESCRIPTION
`KeyError`s coming out of the getter call shouldn't be caught by `extra()`.