### PR TITLE
Updated Path documentation and made is_junction() conditional

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,12 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Corrected documentation on ``anyio.Path`` regarding the limitations imposed by the
+  current Python version on several of its methods, and made the ``is_junction`` method
+  unavailable on Python versions earlier than 3.12
+
 **4.6.0**
 
 - Dropped support for Python 3.8

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -222,6 +222,7 @@ class Path:
 
     * :meth:`~pathlib.Path.from_uri` (available on Python 3.13 or later)
     * :meth:`~pathlib.Path.full_match` (available on Python 3.13 or later)
+    * :meth:`~pathlib.Path.is_junction` (available on Python 3.12 or later)
     * :meth:`~pathlib.Path.match` (the ``case_sensitive`` paramater is only available on
       Python 3.13 or later)
     * :meth:`~pathlib.Path.relative_to` (the ``walk_up`` parameter is only available on

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -217,6 +217,17 @@ class Path:
     It implements the Python 3.10 version of :class:`pathlib.Path` interface, except for
     the deprecated :meth:`~pathlib.Path.link_to` method.
 
+    Some methods may be unavailable or have limited functionality, based on the Python
+    version:
+
+    * :meth:`~pathlib.Path.from_uri` (available on Python 3.13 or later)
+    * :meth:`~pathlib.Path.full_match` (available on Python 3.13 or later)
+    * :meth:`~pathlib.Path.match` (the ``case_sensitive`` paramater is only available on
+      Python 3.13 or later)
+    * :meth:`~pathlib.Path.relative_to` (the ``walk_up`` parameter is only available on
+      Python 3.12 or later)
+    * :meth:`~pathlib.Path.walk` (available on Python 3.12 or later)
+
     Any methods that do disk I/O need to be awaited on. These methods are:
 
     * :meth:`~pathlib.Path.absolute`
@@ -232,7 +243,10 @@ class Path:
     * :meth:`~pathlib.Path.is_dir`
     * :meth:`~pathlib.Path.is_fifo`
     * :meth:`~pathlib.Path.is_file`
+    * :meth:`~pathlib.Path.is_junction`
     * :meth:`~pathlib.Path.is_mount`
+    * :meth:`~pathlib.Path.is_socket`
+    * :meth:`~pathlib.Path.is_symlink`
     * :meth:`~pathlib.Path.lchmod`
     * :meth:`~pathlib.Path.lstat`
     * :meth:`~pathlib.Path.mkdir`
@@ -243,11 +257,14 @@ class Path:
     * :meth:`~pathlib.Path.readlink`
     * :meth:`~pathlib.Path.rename`
     * :meth:`~pathlib.Path.replace`
+    * :meth:`~pathlib.Path.resolve`
     * :meth:`~pathlib.Path.rmdir`
     * :meth:`~pathlib.Path.samefile`
     * :meth:`~pathlib.Path.stat`
+    * :meth:`~pathlib.Path.symlink_to`
     * :meth:`~pathlib.Path.touch`
     * :meth:`~pathlib.Path.unlink`
+    * :meth:`~pathlib.Path.walk`
     * :meth:`~pathlib.Path.write_bytes`
     * :meth:`~pathlib.Path.write_text`
 
@@ -385,9 +402,6 @@ class Path:
         except ValueError:
             return False
 
-    async def is_junction(self) -> bool:
-        return await to_thread.run_sync(self._path.is_junction)
-
     async def chmod(self, mode: int, *, follow_symlinks: bool = True) -> None:
         func = partial(os.chmod, follow_symlinks=follow_symlinks)
         return await to_thread.run_sync(func, self._path, mode)
@@ -446,6 +460,11 @@ class Path:
 
     async def is_file(self) -> bool:
         return await to_thread.run_sync(self._path.is_file, abandon_on_cancel=True)
+
+    if sys.version_info >= (3, 12):
+
+        async def is_junction(self) -> bool:
+            return await to_thread.run_sync(self._path.is_junction)
 
     async def is_mount(self) -> bool:
         return await to_thread.run_sync(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Updated the `anyio.Path` docs to fix several omissions, and to mention limitations on earlier Python versions.
Also, the `is_junction()` method is now hidden unless on Python 3.12 or later, to match its stdlib counterpart (as it wouldn't work anyway).

Fixes #794. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [X] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
