### PR TITLE
Added more process arguments

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -9,8 +9,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   in ``anyio.Path``, newly added in Python 3.13
   (`#737 <https://github.com/agronholm/anyio/issues/737>`_)
 - Added support for more keyword arguments for ``run_process()`` and ``open_process()``:
-  ``preexec_fn``, ``startupinfo``, ``creationflags``, ``user``, ``group``,
-  ``extra_groups`` and ``umask``
+  ``startupinfo``, ``creationflags``, ``user``, ``group``, ``extra_groups`` and ``umask``
   (`#742 <https://github.com/agronholm/anyio/issues/742>`_)
 - Improved the type annotations in ``run_process()`` and ``open_process()`` to allow for
   path-like arguments, just like ``subprocess.Popen``

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,7 +11,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   in ``anyio.Path``, newly added in Python 3.13
   (`#737 <https://github.com/agronholm/anyio/issues/737>`_)
 - Added support for more keyword arguments for ``run_process()`` and ``open_process()``:
-  ``startupinfo``, ``creationflags``, ``user``, ``group``, ``extra_groups`` and ``umask``
+  ``startupinfo``, ``creationflags``, ``pass_fds``, ``user``, ``group``,
+  ``extra_groups`` and ``umask``
   (`#742 <https://github.com/agronholm/anyio/issues/742>`_)
 - Improved the type annotations in ``run_process()`` and ``open_process()`` to allow for
   path-like arguments, just like ``subprocess.Popen``

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,6 +8,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Added support for the ``from_uri()``, ``full_match()``, ``parser`` methods/properties
   in ``anyio.Path``, newly added in Python 3.13
   (`#737 <https://github.com/agronholm/anyio/issues/737>`_)
+- Added support for more keyword arguments for ``run_process()`` and ``open_process()``:
+  ``preexec_fn``, ``startupinfo``, ``creationflags``, ``user``, ``group``,
+  ``extra_groups`` and ``umask``
+- Improved the type annotations in ``run_process()`` and ``open_process()`` to allow for
+  path-like arguments, just like ``subprocess.Popen``
 - Changed the ``ResourceWarning`` from an unclosed memory object stream to include its
   address for easier identification
 - Fixed ``to_process.run_sync()`` failing to initialize if ``__main__.__file__`` pointed

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -14,8 +14,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``startupinfo``, ``creationflags``, ``pass_fds``, ``user``, ``group``,
   ``extra_groups`` and ``umask``
   (`#742 <https://github.com/agronholm/anyio/issues/742>`_)
-- Improved the type annotations in ``run_process()`` and ``open_process()`` to allow for
-  path-like arguments, just like ``subprocess.Popen``
+- Improved the type annotations and support for ``PathLike`` in ``run_process()`` and
+  ``open_process()`` to allow for path-like arguments, just like ``subprocess.Popen``
 - Changed the ``ResourceWarning`` from an unclosed memory object stream to include its
   address for easier identification
 - Changed ``start_blocking_portal()`` to always use daemonic threads, to accommodate the

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,6 +11,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Added support for more keyword arguments for ``run_process()`` and ``open_process()``:
   ``preexec_fn``, ``startupinfo``, ``creationflags``, ``user``, ``group``,
   ``extra_groups`` and ``umask``
+  (`#742 <https://github.com/agronholm/anyio/issues/742>`_)
 - Improved the type annotations in ``run_process()`` and ``open_process()`` to allow for
   path-like arguments, just like ``subprocess.Popen``
 - Changed the ``ResourceWarning`` from an unclosed memory object stream to include its

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -41,6 +41,7 @@ from threading import Thread
 from types import TracebackType
 from typing import (
     IO,
+    TYPE_CHECKING,
     Any,
     AsyncGenerator,
     Awaitable,
@@ -80,7 +81,6 @@ from ..abc import (
     UDPPacketType,
     UNIXDatagramPacketType,
 )
-from ..abc._eventloop import StrOrBytesPath
 from ..lowlevel import RunVar
 from ..streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
@@ -276,6 +276,10 @@ else:
             await future
         finally:
             thread.join()
+
+
+if TYPE_CHECKING:
+    from _typeshed import StrOrBytesPath
 
 
 T_Retval = TypeVar("T_Retval")

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -4,7 +4,7 @@ import array
 import asyncio
 import concurrent.futures
 import math
-import pathlib
+import os
 import socket
 import sys
 import threading
@@ -2255,7 +2255,7 @@ class AsyncIOBackend(AsyncBackend):
     ) -> Process:
         await cls.checkpoint()
         if isinstance(command, PathLike):
-            command = str(pathlib.Path(command))
+            command = os.fspath(command)
 
         if isinstance(command, (str, bytes)):
             process = await asyncio.create_subprocess_shell(

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -41,7 +41,6 @@ from threading import Thread
 from types import TracebackType
 from typing import (
     IO,
-    TYPE_CHECKING,
     Any,
     AsyncGenerator,
     Awaitable,
@@ -81,6 +80,7 @@ from ..abc import (
     UDPPacketType,
     UNIXDatagramPacketType,
 )
+from ..abc._eventloop import StrOrBytesPath
 from ..lowlevel import RunVar
 from ..streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
@@ -276,10 +276,6 @@ else:
             await future
         finally:
             thread.join()
-
-
-if TYPE_CHECKING:
-    from _typeshed import StrOrBytesPath
 
 
 T_Retval = TypeVar("T_Retval")

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import array
 import math
+import os
 import socket
 import sys
 import types
@@ -973,9 +974,16 @@ class TrioBackend(AsyncBackend):
         stderr: int | IO[Any] | None,
         **kwargs: Any,
     ) -> Process:
+        def convert_item(item: StrOrBytesPath) -> str:
+            str_or_bytes = os.fspath(item)
+            if isinstance(str_or_bytes, str):
+                return str_or_bytes
+            else:
+                return os.fsdecode(str_or_bytes)
+
         if isinstance(command, (str, bytes, PathLike)):
             process = await trio.lowlevel.open_process(
-                command,
+                convert_item(command),
                 stdin=stdin,
                 stdout=stdout,
                 stderr=stderr,
@@ -984,7 +992,7 @@ class TrioBackend(AsyncBackend):
             )
         else:
             process = await trio.lowlevel.open_process(
-                command,
+                [convert_item(item) for item in command],
                 stdin=stdin,
                 stdout=stdout,
                 stderr=stderr,

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -18,7 +18,6 @@ from socket import AddressFamily, SocketKind
 from types import TracebackType
 from typing import (
     IO,
-    TYPE_CHECKING,
     Any,
     AsyncGenerator,
     Awaitable,
@@ -61,7 +60,7 @@ from .._core._synchronization import Event as BaseEvent
 from .._core._synchronization import ResourceGuard
 from .._core._tasks import CancelScope as BaseCancelScope
 from ..abc import IPSockAddrType, UDPPacketType, UNIXDatagramPacketType
-from ..abc._eventloop import AsyncBackend
+from ..abc._eventloop import AsyncBackend, StrOrBytesPath
 from ..streams.memory import MemoryObjectSendStream
 
 if sys.version_info >= (3, 10):
@@ -74,9 +73,6 @@ if sys.version_info >= (3, 11):
 else:
     from exceptiongroup import BaseExceptionGroup
     from typing_extensions import TypeVarTuple, Unpack
-
-if TYPE_CHECKING:
-    from _typeshed import StrOrBytesPath
 
 T = TypeVar("T")
 T_Retval = TypeVar("T_Retval")

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -18,6 +18,7 @@ from socket import AddressFamily, SocketKind
 from types import TracebackType
 from typing import (
     IO,
+    TYPE_CHECKING,
     Any,
     AsyncGenerator,
     Awaitable,
@@ -60,7 +61,7 @@ from .._core._synchronization import Event as BaseEvent
 from .._core._synchronization import ResourceGuard
 from .._core._tasks import CancelScope as BaseCancelScope
 from ..abc import IPSockAddrType, UDPPacketType, UNIXDatagramPacketType
-from ..abc._eventloop import AsyncBackend, StrOrBytesPath
+from ..abc._eventloop import AsyncBackend
 from ..streams.memory import MemoryObjectSendStream
 
 if sys.version_info >= (3, 10):
@@ -73,6 +74,9 @@ if sys.version_info >= (3, 11):
 else:
     from exceptiongroup import BaseExceptionGroup
     from typing_extensions import TypeVarTuple, Unpack
+
+if TYPE_CHECKING:
+    from _typeshed import StrOrBytesPath
 
 T = TypeVar("T")
 T_Retval = TypeVar("T_Retval")

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -31,6 +31,7 @@ async def run_process(
     startupinfo: Any = None,
     creationflags: int = 0,
     start_new_session: bool = False,
+    pass_fds: Sequence[int] = (),
     user: str | int | None = None,
     group: str | int | None = None,
     extra_groups: Iterable[str | int] | None = None,
@@ -60,6 +61,8 @@ async def run_process(
         subprocess (see :class:`subprocess.Popen` for the specifics)
     :param start_new_session: if ``true`` the setsid() system call will be made in the
         child process prior to the execution of the subprocess. (POSIX only)
+    :param pass_fds: sequence of file descriptors to keep open between the parent and
+        child processes. (POSIX only)
     :param user: effective user to run the process as (Python >= 3.9, POSIX only)
     :param group: effective group to run the process as (Python >= 3.9, POSIX only)
     :param extra_groups: supplementary groups to set in the subprocess (Python >= 3.9,
@@ -89,6 +92,7 @@ async def run_process(
         startupinfo=startupinfo,
         creationflags=creationflags,
         start_new_session=start_new_session,
+        pass_fds=pass_fds,
         user=user,
         group=group,
         extra_groups=extra_groups,

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -4,14 +4,12 @@ import sys
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from io import BytesIO
 from subprocess import DEVNULL, PIPE, CalledProcessError, CompletedProcess
-from typing import IO, TYPE_CHECKING, Any, cast
+from typing import IO, Any, cast
 
 from ..abc import Process
+from ..abc._eventloop import StrOrBytesPath
 from ._eventloop import get_async_backend
 from ._tasks import create_task_group
-
-if TYPE_CHECKING:
-    from _typeshed import StrOrBytesPath
 
 
 async def run_process(

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 import sys
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from io import BytesIO
+from os import PathLike
 from subprocess import DEVNULL, PIPE, CalledProcessError, CompletedProcess
-from typing import IO, Any, cast
+from typing import IO, Any, TypeAlias, Union, cast
 
 from ..abc import Process
-from ..abc._eventloop import StrOrBytesPath
 from ._eventloop import get_async_backend
 from ._tasks import create_task_group
 
 PY39_ARGS = frozenset(["user", "group", "extra_groups", "umask"])
+
+StrOrBytesPath: TypeAlias = Union[str, bytes, "PathLike[str]"]
 
 
 async def run_process(

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -16,7 +16,7 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-StrOrBytesPath: TypeAlias = Union[str, bytes, "PathLike[str]"]
+StrOrBytesPath: TypeAlias = Union[str, bytes, "PathLike[str]", "PathLike[bytes]"]
 
 
 async def run_process(

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -16,8 +16,6 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-PY39_ARGS = frozenset(["user", "group", "extra_groups", "umask"])
-
 StrOrBytesPath: TypeAlias = Union[str, bytes, "PathLike[str]"]
 
 

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import AsyncIterable, Callable, Iterable, Mapping, Sequence
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from io import BytesIO
-from os import PathLike
 from subprocess import DEVNULL, PIPE, CalledProcessError, CompletedProcess
 from typing import IO, Any, cast
 
@@ -21,7 +20,6 @@ async def run_process(
     input: bytes | None = None,
     stdout: int | IO[Any] | None = PIPE,
     stderr: int | IO[Any] | None = PIPE,
-    preexec_fn: Callable[[], Any] | None = None,
     check: bool = True,
     cwd: StrOrBytesPath | None = None,
     env: Mapping[str, str] | None = None,
@@ -45,8 +43,6 @@ async def run_process(
         a file-like object, or `None`
     :param stderr: one of :data:`subprocess.PIPE`, :data:`subprocess.DEVNULL`,
         :data:`subprocess.STDOUT`, a file-like object, or `None`
-    :param preexec_fn: a callable that is called in the child process just before the
-        actual command is executed
     :param check: if ``True``, raise :exc:`~subprocess.CalledProcessError` if the
         process terminates with a return code other than 0
     :param cwd: If not ``None``, change the working directory to this before running the
@@ -83,7 +79,6 @@ async def run_process(
         stdin=PIPE if input else DEVNULL,
         stdout=stdout,
         stderr=stderr,
-        preexec_fn=preexec_fn,
         cwd=cwd,
         env=env,
         startupinfo=startupinfo,
@@ -121,7 +116,6 @@ async def open_process(
     stdin: int | IO[Any] | None = PIPE,
     stdout: int | IO[Any] | None = PIPE,
     stderr: int | IO[Any] | None = PIPE,
-    preexec_fn: Callable[[], Any] | None = None,
     cwd: StrOrBytesPath | None = None,
     env: Mapping[str, str] | None = None,
     startupinfo: Any = None,
@@ -145,8 +139,6 @@ async def open_process(
         a file-like object, or ``None``
     :param stderr: one of :data:`subprocess.PIPE`, :data:`subprocess.DEVNULL`,
         :data:`subprocess.STDOUT`, a file-like object, or ``None``
-    :param preexec_fn: a callable that is called in the child process just before the
-        actual command is executed
     :param cwd: If not ``None``, the working directory is changed before executing
     :param env: If env is not ``None``, it must be a mapping that defines the
         environment variables for the new process
@@ -190,31 +182,15 @@ async def open_process(
 
         kwargs["umask"] = umask
 
-    if isinstance(command, (str, bytes, PathLike)):
-        return await get_async_backend().open_process(
-            command,
-            stdin=stdin,
-            stdout=stdout,
-            stderr=stderr,
-            preexec_fn=preexec_fn,
-            cwd=cwd,
-            env=env,
-            startupinfo=startupinfo,
-            creationflags=creationflags,
-            start_new_session=start_new_session,
-            **kwargs,
-        )
-    else:
-        return await get_async_backend().open_process(
-            command,
-            stdin=stdin,
-            stdout=stdout,
-            stderr=stderr,
-            preexec_fn=preexec_fn,
-            cwd=cwd,
-            env=env,
-            startupinfo=startupinfo,
-            creationflags=creationflags,
-            start_new_session=start_new_session,
-            **kwargs,
-        )
+    return await get_async_backend().open_process(
+        command,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        cwd=cwd,
+        env=env,
+        startupinfo=startupinfo,
+        creationflags=creationflags,
+        start_new_session=start_new_session,
+        **kwargs,
+    )

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -126,6 +126,7 @@ async def open_process(
     startupinfo: Any = None,
     creationflags: int = 0,
     start_new_session: bool = False,
+    pass_fds: Sequence[int] = (),
     user: str | int | None = None,
     group: str | int | None = None,
     extra_groups: Iterable[str | int] | None = None,
@@ -153,6 +154,8 @@ async def open_process(
         to specify process startup parameters (Windows only)
     :param start_new_session: if ``true`` the setsid() system call will be made in the
         child process prior to the execution of the subprocess. (POSIX only)
+    :param pass_fds: sequence of file descriptors to keep open between the parent and
+        child processes. (POSIX only)
     :param user: effective user to run the process as (Python >= 3.9; POSIX only)
     :param group: effective group to run the process as (Python >= 3.9; POSIX only)
     :param extra_groups: supplementary groups to set in the subprocess (Python >= 3.9;
@@ -197,5 +200,6 @@ async def open_process(
         startupinfo=startupinfo,
         creationflags=creationflags,
         start_new_session=start_new_session,
+        pass_fds=pass_fds,
         **kwargs,
     )

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -3,20 +3,15 @@ from __future__ import annotations
 import sys
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from io import BytesIO
-from os import PathLike
 from subprocess import DEVNULL, PIPE, CalledProcessError, CompletedProcess
-from typing import IO, Any, Union, cast
+from typing import IO, TYPE_CHECKING, Any, cast
 
 from ..abc import Process
 from ._eventloop import get_async_backend
 from ._tasks import create_task_group
 
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
-
-StrOrBytesPath: TypeAlias = Union[str, bytes, "PathLike[str]", "PathLike[bytes]"]
+if TYPE_CHECKING:
+    from _typeshed import StrOrBytesPath
 
 
 async def run_process(

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -5,11 +5,16 @@ from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from io import BytesIO
 from os import PathLike
 from subprocess import DEVNULL, PIPE, CalledProcessError, CompletedProcess
-from typing import IO, Any, TypeAlias, Union, cast
+from typing import IO, Any, Union, cast
 
 from ..abc import Process
 from ._eventloop import get_async_backend
 from ._tasks import create_task_group
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 PY39_ARGS = frozenset(["user", "group", "extra_groups", "umask"])
 

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -3,13 +3,20 @@ from __future__ import annotations
 import sys
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from io import BytesIO
+from os import PathLike
 from subprocess import DEVNULL, PIPE, CalledProcessError, CompletedProcess
-from typing import IO, Any, cast
+from typing import IO, Any, Union, cast
 
 from ..abc import Process
-from ..abc._eventloop import StrOrBytesPath
 from ._eventloop import get_async_backend
 from ._tasks import create_task_group
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+StrOrBytesPath: TypeAlias = Union[str, bytes, "PathLike[str]", "PathLike[bytes]"]
 
 
 async def run_process(

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -4,7 +4,6 @@ import math
 import sys
 from abc import ABCMeta, abstractmethod
 from collections.abc import AsyncIterator, Awaitable
-from os import PathLike
 from signal import Signals
 from socket import AddressFamily, SocketKind, socket
 from typing import (
@@ -15,7 +14,6 @@ from typing import (
     ContextManager,
     Sequence,
     TypeVar,
-    Union,
     overload,
 )
 
@@ -24,12 +22,9 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import TypeVarTuple, Unpack
 
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
-
 if TYPE_CHECKING:
+    from _typeshed import StrOrBytesPath
+
     from .._core._synchronization import CapacityLimiter, Event
     from .._core._tasks import CancelScope
     from .._core._testing import TaskInfo
@@ -50,7 +45,6 @@ if TYPE_CHECKING:
 
 T_Retval = TypeVar("T_Retval")
 PosArgsT = TypeVarTuple("PosArgsT")
-StrOrBytesPath: TypeAlias = Union[str, bytes, "PathLike[str]", "PathLike[bytes]"]
 
 
 class AsyncBackend(metaclass=ABCMeta):

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 
 T_Retval = TypeVar("T_Retval")
 PosArgsT = TypeVarTuple("PosArgsT")
-StrOrBytesPath: TypeAlias = Union[str, bytes, "PathLike[str]"]
+StrOrBytesPath: TypeAlias = Union[str, bytes, "PathLike[str]", "PathLike[bytes]"]
 
 
 class AsyncBackend(metaclass=ABCMeta):

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import sys
 from abc import ABCMeta, abstractmethod
-from collections.abc import AsyncIterator, Awaitable, Mapping
+from collections.abc import AsyncIterator, Awaitable
 from os import PathLike
 from signal import Signals
 from socket import AddressFamily, SocketKind, socket
@@ -15,6 +15,7 @@ from typing import (
     ContextManager,
     Sequence,
     TypeVar,
+    Union,
     overload,
 )
 
@@ -23,9 +24,12 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import TypeVarTuple, Unpack
 
-if TYPE_CHECKING:
-    from typing import Literal
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
+if TYPE_CHECKING:
     from .._core._synchronization import CapacityLimiter, Event
     from .._core._tasks import CancelScope
     from .._core._testing import TaskInfo
@@ -46,6 +50,7 @@ if TYPE_CHECKING:
 
 T_Retval = TypeVar("T_Retval")
 PosArgsT = TypeVarTuple("PosArgsT")
+StrOrBytesPath: TypeAlias = Union[str, bytes, "PathLike[str]"]
 
 
 class AsyncBackend(metaclass=ABCMeta):
@@ -214,50 +219,15 @@ class AsyncBackend(metaclass=ABCMeta):
         pass
 
     @classmethod
-    @overload
-    async def open_process(
-        cls,
-        command: str | bytes,
-        *,
-        shell: Literal[True],
-        stdin: int | IO[Any] | None,
-        stdout: int | IO[Any] | None,
-        stderr: int | IO[Any] | None,
-        cwd: str | bytes | PathLike[str] | None = None,
-        env: Mapping[str, str] | None = None,
-        start_new_session: bool = False,
-    ) -> Process:
-        pass
-
-    @classmethod
-    @overload
-    async def open_process(
-        cls,
-        command: Sequence[str | bytes],
-        *,
-        shell: Literal[False],
-        stdin: int | IO[Any] | None,
-        stdout: int | IO[Any] | None,
-        stderr: int | IO[Any] | None,
-        cwd: str | bytes | PathLike[str] | None = None,
-        env: Mapping[str, str] | None = None,
-        start_new_session: bool = False,
-    ) -> Process:
-        pass
-
-    @classmethod
     @abstractmethod
     async def open_process(
         cls,
-        command: str | bytes | Sequence[str | bytes],
+        command: StrOrBytesPath | Sequence[StrOrBytesPath],
         *,
-        shell: bool,
         stdin: int | IO[Any] | None,
         stdout: int | IO[Any] | None,
         stderr: int | IO[Any] | None,
-        cwd: str | bytes | PathLike[str] | None = None,
-        env: Mapping[str, str] | None = None,
-        start_new_session: bool = False,
+        **kwargs: Any,
     ) -> Process:
         pass
 

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -4,6 +4,7 @@ import math
 import sys
 from abc import ABCMeta, abstractmethod
 from collections.abc import AsyncIterator, Awaitable
+from os import PathLike
 from signal import Signals
 from socket import AddressFamily, SocketKind, socket
 from typing import (
@@ -14,6 +15,7 @@ from typing import (
     ContextManager,
     Sequence,
     TypeVar,
+    Union,
     overload,
 )
 
@@ -22,9 +24,12 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import TypeVarTuple, Unpack
 
-if TYPE_CHECKING:
-    from _typeshed import StrOrBytesPath
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
+if TYPE_CHECKING:
     from .._core._synchronization import CapacityLimiter, Event
     from .._core._tasks import CancelScope
     from .._core._testing import TaskInfo
@@ -45,6 +50,7 @@ if TYPE_CHECKING:
 
 T_Retval = TypeVar("T_Retval")
 PosArgsT = TypeVarTuple("PosArgsT")
+StrOrBytesPath: TypeAlias = Union[str, bytes, "PathLike[str]", "PathLike[bytes]"]
 
 
 class AsyncBackend(metaclass=ABCMeta):

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -233,7 +233,7 @@ async def test_process_aexit_cancellation_closes_standard_streams(
     "argname, argvalue",
     [
         pytest.param("user", os.getuid(), id="user"),
-        pytest.param("group", os.getuid(), id="group"),
+        pytest.param("group", os.getgid(), id="group"),
         pytest.param("extra_groups", [], id="extra_groups"),
         pytest.param("umask", 0, id="umask"),
     ],

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -233,8 +233,28 @@ async def test_process_aexit_cancellation_closes_standard_streams(
 @pytest.mark.parametrize(
     "argname, argvalue_factory",
     [
-        pytest.param("user", lambda: os.getuid(), id="user"),
-        pytest.param("group", lambda: os.getgid(), id="group"),
+        pytest.param(
+            "user",
+            lambda: os.getuid(),
+            id="user",
+            marks=[
+                pytest.mark.skipif(
+                    platform.system() == "Windows",
+                    reason="os.getuid() is not available on Windows",
+                )
+            ],
+        ),
+        pytest.param(
+            "group",
+            lambda: os.getgid(),
+            id="user",
+            marks=[
+                pytest.mark.skipif(
+                    platform.system() == "Windows",
+                    reason="os.getgid() is not available on Windows",
+                )
+            ],
+        ),
         pytest.param("extra_groups", list, id="extra_groups"),
         pytest.param("umask", lambda: 0, id="umask"),
     ],

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import os
 import platform
 import sys
+from contextlib import ExitStack
 from pathlib import Path
 from subprocess import CalledProcessError
 from textwrap import dedent
+from typing import Any
 
 import pytest
-from _pytest.fixtures import FixtureRequest
+from pytest import FixtureRequest
 
 from anyio import CancelScope, ClosedResourceError, open_process, run_process
 from anyio.streams.buffered import BufferedByteReceiveStream
@@ -225,3 +227,43 @@ async def test_process_aexit_cancellation_closes_standard_streams(
 
     with pytest.raises(ClosedResourceError):
         await process.stderr.receive(1)
+
+
+@pytest.mark.parametrize(
+    "argname, argvalue",
+    [
+        pytest.param("user", os.getuid(), id="user"),
+        pytest.param("group", os.getuid(), id="group"),
+        pytest.param("extra_groups", [], id="extra_groups"),
+        pytest.param("umask", 0, id="umask"),
+    ],
+)
+async def test_py39_arguments(
+    argname: str,
+    argvalue: Any,
+    anyio_backend_name: str,
+    anyio_backend_options: dict[str, Any],
+) -> None:
+    with ExitStack() as stack:
+        if sys.version_info < (3, 9):
+            stack.enter_context(
+                pytest.raises(
+                    TypeError,
+                    match=rf"the {argname!r} argument requires Python 3.9 or later",
+                )
+            )
+
+        try:
+            await run_process(
+                [sys.executable, "-c", "print('hello')"], **{argname: argvalue}
+            )
+        except TypeError as exc:
+            if (
+                "unexpected keyword argument" in str(exc)
+                and anyio_backend_name == "asyncio"
+                and anyio_backend_options["loop_factory"]
+                and anyio_backend_options["loop_factory"].__module__ == "uvloop"
+            ):
+                pytest.skip(f"the {argname!r} argument is not supported by uvloop yet")
+
+            raise


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This adds a number of new arguments to `run_process()` and `open_process()`:

1. `startupinfo`
2. `creationflags`
3. `user`
4. `group`
5. `extra_groups`
6. `umask`

Fixes #742.
<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
