### PR TITLE
Fix `asyncio.Task.cancelling` issues

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -18,6 +18,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed the return type annotations of ``readinto()`` and ``readinto1()`` methods in the
   ``anyio.AsyncFile`` class
   (`#825 <https://github.com/agronholm/anyio/issues/825>`_)
+- Fixed ``TaskInfo.has_pending_cancellation()`` on asyncio returning false positives in
+  cleanup code on Python >= 3.11
+  (`#832 <https://github.com/agronholm/anyio/issues/832>`_; PR by @gschaffner)
 
 **4.6.2**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -21,6 +21,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``TaskInfo.has_pending_cancellation()`` on asyncio returning false positives in
   cleanup code on Python >= 3.11
   (`#832 <https://github.com/agronholm/anyio/issues/832>`_; PR by @gschaffner)
+- Fixed cancelled cancel scopes on asyncio calling ``asyncio.Task.uncancel`` when
+  propagating a ``CancelledError`` on exit to a cancelled parent scope
+  (`#790 <https://github.com/agronholm/anyio/pull/790>`_; PR by @gschaffner)
 
 **4.6.2**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -377,7 +377,7 @@ def is_anyio_cancellation(exc: CancelledError) -> bool:
     # matching cancel message
     while True:
         if (
-            bool(exc.args)
+            exc.args
             and isinstance(exc.args[0], str)
             and exc.args[0].startswith("Cancelled by cancel scope ")
         ):

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -408,9 +408,8 @@ class CancelScope(BaseCancelScope):
         self._cancel_handle: asyncio.Handle | None = None
         self._tasks: set[asyncio.Task] = set()
         self._host_task: asyncio.Task | None = None
-        self._pending_uncancellations: int | None
         if sys.version_info >= (3, 11):
-            self._pending_uncancellations = 0
+            self._pending_uncancellations: int | None = 0
         else:
             self._pending_uncancellations = None
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2154,12 +2154,11 @@ class AsyncIOTaskInfo(TaskInfo):
             # If the task isn't around anymore, it won't have a pending cancellation
             return False
 
-        if sys.version_info >= (3, 11):
-            if task.cancelling():
-                return True
+        if task._must_cancel:  # type: ignore[attr-defined]
+            return True
         elif (
-            isinstance(task._fut_waiter, asyncio.Future)
-            and task._fut_waiter.cancelled()
+            isinstance(task._fut_waiter, asyncio.Future)  # type: ignore[attr-defined]
+            and task._fut_waiter.cancelled()  # type: ignore[attr-defined]
         ):
             return True
 


### PR DESCRIPTION
## Changes

This is a small patch that fixes the more obscure case that we skipped yesterday (https://github.com/agronholm/anyio/pull/774#discussion_r1766604109).

After a night's rest I woke up this morning with the realization that this case shouldn't involve whack-a-mole as we feared. IIUC it seems to be relatively straightforward to fix.

d342ae144083993f671bfe702af3ec6f25449ea6 is the core patch here in its simplest form. The subsequent two commits are some minor follow-up refactoring for performance optimization:

*   Avoid doing repeated computations of `_effectively_cancelled` & `_parent_cancellation_is_visible_to_us` in `CancelScope.__exit__` (I missed this during review).

*   Move the counter back from `TaskState` to `CancelScope`. This makes the impl. a little harder to understand IMO (as this makes the impl. diverge a bit further from Trio's model of delaying deciding which scope a level cancellation exception belongs to), but it may(?) save a little memory (as the counter is only needed for host tasks).

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).