### PR TITLE
Switched start_blocking_portal() to use daemon threads

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,6 +10,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#737 <https://github.com/agronholm/anyio/issues/737>`_)
 - Changed the ``ResourceWarning`` from an unclosed memory object stream to include its
   address for easier identification
+- Changed ``start_blocking_portal()`` to always use daemonic threads, to accommodate the
+  "loitering event loop" use case
 - Fixed ``to_process.run_sync()`` failing to initialize if ``__main__.__file__`` pointed
   to a file in a nonexistent directory
   (`#696 <https://github.com/agronholm/anyio/issues/696>`_)

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
 import sys
-import threading
 from collections.abc import Awaitable, Callable, Generator
-from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from concurrent.futures import Future
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass, field
 from inspect import isawaitable
+from threading import Lock, Thread, get_ident
 from types import TracebackType
 from typing import (
     Any,
     AsyncContextManager,
     ContextManager,
     Generic,
-    Iterable,
     TypeVar,
     cast,
     overload,
@@ -146,7 +145,7 @@ class BlockingPortal:
         return get_async_backend().create_blocking_portal()
 
     def __init__(self) -> None:
-        self._event_loop_thread_id: int | None = threading.get_ident()
+        self._event_loop_thread_id: int | None = get_ident()
         self._stop_event = Event()
         self._task_group = create_task_group()
         self._cancelled_exc_class = get_cancelled_exc_class()
@@ -167,7 +166,7 @@ class BlockingPortal:
     def _check_running(self) -> None:
         if self._event_loop_thread_id is None:
             raise RuntimeError("This portal is not running")
-        if self._event_loop_thread_id == threading.get_ident():
+        if self._event_loop_thread_id == get_ident():
             raise RuntimeError(
                 "This method cannot be called from the event loop thread"
             )
@@ -202,7 +201,7 @@ class BlockingPortal:
         def callback(f: Future[T_Retval]) -> None:
             if f.cancelled() and self._event_loop_thread_id not in (
                 None,
-                threading.get_ident(),
+                get_ident(),
             ):
                 self.call(scope.cancel)
 
@@ -411,7 +410,7 @@ class BlockingPortalProvider:
 
     backend: str = "asyncio"
     backend_options: dict[str, Any] | None = None
-    _lock: threading.Lock = field(init=False, default_factory=threading.Lock)
+    _lock: Lock = field(init=False, default_factory=Lock)
     _leases: int = field(init=False, default=0)
     _portal: BlockingPortal = field(init=False)
     _portal_cm: AbstractContextManager[BlockingPortal] | None = field(
@@ -469,43 +468,41 @@ def start_blocking_portal(
 
     async def run_portal() -> None:
         async with BlockingPortal() as portal_:
-            if future.set_running_or_notify_cancel():
-                future.set_result(portal_)
-                await portal_.sleep_until_stopped()
+            future.set_result(portal_)
+            await portal_.sleep_until_stopped()
+
+    def run_blocking_portal() -> None:
+        if future.set_running_or_notify_cancel():
+            try:
+                _eventloop.run(
+                    run_portal, backend=backend, backend_options=backend_options
+                )
+            except BaseException as exc:
+                if not future.done():
+                    future.set_exception(exc)
 
     future: Future[BlockingPortal] = Future()
-    with ThreadPoolExecutor(1) as executor:
-        run_future = executor.submit(
-            _eventloop.run,  # type: ignore[arg-type]
-            run_portal,
-            backend=backend,
-            backend_options=backend_options,
-        )
+    thread = Thread(target=run_blocking_portal, daemon=True)
+    thread.start()
+    try:
+        portal = future.result()
+    except BaseException:
+        thread.join()
+        raise
+
+    cancel_remaining_tasks = False
+    try:
+        yield portal
+    except BaseException:
+        cancel_remaining_tasks = True
+        raise
+    finally:
         try:
-            wait(
-                cast(Iterable[Future], [run_future, future]),
-                return_when=FIRST_COMPLETED,
-            )
-        except BaseException:
-            future.cancel()
-            run_future.cancel()
-            raise
+            portal.call(portal.stop, cancel_remaining_tasks)
+        except RuntimeError:
+            pass
 
-        if future.done():
-            portal = future.result()
-            cancel_remaining_tasks = False
-            try:
-                yield portal
-            except BaseException:
-                cancel_remaining_tasks = True
-                raise
-            finally:
-                try:
-                    portal.call(portal.stop, cancel_remaining_tasks)
-                except RuntimeError:
-                    pass
-
-        run_future.result()
+        thread.join()
 
 
 def check_cancelled() -> None:

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -485,23 +485,19 @@ def start_blocking_portal(
     thread = Thread(target=run_blocking_portal, daemon=True)
     thread.start()
     try:
+        cancel_remaining_tasks = False
         portal = future.result()
-    except BaseException:
-        thread.join()
-        raise
-
-    cancel_remaining_tasks = False
-    try:
-        yield portal
-    except BaseException:
-        cancel_remaining_tasks = True
-        raise
-    finally:
         try:
-            portal.call(portal.stop, cancel_remaining_tasks)
-        except RuntimeError:
-            pass
-
+            yield portal
+        except BaseException:
+            cancel_remaining_tasks = True
+            raise
+        finally:
+            try:
+                portal.call(portal.stop, cancel_remaining_tasks)
+            except RuntimeError:
+                pass
+    finally:
         thread.join()
 
 

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -609,10 +609,10 @@ class TestBlockingPortal:
         """
         Test that when a task raises a BaseException, it does not trigger additional
         exceptions when trying to close the portal.
-
         """
 
         async def raise_baseexception() -> None:
+            assert threading.current_thread().daemon
             raise BaseException("fatal error")
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -34,7 +34,7 @@ from anyio.from_thread import BlockingPortal, start_blocking_portal
 from anyio.lowlevel import checkpoint
 
 if sys.version_info < (3, 11):
-    from exceptiongroup import BaseExceptionGroup, ExceptionGroup
+    from exceptiongroup import ExceptionGroup
 
 pytestmark = pytest.mark.anyio
 
@@ -615,17 +615,11 @@ class TestBlockingPortal:
         async def raise_baseexception() -> None:
             raise BaseException("fatal error")
 
-        with pytest.raises(BaseExceptionGroup) as outer_exc:
-            with start_blocking_portal(
-                anyio_backend_name, anyio_backend_options
-            ) as portal:
-                with pytest.raises(BaseException, match="fatal error") as exc:
-                    portal.call(raise_baseexception)
+        with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
+            with pytest.raises(BaseException, match="fatal error") as exc:
+                portal.call(raise_baseexception)
 
-                assert exc.value.__context__ is None
-
-        assert len(outer_exc.value.exceptions) == 1
-        assert str(outer_exc.value.exceptions[0]) == "fatal error"
+            assert exc.value.__context__ is None
 
     @pytest.mark.parametrize("portal_backend_name", get_all_backends())
     async def test_from_async(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

ThreadPoolExecutor used daemon threads in Python 3.8 and non-daemon threads in 3.9 onwards. But daemon threads are essential for the use case where we want to have a "loitering" blocking portal which will only be shut down via an atexit hook.

Related discussion: https://github.com/agronholm/anyio/discussions/743
<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
