### PR TITLE
Fixed TaskGroup and CancelScope exit issues on asyncio

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,14 +61,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", pypy-3.10]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", pypy-3.10]
         include:
         - os: macos-latest
-          python-version: "3.8"
+          python-version: "3.9"
         - os: macos-latest
           python-version: "3.12"
         - os: windows-latest
-          python-version: "3.8"
+          python-version: "3.9"
         - os: windows-latest
           python-version: "3.12"
     runs-on: ${{ matrix.os }}

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Dropped support for Python 3.8
 - Fixed ``__repr__()`` of ``MemoryObjectItemReceiver``, when ``item`` is not defined
   (`#767 <https://github.com/agronholm/anyio/pulls/767>`_; PR by @Danipulok)
 - Added support for the ``from_uri()``, ``full_match()``, ``parser`` methods/properties

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -49,6 +49,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   arrives in an exception group)
 - Fixed support for Linux abstract namespaces in UNIX sockets that was broken in v4.2
   (#781 <https://github.com/agronholm/anyio/issues/781>_; PR by @tapetersen)
+- Fixed asyncio task groups not yielding control to the event loop at exit if there were
+  no child tasks to wait on
 
 **4.4.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -17,6 +17,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``to_process.run_sync()`` failing to initialize if ``__main__.__file__`` pointed
   to a file in a nonexistent directory
   (`#696 <https://github.com/agronholm/anyio/issues/696>`_)
+- Fixed 100% CPU use on asyncio while waiting for an exiting task group to finish while
+  said task group is within a cancelled cancel scope
+  (`#695 <https://github.com/agronholm/anyio/issues/695>`_)
+- Fixed cancel scopes on asyncio not reraising ``CancelledError`` on exit while the
+  enclosing cancel scope has been effectively cancelled
+  (`#698 <https://github.com/agronholm/anyio/issues/698>`_)
 
 **4.4.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,7 +6,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 **UNRELEASED**
 
 - Dropped support for Python 3.8
-  (as `#698 <https://github.com/agronholm/anyio/issues/698>`_) cannot be resolved
+  (as `#698 <https://github.com/agronholm/anyio/issues/698>`_ cannot be resolved
   without cancel message support)
 - Fixed 100% CPU use on asyncio while waiting for an exiting task group to finish while
   said task group is within a cancelled cancel scope

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,9 +3,24 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
-**4.5.0**
+**UNRELEASED**
 
 - Dropped support for Python 3.8
+  (as `#698 <https://github.com/agronholm/anyio/issues/698>`_) cannot be resolved
+  without cancel message support)
+- Fixed 100% CPU use on asyncio while waiting for an exiting task group to finish while
+  said task group is within a cancelled cancel scope
+  (`#695 <https://github.com/agronholm/anyio/issues/695>`_)
+- Fixed cancel scopes on asyncio not reraising ``CancelledError`` on exit while the
+  enclosing cancel scope has been effectively cancelled
+  (`#698 <https://github.com/agronholm/anyio/issues/698>`_)
+- Fixed asyncio task groups not yielding control to the event loop at exit if there were
+  no child tasks to wait on
+- Fixed inconsistent task uncancellation with asyncio cancel scopes belonging to a
+  task group when said task group has child tasks running
+
+**4.5.0**
+
 - Improved the performance of ``anyio.Lock`` and ``anyio.Semaphore`` on asyncio (even up
   to 50 %)
 - Added the ``fast_acquire`` parameter to ``anyio.Lock`` and ``anyio.Semaphore`` to
@@ -30,12 +45,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``to_process.run_sync()`` failing to initialize if ``__main__.__file__`` pointed
   to a file in a nonexistent directory
   (`#696 <https://github.com/agronholm/anyio/issues/696>`_)
-- Fixed 100% CPU use on asyncio while waiting for an exiting task group to finish while
-  said task group is within a cancelled cancel scope
-  (`#695 <https://github.com/agronholm/anyio/issues/695>`_)
-- Fixed cancel scopes on asyncio not reraising ``CancelledError`` on exit while the
-  enclosing cancel scope has been effectively cancelled
-  (`#698 <https://github.com/agronholm/anyio/issues/698>`_)
 - Fixed ``AssertionError: feed_data after feed_eof`` on asyncio when a subprocess is
   closed early, before its output has been read
   (`#490 <https://github.com/agronholm/anyio/issues/490>`_)
@@ -50,10 +59,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed support for Linux abstract namespaces in UNIX sockets that was broken in v4.2
   (#781 <https://github.com/agronholm/anyio/issues/781>_; PR by @tapetersen)
 - Fixed ``KeyboardInterrupt`` (ctrl+c) hanging the asyncio pytest runner
-- Fixed asyncio task groups not yielding control to the event loop at exit if there were
-  no child tasks to wait on
-- Fixed inconsistent task uncancellation with asyncio cancel scopes belonging to a
-  task group when said task group has child tasks running
 
 **4.4.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -52,6 +52,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``KeyboardInterrupt`` (ctrl+c) hanging the asyncio pytest runner
 - Fixed asyncio task groups not yielding control to the event loop at exit if there were
   no child tasks to wait on
+- Fixed inconsistent task uncancellation with asyncio cancel scopes belonging to a
+  task group when said task group has child tasks running
 
 **4.4.0**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,8 @@ test = [
     "pytest-mock >= 3.6.1",
     "trustme",
     """\
-    uvloop >= 0.17; platform_python_implementation == 'CPython' \
-    and platform_system != 'Windows' and python_version < '3.13'\
+    uvloop >= 0.21.0b1; platform_python_implementation == 'CPython' \
+    and platform_system != 'Windows'\
     """
 ]
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,13 @@ classifiers = [
     "Typing :: Typed",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 dependencies = [
     "exceptiongroup >= 1.0.2; python_version < '3.11'",
     "idna >= 2.8",
@@ -128,7 +127,7 @@ show_missing = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = pre-commit, py38, py39, py310, py311, py312, pypy3
+envlist = pre-commit, py39, py310, py311, py312, py313, pypy3
 skip_missing_interpreters = true
 minversion = 4.0.0
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -552,7 +552,7 @@ class CancelScope(BaseCancelScope):
                 waiter = task._fut_waiter  # type: ignore[attr-defined]
                 if not isinstance(waiter, asyncio.Future) or not waiter.done():
                     task.cancel(f"Cancelled by cancel scope {id(origin):x}")
-                    if task is self._host_task:
+                    if task is origin._host_task:
                         origin._cancel_calls += 1
 
         # Deliver cancellation to child scopes that aren't shielded or running their own

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -26,7 +26,6 @@ from collections.abc import (
     Callable,
     Collection,
     Coroutine,
-    Generator,
     Iterable,
     Mapping,
     Sequence,

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -551,8 +551,9 @@ class CancelScope(BaseCancelScope):
             if task is not current and (task is self._host_task or _task_started(task)):
                 waiter = task._fut_waiter  # type: ignore[attr-defined]
                 if not isinstance(waiter, asyncio.Future) or not waiter.done():
-                    origin._cancel_calls += 1
                     task.cancel(f"Cancelled by cancel scope {id(origin):x}")
+                    if task is self._host_task:
+                        origin._cancel_calls += 1
 
         # Deliver cancellation to child scopes that aren't shielded or running their own
         # cancellation callbacks

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -6,8 +6,19 @@ import socket
 import sys
 import types
 import weakref
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import (
+    AsyncGenerator,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Collection,
+    Coroutine,
+    Iterable,
+    Mapping,
+    Sequence,
+)
 from concurrent.futures import Future
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from functools import partial
 from io import IOBase
@@ -18,16 +29,8 @@ from types import TracebackType
 from typing import (
     IO,
     Any,
-    AsyncGenerator,
-    Awaitable,
-    Callable,
-    Collection,
-    ContextManager,
-    Coroutine,
     Generic,
-    Mapping,
     NoReturn,
-    Sequence,
     TypeVar,
     cast,
     overload,
@@ -1138,7 +1141,7 @@ class TrioBackend(AsyncBackend):
     @classmethod
     def open_signal_receiver(
         cls, *signals: Signals
-    ) -> ContextManager[AsyncIterator[Signals]]:
+    ) -> AbstractContextManager[AsyncIterator[Signals]]:
         return _SignalReceiver(signals)
 
     @classmethod

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import pathlib
 import sys
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from functools import partial
 from os import PathLike
@@ -12,7 +12,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AnyStr,
-    AsyncIterator,
     Final,
     Generic,
     overload,

--- a/src/anyio/_core/_signals.py
+++ b/src/anyio/_core/_signals.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from contextlib import AbstractContextManager
 from signal import Signals
-from typing import ContextManager
 
 from ._eventloop import get_async_backend
 
 
-def open_signal_receiver(*signals: Signals) -> ContextManager[AsyncIterator[Signals]]:
+def open_signal_receiver(
+    *signals: Signals,
+) -> AbstractContextManager[AsyncIterator[Signals]]:
     """
     Start receiving operating system signals.
 

--- a/src/anyio/_core/_streams.py
+++ b/src/anyio/_core/_streams.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Tuple, TypeVar
+from typing import TypeVar
 from warnings import warn
 
 from ..streams.memory import (
@@ -14,7 +14,7 @@ T_Item = TypeVar("T_Item")
 
 
 class create_memory_object_stream(
-    Tuple[MemoryObjectSendStream[T_Item], MemoryObjectReceiveStream[T_Item]],
+    tuple[MemoryObjectSendStream[T_Item], MemoryObjectReceiveStream[T_Item]],
 ):
     """
     Create a memory object stream.

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import math
 import sys
 from abc import ABCMeta, abstractmethod
-from collections.abc import AsyncIterator, Awaitable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from contextlib import AbstractContextManager
 from os import PathLike
 from signal import Signals
 from socket import AddressFamily, SocketKind, socket
@@ -11,9 +12,6 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Any,
-    Callable,
-    ContextManager,
-    Sequence,
     TypeVar,
     overload,
 )
@@ -366,7 +364,7 @@ class AsyncBackend(metaclass=ABCMeta):
     @abstractmethod
     def open_signal_receiver(
         cls, *signals: Signals
-    ) -> ContextManager[AsyncIterator[Signals]]:
+    ) -> AbstractContextManager[AsyncIterator[Signals]]:
         pass
 
     @classmethod

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -8,7 +8,7 @@ from io import IOBase
 from ipaddress import IPv4Address, IPv6Address
 from socket import AddressFamily
 from types import TracebackType
-from typing import Any, Tuple, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from .._core._typedattr import (
     TypedAttributeProvider,
@@ -19,10 +19,10 @@ from ._streams import ByteStream, Listener, UnreliableObjectStream
 from ._tasks import TaskGroup
 
 IPAddressType = Union[str, IPv4Address, IPv6Address]
-IPSockAddrType = Tuple[str, int]
+IPSockAddrType = tuple[str, int]
 SockAddrType = Union[IPSockAddrType, str]
-UDPPacketType = Tuple[bytes, IPSockAddrType]
-UNIXDatagramPacketType = Tuple[bytes, str]
+UDPPacketType = tuple[bytes, IPSockAddrType]
+UNIXDatagramPacketType = tuple[bytes, str]
 T_Retval = TypeVar("T_Retval")
 
 

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -2,18 +2,19 @@ from __future__ import annotations
 
 import sys
 import threading
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable, Generator, Iterable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
-from contextlib import AbstractContextManager, contextmanager
+from contextlib import (
+    AbstractAsyncContextManager,
+    AbstractContextManager,
+    contextmanager,
+)
 from dataclasses import dataclass, field
 from inspect import isawaitable
 from types import TracebackType
 from typing import (
     Any,
-    AsyncContextManager,
-    ContextManager,
     Generic,
-    Iterable,
     TypeVar,
     cast,
     overload,
@@ -88,7 +89,9 @@ class _BlockingAsyncContextManager(Generic[T_co], AbstractContextManager):
         type[BaseException] | None, BaseException | None, TracebackType | None
     ] = (None, None, None)
 
-    def __init__(self, async_cm: AsyncContextManager[T_co], portal: BlockingPortal):
+    def __init__(
+        self, async_cm: AbstractAsyncContextManager[T_co], portal: BlockingPortal
+    ):
         self._async_cm = async_cm
         self._portal = portal
 
@@ -375,8 +378,8 @@ class BlockingPortal:
         return f, task_status_future.result()
 
     def wrap_async_context_manager(
-        self, cm: AsyncContextManager[T_co]
-    ) -> ContextManager[T_co]:
+        self, cm: AbstractAsyncContextManager[T_co]
+    ) -> AbstractContextManager[T_co]:
         """
         Wrap an async context manager as a synchronous context manager via this portal.
 

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from inspect import isasyncgenfunction, iscoroutinefunction
-from typing import Any, Dict, Tuple, cast
+from typing import Any, cast
 
 import pytest
 import sniffio
@@ -21,7 +21,7 @@ def extract_backend_and_options(backend: object) -> tuple[str, dict[str, Any]]:
         return backend, {}
     elif isinstance(backend, tuple) and len(backend) == 2:
         if isinstance(backend[0], str) and isinstance(backend[1], dict):
-            return cast(Tuple[str, Dict[str, Any]], backend)
+            return cast(tuple[str, dict[str, Any]], backend)
 
     raise TypeError("anyio_backend must be either a string or tuple of (string, dict)")
 

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -7,7 +7,7 @@ import sys
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Tuple, TypeVar
+from typing import Any, TypeVar
 
 from .. import (
     BrokenResourceError,
@@ -25,8 +25,8 @@ else:
 
 T_Retval = TypeVar("T_Retval")
 PosArgsT = TypeVarTuple("PosArgsT")
-_PCTRTT = Tuple[Tuple[str, str], ...]
-_PCTRTTT = Tuple[_PCTRTT, ...]
+_PCTRTT = tuple[tuple[str, str], ...]
+_PCTRTTT = tuple[_PCTRTT, ...]
 
 
 class TLSAttribute(TypedAttributeSet):

--- a/tests/streams/test_stapled.py
+++ b/tests/streams/test_stapled.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Iterable
 from dataclasses import InitVar, dataclass, field
-from typing import Iterable, TypeVar
+from typing import TypeVar
 
 import pytest
 

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import socket
 import ssl
-from contextlib import ExitStack
+from contextlib import AbstractContextManager, ExitStack
 from threading import Thread
-from typing import ContextManager, NoReturn
+from typing import NoReturn
 
 import pytest
 from pytest_mock import MockerFixture
@@ -210,7 +210,7 @@ class TestTLSStream:
             finally:
                 conn.close()
 
-        client_cm: ContextManager = ExitStack()
+        client_cm: AbstractContextManager = ExitStack()
         if client_compatible and not server_compatible:
             client_cm = pytest.raises(BrokenResourceError)
 

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -4,12 +4,12 @@ import math
 import sys
 import threading
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from concurrent import futures
 from concurrent.futures import CancelledError, Future
 from contextlib import asynccontextmanager, suppress
 from contextvars import ContextVar
-from typing import Any, AsyncGenerator, Literal, NoReturn, TypeVar
+from typing import Any, Literal, NoReturn, TypeVar
 
 import pytest
 import sniffio

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import signal
 import sys
-from typing import AsyncIterable
+from collections.abc import AsyncIterable
 
 import pytest
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -10,12 +10,13 @@ import sys
 import tempfile
 import threading
 import time
+from collections.abc import Generator, Iterable, Iterator
 from contextlib import suppress
 from pathlib import Path
 from socket import AddressFamily
 from ssl import SSLContext, SSLError
 from threading import Thread
-from typing import Any, Generator, Iterable, Iterator, NoReturn, TypeVar, cast
+from typing import Any, NoReturn, TypeVar, cast
 
 import psutil
 import pytest
@@ -1124,9 +1125,10 @@ class TestUNIXListener:
             async with stream:
                 await stream.send(b"Hello\n")
 
-        async with await create_unix_listener(
-            socket_path
-        ) as listener, create_task_group() as tg:
+        async with (
+            await create_unix_listener(socket_path) as listener,
+            create_task_group() as tg,
+        ):
             tg.start_soon(listener.serve, handle)
             await wait_all_tasks_blocked()
 

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -277,9 +277,9 @@ async def test_py39_arguments(
             [sys.executable, "-c", "print('hello')"],
             **{argname: argvalue_factory()},
         )
-    except TypeError as exc:
+    except ValueError as exc:
         if (
-            "unexpected keyword argument" in str(exc)
+            "unexpected kwargs" in str(exc)
             and anyio_backend_name == "asyncio"
             and anyio_backend_options["loop_factory"]
             and anyio_backend_options["loop_factory"].__module__ == "uvloop"

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -126,9 +126,11 @@ async def test_run_process_connect_to_file(tmp_path: Path) -> None:
     stdinfile.write_text("Hello, process!\n")
     stdoutfile = tmp_path / "stdout"
     stderrfile = tmp_path / "stderr"
-    with stdinfile.open("rb") as fin, stdoutfile.open("wb") as fout, stderrfile.open(
-        "wb"
-    ) as ferr:
+    with (
+        stdinfile.open("rb") as fin,
+        stdoutfile.open("wb") as fout,
+        stderrfile.open("wb") as ferr,
+    ):
         async with await open_process(
             [
                 sys.executable,

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -9,6 +9,7 @@ from typing import Any, NoReturn, cast
 
 import pytest
 from exceptiongroup import catch
+from pytest_mock import MockerFixture
 
 import anyio
 from anyio import (
@@ -255,6 +256,27 @@ async def test_propagate_native_cancellation_from_taskgroup() -> None:
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_cancel_with_nested_shielded_scope(mocker: MockerFixture) -> None:
+    """Regression test for #695."""
+
+    async def shield_task() -> None:
+        with CancelScope(shield=True):
+            await sleep(0.5)
+
+    async def middle_task() -> None:
+        async with create_task_group() as tg:
+            tg.start_soon(shield_task, name="shield task")
+
+    async with create_task_group() as tg:
+        spy = mocker.spy(tg.cancel_scope, "_deliver_cancellation")
+        tg.start_soon(middle_task, name="middle task")
+        await wait_all_tasks_blocked()
+        tg.cancel_scope.cancel()
+
+    assert len(spy.call_args_list) < 3
 
 
 async def test_start_exception_delivery(anyio_backend_name: str) -> None:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -720,6 +720,26 @@ async def test_cancelled_not_caught() -> None:
     assert not scope.cancelled_caught
 
 
+@pytest.mark.parametrize("shield_inner", [False, True])
+async def test_cancelled_raises_beyond_origin(shield_inner: bool) -> None:
+    """Regression test for #698."""
+    with CancelScope() as outer_scope:
+        with CancelScope(shield=shield_inner) as inner_scope:
+            inner_scope.cancel()
+            try:
+                await checkpoint()
+            finally:
+                outer_scope.cancel()
+
+            pytest.fail("checkpoint should have raised")
+
+        if not shield_inner:
+            pytest.fail("inner_scope should not have caught cancelled")
+
+    assert inner_scope.cancelled_caught == shield_inner
+    assert outer_scope.cancelled_caught != shield_inner
+
+
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_cancel_host_asyncgen() -> None:
     done = False

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -684,7 +684,7 @@ async def test_cancelled_scope_based_checkpoint() -> None:
     with CancelScope() as outer_scope:
         outer_scope.cancel()
 
-        # The following two lines are a way to implement a checkpoint function.
+        # The following three lines are a way to implement a checkpoint function.
         # See also https://github.com/python-trio/trio/issues/860.
         with CancelScope() as inner_scope:
             inner_scope.cancel()

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1474,6 +1474,18 @@ class TestUncancel:
         assert task.cancelling() == 2
         assert str(exc.value) == "native 2"
 
+    async def test_uncancel_after_child_task_failed(self) -> None:
+        async def taskfunc() -> None:
+            raise Exception("dummy error")
+
+        with pytest.raises(ExceptionGroup) as exc_info:
+            async with create_task_group() as tg:
+                tg.start_soon(taskfunc)
+
+        assert len(exc_info.value.exceptions) == 1
+        assert str(exc_info.value.exceptions[0]) == "dummy error"
+        assert not cast(asyncio.Task, asyncio.current_task()).cancelling()
+
 
 async def test_cancel_before_entering_task_group() -> None:
     with CancelScope() as scope:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -797,12 +797,15 @@ async def test_exception_cancels_siblings() -> None:
 async def test_cancel_cascade() -> None:
     async def do_something() -> NoReturn:
         async with create_task_group() as tg2:
-            tg2.start_soon(sleep, 1)
+            print(f"tg2 ({id(tg2):x}) cancel scope: {id(tg2.cancel_scope):x}\n")
+            tg2.start_soon(sleep, 1, name="sleep")
 
+        print("exited task group tg2")
         raise Exception("foo")
 
     async with create_task_group() as tg:
-        tg.start_soon(do_something)
+        print(f"tg ({id(tg):x}) cancel scope: {id(tg.cancel_scope):x}")
+        tg.start_soon(do_something, name="do_something")
         await wait_all_tasks_blocked()
         tg.cancel_scope.cancel()
 

--- a/tests/test_typedattr.py
+++ b/tests/test_typedattr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping
+from collections.abc import Mapping
+from typing import Any, Callable
 
 import pytest
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This fixes both cancel scope exit behavior on asyncio where an outer cancel scope has been cancelled, and constant unfruitful cancellation attempts of a task that is waiting on `TaskGroup__aexit__()`.

Fixes #695. <!-- Provide issue number if exists -->
Fixes #698.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
