### PR TITLE
Python 3.13: expect DeprecationWarning for pathlib.PurePath.is_reserved()

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -68,6 +68,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``Process.stderr.aclose()`` not including a checkpoint on asyncio (PR by Ganden
   Schaffner)
 - Fixed documentation on how to provide your own typed attributes
+- Adjusted tests to expect a ``DeprecationWarning`` from
+  ``pathlib.PurePath.is_reserved()`` on Python 3.13 and later
 
 **4.2.0**
 

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import os
 import pathlib
 import platform
@@ -271,7 +272,14 @@ class TestPath:
 
     def test_is_reserved(self) -> None:
         expected_result = platform.system() == "Windows"
-        assert Path("nul").is_reserved() == expected_result
+        with (
+            contextlib.nullcontext()
+            if sys.version_info < (3, 13)
+            else pytest.warns(
+                DeprecationWarning, match=r"is_reserved\(\) is deprecated "
+            )
+        ):
+            assert Path("nul").is_reserved() == expected_result
 
     @pytest.mark.skipif(
         platform.system() == "Windows",


### PR DESCRIPTION

<!-- Thank you for your contribution! -->
## Changes

This is a *partial* fix for https://github.com/agronholm/anyio/issues/737.

On Python 3.13 and later, `test_is_reserved` now expects that [`pathlib.PurePath.is_reserved()` produces a `DeprecationWarning`](https://docs.python.org/3.13/library/pathlib.html#pathlib.PurePath.is_reserved).

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch **N/A**
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features) **N/A**
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.