### PR TITLE
Fixed TypeError when TLS handshake fails with truststore SSLContext

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Fixed acquring a lock twice in the same task on asyncio hanging instead of raising a
   ``RuntimeError`` (`#798 <https://github.com/agronholm/anyio/issues/798>`_)
+- Fixed ``TypeError`` with ``TLSStream`` on Windows when a certificate verification
+  error occurs when using a `truststore <https://github.com/sethmlarson/truststore>`_
+  SSL certificate (`#795 <https://github.com/agronholm/anyio/issues/795>`_)
 
 **4.6.0**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ test = [
     "pytest >= 7.0",
     "pytest-mock >= 3.6.1",
     "trustme",
+    "truststore >= 0.9.1; python_version >= '3.10'",
     """\
     uvloop >= 0.21.0b1; platform_python_implementation == 'CPython' \
     and platform_system != 'Windows'\

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -162,9 +162,8 @@ class TLSStream(ByteStream):
             except ssl.SSLError as exc:
                 self._read_bio.write_eof()
                 self._write_bio.write_eof()
-                if (
-                    isinstance(exc, ssl.SSLEOFError)
-                    or "UNEXPECTED_EOF_WHILE_READING" in exc.strerror
+                if isinstance(exc, ssl.SSLEOFError) or (
+                    exc.strerror and "UNEXPECTED_EOF_WHILE_READING" in exc.strerror
                 ):
                     if self.standard_compatible:
                         raise BrokenResourceError from exc

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -388,6 +388,33 @@ class TestTLSStream:
         send1.close()
         receive1.close()
 
+    async def test_truststore_ssl(
+        self, request: pytest.FixtureRequest, server_context: ssl.SSLContext
+    ) -> None:
+        def serve_sync() -> None:
+            with server_sock, pytest.raises(ssl.SSLEOFError):
+                server_sock.accept()
+
+        # We deliberately skip making the client context trust the server context
+        truststore = pytest.importorskip("truststore")
+        client_context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+        server_sock = server_context.wrap_socket(
+            socket.socket(), server_side=True, suppress_ragged_eofs=True
+        )
+        server_sock.settimeout(1)
+        server_sock.bind(("127.0.0.1", 0))
+        server_sock.listen()
+        server_thread = Thread(target=serve_sync, daemon=True)
+        server_thread.start()
+        request.addfinalizer(server_thread.join)
+
+        async with await connect_tcp(*server_sock.getsockname()) as stream:
+            with pytest.raises(ssl.SSLCertVerificationError):
+                await TLSStream.wrap(
+                    stream, hostname="localhost", ssl_context=client_context
+                )
+
 
 class TestTLSListener:
     async def test_handshake_fail(

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -391,6 +391,7 @@ class TestTLSStream:
     async def test_truststore_ssl(
         self, request: pytest.FixtureRequest, server_context: ssl.SSLContext
     ) -> None:
+        # This test is only expected to fail on Windows without the associated patch
         def serve_sync() -> None:
             with server_sock, pytest.raises(ssl.SSLEOFError):
                 server_sock.accept()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixed TypeError when TLS handshake fails with truststore `SSLContext`.
We shouldn't assume that `SSLError.strerror` is always a string.

Fixes #795. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
