### PR TITLE
Fixed `repr` of `MemoryObjectItemReceiver`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,8 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Fixed ``str`` and ``repr`` of ``MemoryObjectItemReceiver``, when ``item`` is not defined.
-  (`#767 <https://github.com/agronholm/anyio/pulls/767>`_)
+- Fixed ``__repr__()`` of ``MemoryObjectItemReceiver``, when ``item`` is not defined
+  (`#767 <https://github.com/agronholm/anyio/pulls/767>`_; PR by @Danipulok)
 - Added support for the ``from_uri()``, ``full_match()``, ``parser`` methods/properties
   in ``anyio.Path``, newly added in Python 3.13
   (`#737 <https://github.com/agronholm/anyio/issues/737>`_)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed ``str`` and ``repr`` of ``MemoryObjectItemReceiver``, when ``item`` is not defined.
+  (`#767 <https://github.com/agronholm/anyio/pulls/767>`_)
 - Added support for the ``from_uri()``, ``full_match()``, ``parser`` methods/properties
   in ``anyio.Path``, newly added in Python 3.13
   (`#737 <https://github.com/agronholm/anyio/issues/737>`_)

--- a/src/anyio/streams/memory.py
+++ b/src/anyio/streams/memory.py
@@ -38,6 +38,12 @@ class MemoryObjectItemReceiver(Generic[T_Item]):
     task_info: TaskInfo = field(init=False, default_factory=get_current_task)
     item: T_Item = field(init=False)
 
+    def __repr__(self) -> str:
+        # When item is not defined, we get following error with default __repr__:
+        # AttributeError: 'MemoryObjectItemReceiver' object has no attribute 'item'
+        item = getattr(self, "item", None)
+        return f"{self.__class__.__name__}(task_info={self.task_info}, item={item!r})"
+
 
 @dataclass(eq=False)
 class MemoryObjectStreamState(Generic[T_Item]):

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -18,7 +18,11 @@ from anyio import (
     wait_all_tasks_blocked,
 )
 from anyio.abc import ObjectReceiveStream, ObjectSendStream, TaskStatus
-from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from anyio.streams.memory import (
+    MemoryObjectItemReceiver, 
+    MemoryObjectReceiveStream, 
+    MemoryObjectSendStream,
+)
 
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
@@ -502,3 +506,20 @@ async def test_send_to_natively_cancelled_receiver() -> None:
             await receive_task
 
         assert receive.receive_nowait() == "hello"
+
+
+async def test_memory_object_item_receiver_repr() -> None:
+    """
+    Test the repr of `MemoryObjectItemReceiver`.
+    Since when `item` is not set, the default dataclass repr raises an AttributeError.
+    """
+    receiver = MemoryObjectItemReceiver[str]()
+
+    assert str(receiver) is not None
+    receiver_repr = repr(receiver)
+    assert "item=None" in receiver_repr
+
+    assert str(receiver) is not None
+    receiver.item = "test_item"
+    receiver_repr = repr(receiver)
+    assert "item='test_item'" in receiver_repr

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -19,8 +19,8 @@ from anyio import (
 )
 from anyio.abc import ObjectReceiveStream, ObjectSendStream, TaskStatus
 from anyio.streams.memory import (
-    MemoryObjectItemReceiver, 
-    MemoryObjectReceiveStream, 
+    MemoryObjectItemReceiver,
+    MemoryObjectReceiveStream,
     MemoryObjectSendStream,
 )
 


### PR DESCRIPTION
## Changes
Fix error that sometimes happened on `print` \ `str` \ `repr` on `MemoryObjectItemReceiver`:
`AttributeError: 'MemoryObjectItemReceiver' object has no attribute 'item'`

Here's the full traceback I receive:
```
Traceback (most recent call last):
  File "D:\project\test.py", line 305, in stream
    print("Tool tool_stream_sender", str(tool_stream_sender))
                                     ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python311\Lib\dataclasses.py", line 240, in wrapper
    result = user_function(self)
             ^^^^^^^^^^^^^^^^^^^
  File "<string>", line 3, in __repr__
  File "C:\Program Files\Python311\Lib\dataclasses.py", line 240, in wrapper
    result = user_function(self)
             ^^^^^^^^^^^^^^^^^^^
  File "<string>", line 3, in __repr__
  File "C:\Program Files\Python311\Lib\dataclasses.py", line 240, in wrapper
    result = user_function(self)
             ^^^^^^^^^^^^^^^^^^^
  File "<string>", line 3, in __repr__
AttributeError: 'MemoryObjectItemReceiver' object has no attribute 'item'

During handling of the above exception, another exception occurred:

  + Exception Group Traceback (most recent call last):
  |   File "D:\project\mre.py", line 303, in <module>
  |     asyncio.run(main())
  |   File "C:\Program Files\Python311\Lib\asyncio\runners.py", line 190, in run
  |     return runner.run(main)
  |            ^^^^^^^^^^^^^^^^
  |   File "C:\Program Files\Python311\Lib\asyncio\runners.py", line 118, in run
  |     return self._loop.run_until_complete(task)
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "C:\Program Files\Python311\Lib\asyncio\base_events.py", line 654, in run_until_complete
  |     return future.result()
  |            ^^^^^^^^^^^^^^^
  |   File "D:\project\mre.py", line 296, in main
  |     await check()  # ok
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "D:\project\mre.py", line 281, in check_agent
  |     async for index, chunk in asyncstdlib.enumerate(agent.stream(payload)):
  |   File "D:\project\.venv\Lib\site-packages\asyncstdlib\builtins.py", line 359, in enumerate
  |     async for item in item_iter:
  |   File "D:\project\test.py", line 294, in stream
  |     async with create_task_group() as tg:
  |   File "D:\project\.venv\Lib\site-packages\anyio\_backends\_asyncio.py", line 680, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "D:\project\test.py", line 305, in stream
    |     print("Tool tool_stream_sender", str(tool_stream_sender))
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\Program Files\Python311\Lib\dataclasses.py", line 240, in wrapper
    |     result = user_function(self)
    |              ^^^^^^^^^^^^^^^^^^^
    |   File "<string>", line 3, in __repr__
    |   File "C:\Program Files\Python311\Lib\dataclasses.py", line 240, in wrapper
    |     result = user_function(self)
    |              ^^^^^^^^^^^^^^^^^^^
    |   File "<string>", line 3, in __repr__
    |   File "C:\Program Files\Python311\Lib\dataclasses.py", line 240, in wrapper
    |     result = user_function(self)
    |              ^^^^^^^^^^^^^^^^^^^
    |   File "<string>", line 3, in __repr__
    | AttributeError: 'MemoryObjectItemReceiver' object has no attribute 'item'
    +------------------------------------
```

Unfortunately, I cannot provide full MRE or code, since it's partially a production code.
Here are some of the key moments (IMO):
```check.py
def get_tool_streams(
    tool_streams: dict[str, tuple[MemoryObjectSendStream[Any], MemoryObjectReceiveStream[Any]]],
    tool_name: str,
) -> tuple[MemoryObjectSendStream[Any], MemoryObjectReceiveStream[Any]]:
    if tool_name not in tool_streams:
        tool_streams[tool_name] = create_memory_object_stream(
            max_buffer_size=math.inf,
        )
    return tool_streams[tool_name]

class Agent:
    async def stream(self):
        async with create_task_group() as tg:
            async for chunk in generic_llm_output_stream:
                    tool_stream_sender, tool_stream_receiver = get_tool_streams(_tool_streams, tool_call.name)
                    print("Tool tool_stream_sender", str(tool_stream_sender))  # AttributeError
                    print("Tool tool_stream_sender", repr(tool_stream_sender))  # AttributeError
                    if tool_call.name not in _started_tools:
                        tg.start_soon(stream_to_task, tool, tool_stream_receiver)
                    tool_stream_sender.send_nowait(tool_call.input)

async def check_agent():
    payload = get_agent_input()
    async for index, chunk in asyncstdlib.enumerate(agent.stream(payload)):
        results_generic.append(chunk)

async def main() -> None:
    await check_agent()

if __name__ == "__main__":
    asyncio.run(main())
```

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).