### PR TITLE
Delegated the implementations of Lock and Semaphore to the async backend class

### DIFF
--- a/docs/synchronization.rst
+++ b/docs/synchronization.rst
@@ -66,6 +66,13 @@ Example::
 
     run(main)
 
+.. tip:: If the performance of semaphores is critical for you, you could pass
+   ``fast_acquire=True`` to :class:`Semaphore`. This has the effect of skipping the
+   :func:`~.lowlevel.cancel_shielded_checkpoint` call in :meth:`Semaphore.acquire` if
+   there is no contention (acquisition succeeds immediately). This could, in some cases,
+   lead to the task never yielding control back to to the event loop if you have a loop
+   that does not have other yield points.
+
 Locks
 -----
 
@@ -92,6 +99,12 @@ Example::
 
     run(main)
 
+.. tip:: If the performance of locks is critical for you, you could pass
+   ``fast_acquire=True`` to :class:`Lock`. This has the effect of skipping the
+   :func:`~.lowlevel.cancel_shielded_checkpoint` call in :meth:`Lock.acquire` if there
+   is no contention (acquisition succeeds immediately). This could, in some cases, lead
+   to the task never yielding control back to to the event loop if you have a loop that
+   does not have other yield points.
 
 Conditions
 ----------

--- a/docs/synchronization.rst
+++ b/docs/synchronization.rst
@@ -70,8 +70,8 @@ Example::
    ``fast_acquire=True`` to :class:`Semaphore`. This has the effect of skipping the
    :func:`~.lowlevel.cancel_shielded_checkpoint` call in :meth:`Semaphore.acquire` if
    there is no contention (acquisition succeeds immediately). This could, in some cases,
-   lead to the task never yielding control back to to the event loop if you have a loop
-   that does not have other yield points.
+   lead to the task never yielding control back to to the event loop if you use the
+   semaphore in a loop that does not have other yield points.
 
 Locks
 -----
@@ -103,8 +103,8 @@ Example::
    ``fast_acquire=True`` to :class:`Lock`. This has the effect of skipping the
    :func:`~.lowlevel.cancel_shielded_checkpoint` call in :meth:`Lock.acquire` if there
    is no contention (acquisition succeeds immediately). This could, in some cases, lead
-   to the task never yielding control back to to the event loop if you have a loop that
-   does not have other yield points.
+   to the task never yielding control back to to the event loop if use the lock in a
+   loop that does not have other yield points.
 
 Conditions
 ----------

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Improved the performance of ``anyio.Lock`` on asyncio (even up to 50 %)
 - Added support for the ``from_uri()``, ``full_match()``, ``parser`` methods/properties
   in ``anyio.Path``, newly added in Python 3.13
   (`#737 <https://github.com/agronholm/anyio/issues/737>`_)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Improved the performance of ``anyio.Lock`` and ``anyio.Semaphore`` on asyncio (even up
   to 50 %)
+- Added the ``fast_acquire`` parameter to ``anyio.Lock`` and ``anyio.Semaphore`` to
+  further boost performance at the expense of safety (``acquire()`` will not yield
+  control back if there is no contention)
 - Fixed ``__repr__()`` of ``MemoryObjectItemReceiver``, when ``item`` is not defined
   (`#767 <https://github.com/agronholm/anyio/pulls/767>`_; PR by @Danipulok)
 - Added support for the ``from_uri()``, ``full_match()``, ``parser`` methods/properties

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,7 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Improved the performance of ``anyio.Lock`` on asyncio (even up to 50 %)
+- Improved the performance of ``anyio.Lock`` and ``anyio.Semaphore`` on asyncio (even up
+  to 50 %)
 - Added support for the ``from_uri()``, ``full_match()``, ``parser`` methods/properties
   in ``anyio.Path``, newly added in Python 3.13
   (`#737 <https://github.com/agronholm/anyio/issues/737>`_)

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -26,7 +26,7 @@ else:
 if TYPE_CHECKING:
     from typing import Literal
 
-    from .._core._synchronization import CapacityLimiter, Event
+    from .._core._synchronization import CapacityLimiter, Event, Lock
     from .._core._tasks import CancelScope
     from .._core._testing import TaskInfo
     from ..from_thread import BlockingPortal
@@ -165,6 +165,11 @@ class AsyncBackend(metaclass=ABCMeta):
     @classmethod
     @abstractmethod
     def create_event(cls) -> Event:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def create_lock(cls) -> Lock:
         pass
 
     @classmethod

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -169,13 +169,17 @@ class AsyncBackend(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def create_lock(cls) -> Lock:
+    def create_lock(cls, *, fast_acquire: bool) -> Lock:
         pass
 
     @classmethod
     @abstractmethod
     def create_semaphore(
-        cls, initial_value: int, *, max_value: int | None = None
+        cls,
+        initial_value: int,
+        *,
+        max_value: int | None = None,
+        fast_acquire: bool = False,
     ) -> Semaphore:
         pass
 

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -26,7 +26,7 @@ else:
 if TYPE_CHECKING:
     from typing import Literal
 
-    from .._core._synchronization import CapacityLimiter, Event, Lock
+    from .._core._synchronization import CapacityLimiter, Event, Lock, Semaphore
     from .._core._tasks import CancelScope
     from .._core._testing import TaskInfo
     from ..from_thread import BlockingPortal
@@ -170,6 +170,13 @@ class AsyncBackend(metaclass=ABCMeta):
     @classmethod
     @abstractmethod
     def create_lock(cls) -> Lock:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def create_semaphore(
+        cls, initial_value: int, *, max_value: int | None = None
+    ) -> Semaphore:
         pass
 
     @classmethod

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -64,6 +64,24 @@ class TestLock:
         assert not lock.locked()
         assert results == ["1", "2"]
 
+    async def test_fast_acquire(self) -> None:
+        """
+        Test that fast_acquire=True does not yield back control to the event loop when
+        there is no contention.
+
+        """
+        other_task_called = False
+
+        async def other_task() -> None:
+            nonlocal other_task_called
+            other_task_called = True
+
+        lock = Lock(fast_acquire=True)
+        async with create_task_group() as tg:
+            tg.start_soon(other_task)
+            async with lock:
+                assert not other_task_called
+
     async def test_acquire_nowait(self) -> None:
         lock = Lock()
         lock.acquire_nowait()
@@ -433,6 +451,24 @@ class TestSemaphore:
             tg.start_soon(acquire, name="task 2")
 
         assert semaphore.value == 2
+
+    async def test_fast_acquire(self) -> None:
+        """
+        Test that fast_acquire=True does not yield back control to the event loop when
+        there is no contention.
+
+        """
+        other_task_called = False
+
+        async def other_task() -> None:
+            nonlocal other_task_called
+            other_task_called = True
+
+        semaphore = Semaphore(1, fast_acquire=True)
+        async with create_task_group() as tg:
+            tg.start_soon(other_task)
+            async with semaphore:
+                assert not other_task_called
 
     async def test_acquire_nowait(self) -> None:
         semaphore = Semaphore(1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This improves the performance of `anyio.Lock` on asyncio by ~50% by delegating the implementation of the class to the async back-end.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
