### PR TITLE
Added opt-in locking of first detected async backend

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -55,18 +55,17 @@ native ``run()`` function of the backend library::
     trio.run(main)
 
 Unless you're using trio-asyncio_, you will probably want to reduce the overhead caused
-by dynamic backend detection by setting the ``ANYIO_LOCK_DETECTED_BACKEND`` environment
-variable to ``1``. This makes AnyIO assume that whichever backend is detected on the
-first AnyIO call will always be used going forward. This will not adversely affect the
-pytest plugin, as AnyIO detects its presence and then disables backend locking.
+by dynamic backend detection by setting the ``ANYIO_BACKEND`` environment variable to
+either ``asyncio`` or ``trio``, depending on your backend of choice. This will enable
+AnyIO to avoid checking which flavor of async event loop you're running when you call
+one of AnyIO's functions – a check that typically involves at least one system call.
 
 .. versionchanged:: 4.0.0
     On the ``asyncio`` backend, ``anyio.run()`` now uses a back-ported version of
     :class:`asyncio.Runner` on Pythons older than 3.11.
 
 .. versionchanged:: 4.4.0
-    Added support for locking in the first detected backend via
-    ``ANYIO_LOCK_DETECTED_BACKEND``
+    Added support for forcing a specific backend via ``ANYIO_BACKEND``
 
 .. _trio-asyncio: https://github.com/python-trio/trio-asyncio
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -54,9 +54,21 @@ native ``run()`` function of the backend library::
 
     trio.run(main)
 
+Unless you're using trio-asyncio_, you will probably want to reduce the overhead caused
+by dynamic backend detection by setting the ``ANYIO_LOCK_DETECTED_BACKEND`` environment
+variable to ``1``. This makes AnyIO assume that whichever backend is detected on the
+first AnyIO call will always be used going forward. This will not adversely affect the
+pytest plugin, as AnyIO detects its presence and then disables backend locking.
+
 .. versionchanged:: 4.0.0
     On the ``asyncio`` backend, ``anyio.run()`` now uses a back-ported version of
     :class:`asyncio.Runner` on Pythons older than 3.11.
+
+.. versionchanged:: 4.4.0
+    Added support for locking in the first detected backend via
+    ``ANYIO_LOCK_DETECTED_BACKEND``
+
+.. _trio-asyncio: https://github.com/python-trio/trio-asyncio
 
 .. _backend options:
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added an opt-in performance optimization that decreases AnyIO's overhead (compared to
+  native calls on the selected async backend) by locking in the first automatically
+  detected async backend, thus always assuming the same backend for future calls by
+  setting the ``ANYIO_LOCK_DETECTED_BACKEND`` environment variable to ``1``
 - Added the ``BlockingPortalProvider`` class to aid with constructing synchronous
   counterparts to asynchronous interfaces that would otherwise require multiple blocking
   portals

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,12 +3,14 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
-**4.4.0**
+**UNRELEASED**
 
 - Added an opt-in performance optimization that decreases AnyIO's overhead (compared to
-  native calls on the selected async backend) by locking in the first automatically
-  detected async backend, thus always assuming the same backend for future calls by
-  setting the ``ANYIO_LOCK_DETECTED_BACKEND`` environment variable to ``1``
+  native calls on the selected async backend), used by setting the ``ANYIO_BACKEND``
+  environment variable to ``auto``, ``asyncio`` or ``trio``
+
+**4.4.0**
+
 - Added the ``BlockingPortalProvider`` class to aid with constructing synchronous
   counterparts to asynchronous interfaces that would otherwise require multiple blocking
   portals

--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -27,22 +27,25 @@ PosArgsT = TypeVarTuple("PosArgsT")
 
 threadlocals = threading.local()
 loaded_backends: dict[str, type[AsyncBackend]] = {}
-lock_detected_backend = os.getenv(
-    "ANYIO_LOCK_DETECTED_BACKEND", "0"
-) == "1" and not os.getenv("PYTEST_CURRENT_TEST")
-locked_backend: type[AsyncBackend]
+forced_backend_name = os.getenv("ANYIO_BACKEND")
+forced_backend: type[AsyncBackend]
 
 
 def run(
     func: Callable[[Unpack[PosArgsT]], Awaitable[T_Retval]],
     *args: Unpack[PosArgsT],
-    backend: str = "asyncio",
+    backend: str | None = None,
     backend_options: dict[str, Any] | None = None,
 ) -> T_Retval:
     """
     Run the given coroutine function in an asynchronous event loop.
 
     The current thread must not be already running an event loop.
+
+    The backend will be chosen using the following priority list:
+    * the ``backend`` argument, if not ``None``
+    * the ``ANYIO_BACKEND`` environment variable
+    * ``asyncio``
 
     :param func: a coroutine function
     :param args: positional arguments to ``func``
@@ -63,6 +66,7 @@ def run(
     else:
         raise RuntimeError(f"Already running {asynclib_name} in this thread")
 
+    backend = backend or os.getenv("ANYIO_BACKEND") or "asyncio"
     try:
         async_backend = get_async_backend(backend)
     except ImportError as exc:
@@ -129,7 +133,16 @@ def current_time() -> float:
 
 
 def get_all_backends() -> tuple[str, ...]:
-    """Return a tuple of the names of all built-in backends."""
+    """
+    Return a tuple of the names of all built-in backends.
+
+    If the ``ANYIO_BACKEND`` environment variable was set, then the returned tuple will
+    only contain that backend.
+
+    """
+    if forced_backend_name:
+        return (forced_backend_name,)
+
     return BACKENDS
 
 
@@ -157,16 +170,16 @@ def claim_worker_thread(
 
 
 def get_async_backend(asynclib_name: str | None = None) -> type[AsyncBackend]:
-    global locked_backend
+    global forced_backend
 
     if asynclib_name is None:
-        if lock_detected_backend:
+        if os.getenv("PYTEST_CURRENT_TEST"):
             try:
-                return locked_backend
+                return forced_backend
             except NameError:
                 pass
 
-        asynclib_name = sniffio.current_async_library()
+        asynclib_name = forced_backend_name or sniffio.current_async_library()
 
     # We use our own dict instead of sys.modules to get the already imported back-end
     # class because the appropriate modules in sys.modules could potentially be only
@@ -176,7 +189,7 @@ def get_async_backend(asynclib_name: str | None = None) -> type[AsyncBackend]:
     except KeyError:
         module = import_module(f"anyio._backends._{asynclib_name}")
         loaded_backends[asynclib_name] = module.backend_class
-        if lock_detected_backend:
-            locked_backend = module.backend_class
+        if asynclib_name == forced_backend_name:
+            forced_backend = module.backend_class
 
         return module.backend_class

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -425,19 +425,6 @@ def test_hypothesis_function_mark(testdir: Pytester) -> None:
 def test_lock_backend(
     backend_name: str, testdir: Pytester, monkeypatch: MonkeyPatch
 ) -> None:
-    testdir.makeconftest(
-        f"""
-        import os
-        import sys
-
-        pytest_plugins = ["anyio"]
-
-        os.environ["ANYIO_BACKEND"] = "{backend_name}"
-        del sys.modules['anyio._core._eventloop']
-        del sys.modules['anyio.pytest_plugin']
-        del sys.modules['anyio']
-        """
-    )
     testdir.makepyfile(
         f"""
         import os
@@ -455,5 +442,6 @@ def test_lock_backend(
         """
     )
 
-    result = testdir.runpytest("-p", "no:anyio")
+    monkeypatch.setenv("ANYIO_BACKEND", backend_name)
+    result = testdir.runpytest_subprocess(*pytest_args)
     result.assert_outcomes(passed=1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

<!-- Please give a short brief about these changes. -->

Prompted by https://github.com/agronholm/anyio/discussions/543, this adds an optimization, enabled by the `ANYIO_BACKEND` environment variable, for skipping the costly sniffio automatic async backend detection after the first call. Whatever backend is detected is assumed to be running on every call since. This avoids the `getpid()` system calls in this extremely often called function.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [X] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by Yourname)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.

If possible, use your real name in the changelog entry. If not, use your GitHub
username.
