### PR TITLE
Fixed missing or inconsistent error when acquiring already owned Lock

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,11 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed acquring a lock twice in the same task on asyncio hanging instead of raising a
+  ``RuntimeError`` (`#798 <https://github.com/agronholm/anyio/issues/798>`_)
+
 **4.6.0**
 
 - Dropped support for Python 3.8

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1731,9 +1731,10 @@ class Lock(BaseLock):
         self._waiters: deque[tuple[asyncio.Task, asyncio.Future]] = deque()
 
     async def acquire(self) -> None:
+        task = cast(asyncio.Task, current_task())
         if self._owner_task is None and not self._waiters:
             await AsyncIOBackend.checkpoint_if_cancelled()
-            self._owner_task = current_task()
+            self._owner_task = task
 
             # Unless on the "fast path", yield control of the event loop so that other
             # tasks can run too
@@ -1746,7 +1747,9 @@ class Lock(BaseLock):
 
             return
 
-        task = cast(asyncio.Task, current_task())
+        if self._owner_task == task:
+            raise RuntimeError("Attempted to acquire an already held Lock")
+
         fut: asyncio.Future[None] = asyncio.Future()
         item = task, fut
         self._waiters.append(item)
@@ -1762,9 +1765,13 @@ class Lock(BaseLock):
         self._waiters.remove(item)
 
     def acquire_nowait(self) -> None:
+        task = cast(asyncio.Task, current_task())
         if self._owner_task is None and not self._waiters:
-            self._owner_task = current_task()
+            self._owner_task = task
             return
+
+        if self._owner_task == task:
+            raise RuntimeError("Attempted to acquire an already held Lock")
 
         raise WouldBlock
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1770,7 +1770,7 @@ class Lock(BaseLock):
             self._owner_task = task
             return
 
-        if self._owner_task == task:
+        if self._owner_task is task:
             raise RuntimeError("Attempted to acquire an already held Lock")
 
         raise WouldBlock

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -662,9 +662,19 @@ class Lock(BaseLock):
         self._fast_acquire = fast_acquire
         self.__original = trio.Lock()
 
+    @staticmethod
+    def _convert_runtime_error_msg(exc: RuntimeError) -> None:
+        if exc.args == ("attempt to re-acquire an already held Lock",):
+            exc.args = ("Attempted to acquire an already held Lock",)
+
     async def acquire(self) -> None:
         if not self._fast_acquire:
-            await self.__original.acquire()
+            try:
+                await self.__original.acquire()
+            except RuntimeError as exc:
+                self._convert_runtime_error_msg(exc)
+                raise
+
             return
 
         # This is the "fast path" where we don't let other tasks run
@@ -673,12 +683,18 @@ class Lock(BaseLock):
             self.__original.acquire_nowait()
         except trio.WouldBlock:
             await self.__original._lot.park()
+        except RuntimeError as exc:
+            self._convert_runtime_error_msg(exc)
+            raise
 
     def acquire_nowait(self) -> None:
         try:
             self.__original.acquire_nowait()
         except trio.WouldBlock:
             raise WouldBlock from None
+        except RuntimeError as exc:
+            self._convert_runtime_error_msg(exc)
+            raise
 
     def locked(self) -> bool:
         return self.__original.locked()

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -96,6 +96,23 @@ class TestLock:
             assert lock.locked()
             tg.start_soon(try_lock)
 
+    @pytest.mark.parametrize("fast_acquire", [True, False])
+    async def test_acquire_twice_async(self, fast_acquire: bool) -> None:
+        lock = Lock(fast_acquire=fast_acquire)
+        await lock.acquire()
+        with pytest.raises(
+            RuntimeError, match="Attempted to acquire an already held Lock"
+        ):
+            await lock.acquire()
+
+    async def test_acquire_twice_sync(self) -> None:
+        lock = Lock()
+        lock.acquire_nowait()
+        with pytest.raises(
+            RuntimeError, match="Attempted to acquire an already held Lock"
+        ):
+            lock.acquire_nowait()
+
     @pytest.mark.parametrize(
         "release_first",
         [pytest.param(False, id="releaselast"), pytest.param(True, id="releasefirst")],


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Reintroduces a check to see if the lock is already owned by this task, on asyncio. On Trio, harmonize the `RuntimeError` message to match that on asyncio.

Fixes #798. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
