### PR TITLE
Fix `TaskInfo.has_pending_cancellation()` false positives on asyncio with shielding

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -16,6 +16,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``to_process.run_sync()`` failing to initialize if ``__main__.__file__`` pointed
   to a file in a nonexistent directory
   (`#696 <https://github.com/agronholm/anyio/issues/696>`_)
+- Fixed ``TaskInfo.has_pending_cancellation()`` on asyncio not respecting shielded
+  scopes (`#771 <https://github.com/agronholm/anyio/issues/771>`_; PR by @gschaffner)
 
 **4.4.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1861,7 +1861,9 @@ class AsyncIOTaskInfo(TaskInfo):
 
         if task_state := _task_states.get(task):
             if cancel_scope := task_state.cancel_scope:
-                return cancel_scope.cancel_called or cancel_scope._parent_cancelled()
+                return cancel_scope.cancel_called or (
+                    not cancel_scope.shield and cancel_scope._parent_cancelled()
+                )
 
         return False
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -628,9 +628,11 @@ async def test_cancel_from_shielded_scope() -> None:
             assert inner_scope.shield
             tg.cancel_scope.cancel()
             assert current_effective_deadline() == math.inf
+            assert not get_current_task().has_pending_cancellation()
             await checkpoint()
 
         assert current_effective_deadline() == -math.inf
+        assert get_current_task().has_pending_cancellation()
 
         with pytest.raises(get_cancelled_exc_class()):
             await sleep(0.01)
@@ -644,6 +646,7 @@ async def test_cancel_shielded_scope() -> None:
         assert cancel_scope.shield
         cancel_scope.cancel()
         assert current_effective_deadline() == -math.inf
+        assert get_current_task().has_pending_cancellation()
 
         with pytest.raises(get_cancelled_exc_class()):
             await checkpoint()


### PR DESCRIPTION
## Changes

Fixes #771.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).