### PR TITLE
Fixed EOF detection on asyncio when there is also data in the buffer

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Fixed erroneous ``TypedAttributeLookupError`` if a typed attribute getter raises
   ``KeyError``
+- Fixed ``SocketStream.receive()`` not detecting EOF on asyncio if there is also data in
+  the read buffer (`#701 <https://github.com/agronholm/anyio/issues/701>`_)
 
 **4.3.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1047,6 +1047,7 @@ class StreamProtocol(asyncio.Protocol):
     read_event: asyncio.Event
     write_event: asyncio.Event
     exception: Exception | None = None
+    is_at_eof: bool = False
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.read_queue = deque()
@@ -1068,6 +1069,7 @@ class StreamProtocol(asyncio.Protocol):
         self.read_event.set()
 
     def eof_received(self) -> bool | None:
+        self.is_at_eof = True
         self.read_event.set()
         return True
 
@@ -1123,15 +1125,16 @@ class SocketStream(abc.SocketStream):
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
         with self._receive_guard:
-            await AsyncIOBackend.checkpoint()
-
             if (
                 not self._protocol.read_event.is_set()
                 and not self._transport.is_closing()
+                and not self._protocol.is_at_eof
             ):
                 self._transport.resume_reading()
                 await self._protocol.read_event.wait()
                 self._transport.pause_reading()
+            else:
+                await AsyncIOBackend.checkpoint_if_cancelled()
 
             try:
                 chunk = self._protocol.read_queue.popleft()

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1134,7 +1134,7 @@ class SocketStream(abc.SocketStream):
                 await self._protocol.read_event.wait()
                 self._transport.pause_reading()
             else:
-                await AsyncIOBackend.checkpoint_if_cancelled()
+                await AsyncIOBackend.checkpoint()
 
             try:
                 chunk = self._protocol.read_queue.popleft()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -28,6 +28,7 @@ from anyio import (
     BrokenResourceError,
     BusyResourceError,
     ClosedResourceError,
+    EndOfStream,
     Event,
     TypedAttributeLookupError,
     connect_tcp,
@@ -680,6 +681,29 @@ class TestTCPListener:
                             break
 
             tg.cancel_scope.cancel()
+
+    async def test_eof_after_send(self, family: AnyIPAddressFamily) -> None:
+        """Regression test for #701."""
+        received_bytes = b""
+
+        async def handle(stream: SocketStream) -> None:
+            nonlocal received_bytes
+            async with stream:
+                received_bytes = await stream.receive()
+                with pytest.raises(EndOfStream), fail_after(1):
+                    await stream.receive()
+
+            tg.cancel_scope.cancel()
+
+        multi = await create_tcp_listener(family=family, local_host="localhost")
+        async with multi, create_task_group() as tg:
+            with socket.socket(family) as client:
+                client.connect(multi.extra(SocketAttribute.local_address))
+                client.send(b"Hello")
+                client.shutdown(socket.SHUT_WR)
+                await multi.serve(handle)
+
+        assert received_bytes == b"Hello"
 
     @skip_ipv6_mark
     @pytest.mark.skipif(

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -9,7 +9,6 @@ from typing import Any, NoReturn, cast
 
 import pytest
 from exceptiongroup import catch
-from pytest_mock import MockerFixture
 
 import anyio
 from anyio import (
@@ -248,27 +247,6 @@ async def test_propagate_native_cancellation_from_taskgroup() -> None:
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
-
-
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
-async def test_cancel_with_nested_shielded_scope(mocker: MockerFixture) -> None:
-    """Regression test for #695."""
-
-    async def shield_task() -> None:
-        with CancelScope(shield=True):
-            await sleep(0.5)
-
-    async def task() -> None:
-        async with create_task_group() as tg:
-            tg.start_soon(shield_task)
-
-    async with create_task_group() as tg:
-        spy = mocker.spy(tg.cancel_scope, "_deliver_cancellation")
-        tg.start_soon(task)
-        await wait_all_tasks_blocked()
-        tg.cancel_scope.cancel()
-
-    assert len(spy.call_args_list) < 3
 
 
 async def test_start_exception_delivery(anyio_backend_name: str) -> None:


### PR DESCRIPTION
I also made `receive()` more efficient by not having two consecutive checkpoints in the case where it needs to wait for data, and avoided unnecessary task switching if the task hasn't been cancelled.

Closes #701.