### PR TITLE
Removed check for coroutine in asyncio backend

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -747,7 +747,7 @@ class TaskGroup(abc.TaskGroup):
         else:
             parent_id = id(self.cancel_scope._host_task)
 
-        coro = func(*args, **kwargs)
+        coro = cast(Coroutine, func(*args, **kwargs))
         name = get_callable_name(func) if name is None else str(name)
         task = create_task(coro, name=name)
         task.add_done_callback(task_done)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -29,7 +29,6 @@ from inspect import (
     CORO_RUNNING,
     CORO_SUSPENDED,
     getcoroutinestate,
-    iscoroutine,
 )
 from io import IOBase
 from os import PathLike
@@ -749,13 +748,6 @@ class TaskGroup(abc.TaskGroup):
             parent_id = id(self.cancel_scope._host_task)
 
         coro = func(*args, **kwargs)
-        if not iscoroutine(coro):
-            prefix = f"{func.__module__}." if hasattr(func, "__module__") else ""
-            raise TypeError(
-                f"Expected {prefix}{func.__qualname__}() to return a coroutine, but "
-                f"the return value ({coro!r}) is not a coroutine object"
-            )
-
         name = get_callable_name(func) if name is None else str(name)
         task = create_task(coro, name=name)
         task.add_done_callback(task_done)

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -264,7 +264,7 @@ async def test_start_exception_delivery(anyio_backend_name: str) -> None:
     if anyio_backend_name == "trio":
         pattern = "appears to be synchronous"
     else:
-        pattern = "is not a coroutine object"
+        pattern = "a coroutine was expected"
 
     async with anyio.create_task_group() as tg:
         with pytest.raises(TypeError, match=pattern):

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1013,24 +1013,15 @@ def test_cancel_generator_based_task() -> None:
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_schedule_old_style_coroutine_func() -> None:
     """
-    Test that we give a sensible error when a user tries to spawn a task from a
-    generator-style coroutine function.
+    Test that a task can be spawned from a generator-style coroutine function.
     """
 
     @asyncio.coroutine  # type: ignore[attr-defined]
     def corofunc() -> Generator[Any, Any, None]:
-        yield from asyncio.sleep(1)  # type: ignore[misc]
+        yield from asyncio.sleep(0.1)  # type: ignore[misc]
 
     async with create_task_group() as tg:
-        funcname = (
-            f"{__name__}.test_schedule_old_style_coroutine_func.<locals>.corofunc"
-        )
-        with pytest.raises(
-            TypeError,
-            match=f"Expected {funcname}\\(\\) to return a coroutine, but the return "
-            f"value \\(<generator .+>\\) is not a coroutine object",
-        ):
-            tg.start_soon(corofunc)
+        tg.start_soon(corofunc)
 
 
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

See https://github.com/agronholm/anyio/discussions/759#discussioncomment-10096103.
In the asyncio backend, there is no need to check if the object is a coroutine before launching it as a task:
- asyncio already does it,
- it prevents launching a class instance that looks like a coroutine, for instance:
```py
import typing

import anyio

class Foo(typing.Coroutine):
    def __await__(self):
        return self.run().__await__()

    def send(self, value=None):
        return self.__await__().send(value)

    def throw(self, *_unused):
        raise RuntimeError("Shouldn't happen")

    async def run(self):
        print("run")

async def main():
    async with anyio.create_task_group() as tg:
        tg.start_soon(Foo)

anyio.run(main, backend="trio")  # works fine
anyio.run(main, backend="asyncio")  # doesn't work
```
This already works with the Trio backend, but currently not with the asyncio backend.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
