### PR TITLE
Fixed debugger quit not working when inside a task group

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -20,6 +20,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#696 <https://github.com/agronholm/anyio/issues/696>`_)
 - Fixed ``TaskInfo.has_pending_cancellation()`` on asyncio not respecting shielded
   scopes (`#771 <https://github.com/agronholm/anyio/issues/771>`_; PR by @gschaffner)
+- Fixed quitting the debugger in a pytest test session while in an active task group
+  failing the test instead of exiting the test session (because the exit exception
+  arrives in an exception group)
 
 **4.4.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -19,7 +19,7 @@ from asyncio import (
 )
 from asyncio.base_events import _run_until_complete_cb  # type: ignore[attr-defined]
 from collections import OrderedDict, deque
-from collections.abc import AsyncIterator, Generator, Iterable
+from collections.abc import AsyncIterator, Iterable
 from concurrent.futures import Future
 from contextlib import suppress
 from contextvars import Context, copy_context
@@ -66,6 +66,7 @@ from .._core._exceptions import (
     ClosedResourceError,
     EndOfStream,
     WouldBlock,
+    iterate_exceptions,
 )
 from .._core._sockets import convert_ipv6_sockaddr
 from .._core._streams import create_memory_object_stream
@@ -628,16 +629,6 @@ class _AsyncioTaskStatus(abc.TaskStatus):
 
         task = cast(asyncio.Task, current_task())
         _task_states[task].parent_id = self._parent_id
-
-
-def iterate_exceptions(
-    exception: BaseException,
-) -> Generator[BaseException, None, None]:
-    if isinstance(exception, BaseExceptionGroup):
-        for exc in exception.exceptions:
-            yield from iterate_exceptions(exc)
-    else:
-        yield exception
 
 
 class TaskGroup(abc.TaskGroup):

--- a/src/anyio/_core/_exceptions.py
+++ b/src/anyio/_core/_exceptions.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Generator
 
-from exceptiongroup import BaseExceptionGroup
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
 
 
 class BrokenResourceError(Exception):

--- a/src/anyio/_core/_exceptions.py
+++ b/src/anyio/_core/_exceptions.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Generator
+
+from exceptiongroup import BaseExceptionGroup
+
 
 class BrokenResourceError(Exception):
     """
@@ -71,3 +75,13 @@ class TypedAttributeLookupError(LookupError):
 
 class WouldBlock(Exception):
     """Raised by ``X_nowait`` functions if ``X()`` would block."""
+
+
+def iterate_exceptions(
+    exception: BaseException,
+) -> Generator[BaseException, None, None]:
+    if isinstance(exception, BaseExceptionGroup):
+        for exc in exception.exceptions:
+            yield from iterate_exceptions(exc)
+    else:
+        yield exception

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from inspect import isasyncgenfunction, iscoroutinefunction
@@ -8,11 +9,13 @@ from typing import Any, Dict, Tuple, cast
 import pytest
 import sniffio
 from _pytest.outcomes import Exit
-from exceptiongroup import ExceptionGroup
 
 from ._core._eventloop import get_all_backends, get_async_backend
 from ._core._exceptions import iterate_exceptions
 from .abc import TestRunner
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import ExceptionGroup
 
 _current_runner: TestRunner | None = None
 _runner_stack: ExitStack | None = None

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -420,13 +420,16 @@ def test_hypothesis_function_mark(testdir: Pytester) -> None:
     )
 
 
-def test_debugger_exit_in_taskgroup(testdir: Pytester) -> None:
+@pytest.mark.parametrize("anyio_backend", get_all_backends(), indirect=True)
+def test_debugger_exit_in_taskgroup(testdir: Pytester, anyio_backend_name: str) -> None:
     testdir.makepyfile(
-        """
+        f"""
         import pytest
         from _pytest.outcomes import Exit
         from anyio import create_task_group
 
+        def anyio_backend():
+            return {anyio_backend_name!r}
 
         @pytest.mark.anyio
         async def test_anyio_mark_first():

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -428,6 +428,7 @@ def test_debugger_exit_in_taskgroup(testdir: Pytester, anyio_backend_name: str) 
         from _pytest.outcomes import Exit
         from anyio import create_task_group
 
+        @pytest.fixture
         def anyio_backend():
             return {anyio_backend_name!r}
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -418,3 +418,22 @@ def test_hypothesis_function_mark(testdir: Pytester) -> None:
     result.assert_outcomes(
         passed=2 * len(get_all_backends()), xfailed=2 * len(get_all_backends())
     )
+
+
+def test_debugger_exit_in_taskgroup(testdir: Pytester) -> None:
+    testdir.makepyfile(
+        """
+        import pytest
+        from _pytest.outcomes import Exit
+        from anyio import create_task_group
+
+
+        @pytest.mark.anyio
+        async def test_anyio_mark_first():
+            async with create_task_group() as tg:
+                raise Exit('Quitting debugger')
+        """
+    )
+
+    result = testdir.runpytest(*pytest_args)
+    result.assert_outcomes()

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -433,7 +433,7 @@ def test_debugger_exit_in_taskgroup(testdir: Pytester, anyio_backend_name: str) 
             return {anyio_backend_name!r}
 
         @pytest.mark.anyio
-        async def test_anyio_mark_first():
+        async def test_debugger_exit():
             async with create_task_group() as tg:
                 raise Exit('Quitting debugger')
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

If you set a breakpoint inside a task group, quitting the debugger won't exit the pytest test session, but instead fails the current test. These changes find the exit exception in an exception group, and raise just that, ignoring the rest of the exceptions (if any).

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
