### PR TITLE
Accept abstract namespace paths for unix domain sockets

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -37,6 +37,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed quitting the debugger in a pytest test session while in an active task group
   failing the test instead of exiting the test session (because the exit exception
   arrives in an exception group)
+- Re-add support for linux abstract namespace sockets (#781
+  <https://github.com/agronholm/anyio/issues/781>_; PR by @tapetersen)
 
 **4.4.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -37,8 +37,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed quitting the debugger in a pytest test session while in an active task group
   failing the test instead of exiting the test session (because the exit exception
   arrives in an exception group)
-- Re-add support for linux abstract namespace sockets (#781
-  <https://github.com/agronholm/anyio/issues/781>_; PR by @tapetersen)
+- Fixed support for Linux abstract namespaces in UNIX sockets that was broken in v4.2
+  (#781 <https://github.com/agronholm/anyio/issues/781>_; PR by @tapetersen)
 
 **4.4.0**
 

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -680,19 +680,12 @@ async def setup_unix_local_socket(
     :param socktype: socket.SOCK_STREAM or socket.SOCK_DGRAM
 
     """
-    path_str: str | bytes | None
+    path_str: str | None
     if path is not None:
-        path_str = os.fspath(path)
-        is_abstract = (
-            path_str.startswith(b"\0")
-            if isinstance(path_str, bytes)
-            else path_str.startswith("\0")
-        )
+        path_str = os.fsdecode(path)
 
-        if is_abstract:
-            # Unix abstract namespace socket. No file backing so skip stat call
-            pass
-        else:
+        # Linux abstract namespace sockets aren't backed by a concrete file so skip stat call
+        if not path_str.startswith("\0"):
             # Copied from pathlib...
             try:
                 stat_result = os.stat(path)


### PR DESCRIPTION
## Changes

Accept paths starting with a null byte in create_unix_listener and connect_unix_socket to allow creating abstract unix sockets. Fixes #781

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
