### PR TITLE
Fixed feed_data after feed_eof assertion errors on asyncio

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -13,6 +13,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``to_process.run_sync()`` failing to initialize if ``__main__.__file__`` pointed
   to a file in a nonexistent directory
   (`#696 <https://github.com/agronholm/anyio/issues/696>`_)
+- Fixed ``AssertionError: feed_data after feed_eof`` on asyncio when a subprocess is
+  closed early, before its output has been read
+  (`#490 <https://github.com/agronholm/anyio/issues/490>`_)
 
 **4.4.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -24,7 +24,7 @@ from collections.abc import AsyncIterator, Iterable
 from concurrent.futures import Future
 from contextlib import suppress
 from contextvars import Context, copy_context
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import partial, wraps
 from inspect import (
     CORO_RUNNING,
@@ -908,12 +908,8 @@ class BlockingPortal(abc.BlockingPortal):
 @dataclass(eq=False)
 class StreamReaderWrapper(abc.ByteReceiveStream):
     _stream: asyncio.StreamReader
-    _closed: bool = field(init=False, default=False)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
-        if self._closed:
-            raise ClosedResourceError
-
         data = await self._stream.read(max_bytes)
         if data:
             return data
@@ -921,7 +917,7 @@ class StreamReaderWrapper(abc.ByteReceiveStream):
             raise EndOfStream
 
     async def aclose(self) -> None:
-        self._closed = True
+        self._stream.set_exception(ClosedResourceError())
         await AsyncIOBackend.checkpoint()
 
 

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -311,9 +311,9 @@ async def test_close_early() -> None:
 
 async def test_close_while_reading() -> None:
     code = dedent("""\
-    import sys
-    for _ in range(100):
-        sys.stdout.buffer.write(bytes(range(256)))
+    import time
+
+    time.sleep(3)
     """)
 
     async with await open_process(
@@ -323,3 +323,5 @@ async def test_close_while_reading() -> None:
         tg.start_soon(process.stdout.aclose)
         with pytest.raises(ClosedResourceError):
             await process.stdout.receive()
+
+        process.terminate()

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -225,3 +225,15 @@ async def test_process_aexit_cancellation_closes_standard_streams(
 
     with pytest.raises(ClosedResourceError):
         await process.stderr.receive(1)
+
+
+async def test_close_early() -> None:
+    """Regression test for #490."""
+    code = dedent("""\
+    import sys
+    for _ in range(100):
+        sys.stdout.buffer.write(bytes(range(256)))
+    """)
+
+    async with await open_process([sys.executable, "-c", code]):
+        pass


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This removes the call to `self._stream.feed_eof()`, as it should not be done when the protocol is still sending data (and we can't prevent it from doing so). Instead, we set an internal flag and raise `ClosedResourceError` if someone tries to read from the stream after it's closed.

Fixes #490. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
