### PR TITLE
Fixed KeyboardInterrupt hanging the asyncio test runner

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -20,6 +20,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#696 <https://github.com/agronholm/anyio/issues/696>`_)
 - Fixed ``TaskInfo.has_pending_cancellation()`` on asyncio not respecting shielded
   scopes (`#771 <https://github.com/agronholm/anyio/issues/771>`_; PR by @gschaffner)
+- Fixed ``KeyboardInterrupt`` (ctrl+c) hanging the asyncio pytest runner
 
 **4.4.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2088,9 +2088,9 @@ class TestRunner(abc.TestRunner):
             async for coro, future in receive_stream:
                 try:
                     retval = await coro
-                except CancelledError:
+                except CancelledError as exc:
                     if not future.cancelled():
-                        future.cancel()
+                        future.cancel(*exc.args)
 
                     raise
                 except BaseException as exc:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2082,6 +2082,8 @@ class TestRunner(abc.TestRunner):
             tuple[Awaitable[T_Retval], asyncio.Future[T_Retval]]
         ],
     ) -> None:
+        from _pytest.outcomes import OutcomeException
+
         with receive_stream, self._send_stream:
             async for coro, future in receive_stream:
                 try:
@@ -2095,7 +2097,8 @@ class TestRunner(abc.TestRunner):
                     if not future.cancelled():
                         future.set_exception(exc)
 
-                    raise
+                    if not isinstance(exc, (Exception, OutcomeException)):
+                        raise
                 else:
                     if not future.cancelled():
                         future.set_result(retval)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1932,9 +1932,16 @@ class TestRunner(abc.TestRunner):
             async for coro, future in receive_stream:
                 try:
                     retval = await coro
+                except CancelledError:
+                    if not future.cancelled():
+                        future.cancel()
+
+                    raise
                 except BaseException as exc:
                     if not future.cancelled():
                         future.set_exception(exc)
+
+                    raise
                 else:
                     if not future.cancelled():
                         future.set_result(retval)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -418,3 +418,30 @@ def test_hypothesis_function_mark(testdir: Pytester) -> None:
     result.assert_outcomes(
         passed=2 * len(get_all_backends()), xfailed=2 * len(get_all_backends())
     )
+
+
+@pytest.mark.parametrize("anyio_backend", get_all_backends(), indirect=True)
+def test_keyboardinterrupt_during_test(
+    testdir: Pytester, anyio_backend_name: str
+) -> None:
+    testdir.makepyfile(
+        f"""
+        import pytest
+        from anyio import create_task_group, sleep
+
+        @pytest.fixture
+        def anyio_backend():
+            return {anyio_backend_name!r}
+
+        async def send_keyboardinterrupt():
+            raise KeyboardInterrupt
+
+        @pytest.mark.anyio
+        async def test_anyio_mark_first():
+            async with create_task_group() as tg:
+                tg.start_soon(send_keyboardinterrupt)
+                await sleep(10)
+        """
+    )
+
+    testdir.runpytest_subprocess(*pytest_args, timeout=3)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This fixes ctrl+c causing the anyio pytest plugin to hang if the test is currently awaiting something. This was caused by the test runner dropping exceptions on the floor.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
