### PR TITLE
Avoid expose extra vars (key, value)

### DIFF
--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from ._core._eventloop import current_time as current_time
 from ._core._eventloop import get_all_backends as get_all_backends
 from ._core._eventloop import get_cancelled_exc_class as get_cancelled_exc_class
@@ -69,8 +67,6 @@ from ._core._typedattr import TypedAttributeSet as TypedAttributeSet
 from ._core._typedattr import typed_attribute as typed_attribute
 
 # Re-export imports so they look like they live directly in this package
-key: str
-value: Any
-for key, value in list(locals().items()):
-    if getattr(value, "__module__", "").startswith("anyio."):
-        value.__module__ = __name__
+for __value in list(locals().values()):
+    if getattr(__value, "__module__", "").startswith("anyio."):
+        __value.__module__ = __name__

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -70,3 +70,5 @@ from ._core._typedattr import typed_attribute as typed_attribute
 for __value in list(locals().values()):
     if getattr(__value, "__module__", "").startswith("anyio."):
         __value.__module__ = __name__
+
+del __value


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes
```py
import anyio
print(anyio.key)
# typed_attribute
print(anyio.value)
# <function typed_attribute at 0x1033a5e10>
```
<!-- Please give a short brief about these changes. -->
It is unnecessary to expose anyio.key and anyio.value

## Checklist

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.
