### PR TITLE
Add `__slots__` to `AsyncResource`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -29,7 +29,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``MemoryObjectSendStream`` that were garbage collected without being closed (PR by
   Andrey Kazantcev)
 - Added ``__slots__`` to ``AsyncResource`` so that child classes can use ``__slots__``
-  (PR by Justin Su)
+  (`#733 <https://github.com/agronholm/anyio/pull/733>`_; PR by Justin Su)
 
 **4.3.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -28,6 +28,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Emit a ``ResourceWarning`` for ``MemoryObjectReceiveStream`` and
   ``MemoryObjectSendStream`` that were garbage collected without being closed (PR by
   Andrey Kazantcev)
+- Added ``__slots__`` to ``AsyncResource`` so that child classes can use ``__slots__``
+  (PR by Justin Su)
 
 **4.3.0**
 

--- a/src/anyio/abc/_resources.py
+++ b/src/anyio/abc/_resources.py
@@ -15,6 +15,8 @@ class AsyncResource(metaclass=ABCMeta):
     and calls :meth:`aclose` on exit.
     """
 
+    __slots__ = ()
+
     async def __aenter__(self: T) -> T:
         return self
 


### PR DESCRIPTION
### Changes
`AsyncResource` should have `__slots__` so child classes can use `__slots__`.

Similar to https://github.com/python/cpython/issues/105726 and https://github.com/python/cpython/pull/106771 for `contextlib.AbstractAsyncContextManager`.

### Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).