### PR TITLE
gh-633: fix fixture methods run with different self than the test method

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -2,6 +2,10 @@ Version history
 ===============
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
+**UNRELEASED**
+
+- Fixed fixture methods run with different self than the test method
+  (`#633 <https://github.com/agronholm/anyio/issues/633>`_)
 
 **4.6.0**
 

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -125,12 +125,12 @@ def pytest_fixture_setup(fixturedef: Any, request: Any) -> Generator[Any, None, 
                 has_backend_arg = "anyio_backend" in fixturedef.argnames
                 original_func = fixturedef.func
                 fixturedef.func = wrapper
-                stack.callback(setattr, fixturedef, 'func', original_func)
+                stack.callback(setattr, fixturedef, "func", original_func)
 
                 if not has_backend_arg:
                     original_argnames = fixturedef.argnames
                     fixturedef.argnames = original_argnames + ("anyio_backend",)
-                    stack.callback(setattr, fixturedef, 'argnames', original_argnames)
+                    stack.callback(setattr, fixturedef, "argnames", original_argnames)
 
         return (yield)
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -468,3 +468,44 @@ def test_keyboardinterrupt_during_test(
     )
 
     testdir.runpytest_subprocess(*pytest_args, timeout=3)
+
+
+def test_bound_methods(testdir: Pytester) -> None:
+    testdir.makepyfile(
+        """
+        import pytest
+
+        class TestFoo:
+            @pytest.fixture(autouse=True)
+            async def fixt(self):
+                self.is_same_instance = 1
+
+            @pytest.mark.anyio
+            async def test_fixt(self):
+                assert self.is_same_instance == 1
+        """
+    )
+
+    result = testdir.runpytest(*pytest_args)
+    result.assert_outcomes(passed=2)
+
+
+def test_bound_async_gen_methods(testdir: Pytester) -> None:
+    testdir.makepyfile(
+        """
+        import pytest
+
+        class TestFoo:
+            @pytest.fixture(autouse=True)
+            async def fixt(self):
+                self.is_same_instance = 1
+                yield
+
+            @pytest.mark.anyio
+            async def test_fixt(self):
+                assert self.is_same_instance == 1
+        """
+    )
+
+    result = testdir.runpytest(*pytest_args)
+    result.assert_outcomes(passed=2)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -509,3 +509,27 @@ def test_bound_async_gen_methods(testdir: Pytester) -> None:
 
     result = testdir.runpytest(*pytest_args)
     result.assert_outcomes(passed=2)
+
+
+def test_anyio_fixture_adoption_does_not_persist(testdir: Pytester) -> None:
+    testdir.makepyfile(
+        """
+        import inspect
+        import pytest
+
+        @pytest.fixture
+        async def fixt():
+            return 1
+
+        @pytest.mark.anyio
+        async def test_fixt(fixt):
+            assert fixt == 1
+
+        def test_no_mark(fixt):
+            assert inspect.iscoroutine(fixt)
+            fixt.close()
+        """
+    )
+
+    result = testdir.runpytest(*pytest_args)
+    result.assert_outcomes(passed=3)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #633 . <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
