### PR TITLE
Convert bytearray to bytes in `StreamProtocol.receive()`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -20,6 +20,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#696 <https://github.com/agronholm/anyio/issues/696>`_)
 - Fixed ``TaskInfo.has_pending_cancellation()`` on asyncio not respecting shielded
   scopes (`#771 <https://github.com/agronholm/anyio/issues/771>`_; PR by @gschaffner)
+- Fixed ``SocketStream.receive()`` returning ``bytearray`` instead of ``bytes`` when
+  using asyncio with ``ProactorEventLoop`` (Windows)
+  (`#776 <https://github.com/agronholm/anyio/issues/776>`_)
 
 **4.4.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1065,10 +1065,7 @@ class StreamProtocol(asyncio.Protocol):
 
     def data_received(self, data: bytes) -> None:
         # ProactorEventloop sometimes sends bytearray instead of bytes
-        if type(data) is bytearray:
-            data = bytes(data)
-
-        self.read_queue.append(data)
+        self.read_queue.append(bytes(data))
         self.read_event.set()
 
     def eof_received(self) -> bool | None:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1073,6 +1073,10 @@ class StreamProtocol(asyncio.Protocol):
         self.write_event.set()
 
     def data_received(self, data: bytes) -> None:
+        # ProactorEventloop sometimes sends bytearray instead of bytes
+        if type(data) is bytearray:
+            data = bytes(data)
+
         self.read_queue.append(data)
         self.read_event.set()
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -202,7 +202,9 @@ class TestTCPStream:
             thread.start()
             response = b""
             while len(response) < len(buffer):
-                response += await stream.receive()
+                chunk = await stream.receive()
+                assert isinstance(chunk, bytes)
+                response += chunk
 
         thread.join()
         assert response == buffer


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Checks if `Protocol.data_received()` was passed a `bytearray` instead of `bytes`, and converts it accordingly.

Fixes #776. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
