### PR TITLE
Fix memory streams incorrectly raising cancelled when `*_nowait()` is called immediately after cancelling `send()`/`receive()`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -28,6 +28,20 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Emit a ``ResourceWarning`` for ``MemoryObjectReceiveStream`` and
   ``MemoryObjectSendStream`` that were garbage collected without being closed (PR by
   Andrey Kazantcev)
+- Fixed memory object stream operations incorrectly raising cancelled under certain
+  conditions where it is too late to do so:
+
+  - Fixed memory object streams dropping items when
+    ``MemoryObjectSendStream.send_nowait()`` was called immediately after cancelling the
+    scope of an ``await MemoryObjectReceiveStream.receive()`` call (`#728
+    <https://github.com/agronholm/anyio/issues/728>`_)
+
+  - Fixed ``MemoryObjectSendStream.send()`` raising cancelled despite succeeding when
+    ``MemoryObjectReceiveStream.receive_nowait()`` is called immediately after
+    cancelling the scope of the ``MemoryObjectSendStream.send()`` call (`#729
+    <https://github.com/agronholm/anyio/issues/729>`_)
+
+  (PR by Ganden Schaffner)
 
 **4.3.0**
 


### PR DESCRIPTION
### Changes

Fixes:

*   #728 (in sense (1) as defined in https://github.com/agronholm/anyio/issues/728#issuecomment-2105664591). cancellation of `receive()` could drop items, meaning that _neither_ the attempted sender nor the attempted receiver think they are responsible for the item.

*   the analogous issue about cancellation of `send()`. cancellation of `send()` could result in `send()` raising cancelled despite succeeding, meaning that _both_ the attempted sender and the attempted receiver think they are responsible for the item.

### Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
the you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.