### PR TITLE
fix cyclic garbage that keeps traceback frames alive in taskgroup exceptions

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,6 +10,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed an async fixture's ``self`` being different than the test's ``self`` in
   class-based tests (`#633 <https://github.com/agronholm/anyio/issues/633>`_)
   (PR by @agronholm and @graingert)
+- Fixed TaskGroup and CancelScope producing cyclic references in tracebacks
+  when raising exceptions (`#806 <https://github.com/agronholm/anyio/pull/806>`_)
+  (PR by @graingert)
 
 **4.6.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -426,15 +426,16 @@ class CancelScope(BaseCancelScope):
         exc_tb: TracebackType | None,
     ) -> bool | None:
         del exc_tb
-        try:
-            if not self._active:
-                raise RuntimeError("This cancel scope is not active")
-            if current_task() is not self._host_task:
-                raise RuntimeError(
-                    "Attempted to exit cancel scope in a different task than it was "
-                    "entered in"
-                )
 
+        if not self._active:
+            raise RuntimeError("This cancel scope is not active")
+        if current_task() is not self._host_task:
+            raise RuntimeError(
+                "Attempted to exit cancel scope in a different task than it was "
+                "entered in"
+            )
+
+        try:
             assert self._host_task is not None
             host_task_state = _task_states.get(self._host_task)
             if host_task_state is None or host_task_state.cancel_scope is not self:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -481,7 +481,8 @@ class CancelScope(BaseCancelScope):
             self._restart_cancellation_in_parent()
             return swallow_exception and not not_swallowed_exceptions
         finally:
-            del self._host_task, exc_val
+            self._host_task = None
+            del exc_val
 
     @property
     def _effectively_cancelled(self) -> bool:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -689,8 +689,7 @@ class _AsyncioTaskStatus(abc.TaskStatus):
 
 async def _wait(tasks: Iterable[asyncio.Task[object]]) -> None:
     tasks = set(tasks)
-    loop = get_running_loop()
-    waiter = loop.create_future()
+    waiter = get_running_loop().create_future()
 
     def on_completion(task: asyncio.Task[object]) -> None:
         tasks.discard(task)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -425,58 +425,62 @@ class CancelScope(BaseCancelScope):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> bool | None:
-        if not self._active:
-            raise RuntimeError("This cancel scope is not active")
-        if current_task() is not self._host_task:
-            raise RuntimeError(
-                "Attempted to exit cancel scope in a different task than it was "
-                "entered in"
-            )
+        del exc_tb
+        try:
+            if not self._active:
+                raise RuntimeError("This cancel scope is not active")
+            if current_task() is not self._host_task:
+                raise RuntimeError(
+                    "Attempted to exit cancel scope in a different task than it was "
+                    "entered in"
+                )
 
-        assert self._host_task is not None
-        host_task_state = _task_states.get(self._host_task)
-        if host_task_state is None or host_task_state.cancel_scope is not self:
-            raise RuntimeError(
-                "Attempted to exit a cancel scope that isn't the current tasks's "
-                "current cancel scope"
-            )
+            assert self._host_task is not None
+            host_task_state = _task_states.get(self._host_task)
+            if host_task_state is None or host_task_state.cancel_scope is not self:
+                raise RuntimeError(
+                    "Attempted to exit a cancel scope that isn't the current tasks's "
+                    "current cancel scope"
+                )
 
-        self._active = False
-        if self._timeout_handle:
-            self._timeout_handle.cancel()
-            self._timeout_handle = None
+            self._active = False
+            if self._timeout_handle:
+                self._timeout_handle.cancel()
+                self._timeout_handle = None
 
-        self._tasks.remove(self._host_task)
-        if self._parent_scope is not None:
-            self._parent_scope._child_scopes.remove(self)
-            self._parent_scope._tasks.add(self._host_task)
+            self._tasks.remove(self._host_task)
+            if self._parent_scope is not None:
+                self._parent_scope._child_scopes.remove(self)
+                self._parent_scope._tasks.add(self._host_task)
 
-        host_task_state.cancel_scope = self._parent_scope
+            host_task_state.cancel_scope = self._parent_scope
 
-        # Undo all cancellations done by this scope
-        if self._cancelling is not None:
-            while self._cancel_calls:
-                self._cancel_calls -= 1
-                if self._host_task.uncancel() <= self._cancelling:
-                    break
+            # Undo all cancellations done by this scope
+            if self._cancelling is not None:
+                while self._cancel_calls:
+                    self._cancel_calls -= 1
+                    if self._host_task.uncancel() <= self._cancelling:
+                        break
 
-        # We only swallow the exception iff it was an AnyIO CancelledError, either
-        # directly as exc_val or inside an exception group and there are no cancelled
-        # parent cancel scopes visible to us here
-        not_swallowed_exceptions = 0
-        swallow_exception = False
-        if exc_val is not None:
-            for exc in iterate_exceptions(exc_val):
-                if self._cancel_called and isinstance(exc, CancelledError):
-                    if not (swallow_exception := self._uncancel(exc)):
+            # We only swallow the exception iff it was an AnyIO CancelledError, either
+            # directly as exc_val or inside an exception group and there are no cancelled
+            # parent cancel scopes visible to us here
+            not_swallowed_exceptions = 0
+            swallow_exception = False
+            if exc_val is not None:
+                for exc in iterate_exceptions(exc_val):
+                    if self._cancel_called and isinstance(exc, CancelledError):
+                        if not (swallow_exception := self._uncancel(exc)):
+                            not_swallowed_exceptions += 1
+                    else:
                         not_swallowed_exceptions += 1
-                else:
-                    not_swallowed_exceptions += 1
 
-        # Restart the cancellation effort in the closest visible, cancelled parent
-        # scope if necessary
-        self._restart_cancellation_in_parent()
-        return swallow_exception and not not_swallowed_exceptions
+            # Restart the cancellation effort in the closest visible, cancelled parent
+            # scope if necessary
+            self._restart_cancellation_in_parent()
+            return swallow_exception and not not_swallowed_exceptions
+        finally:
+            del self._host_task, exc_val
 
     @property
     def _effectively_cancelled(self) -> bool:
@@ -683,6 +687,27 @@ class _AsyncioTaskStatus(abc.TaskStatus):
         _task_states[task].parent_id = self._parent_id
 
 
+async def _wait(tasks: Iterable[asyncio.Task[object]]) -> None:
+    tasks = set(tasks)
+    loop = get_running_loop()
+    waiter = loop.create_future()
+
+    def on_completion(task: asyncio.Task[object]) -> None:
+        tasks.discard(task)
+        if not tasks and not waiter.done():
+            waiter.set_result(None)
+
+    for task in tasks:
+        task.add_done_callback(on_completion)
+        del task
+
+    try:
+        await waiter
+    finally:
+        while tasks:
+            tasks.pop().remove_done_callback(on_completion)
+
+
 class TaskGroup(abc.TaskGroup):
     def __init__(self) -> None:
         self.cancel_scope: CancelScope = CancelScope()
@@ -701,50 +726,53 @@ class TaskGroup(abc.TaskGroup):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> bool | None:
-        if exc_val is not None:
-            self.cancel_scope.cancel()
-            if not isinstance(exc_val, CancelledError):
-                self._exceptions.append(exc_val)
-
         try:
-            if self._tasks:
-                with CancelScope() as wait_scope:
-                    while self._tasks:
-                        try:
-                            await asyncio.wait(self._tasks)
-                        except CancelledError as exc:
-                            # Shield the scope against further cancellation attempts,
-                            # as they're not productive (#695)
-                            wait_scope.shield = True
-                            self.cancel_scope.cancel()
+            if exc_val is not None:
+                self.cancel_scope.cancel()
+                if not isinstance(exc_val, CancelledError):
+                    self._exceptions.append(exc_val)
 
-                            # Set exc_val from the cancellation exception if it was
-                            # previously unset. However, we should not replace a native
-                            # cancellation exception with one raise by a cancel scope.
-                            if exc_val is None or (
-                                isinstance(exc_val, CancelledError)
-                                and not is_anyio_cancellation(exc)
-                            ):
-                                exc_val = exc
-            else:
-                # If there are no child tasks to wait on, run at least one checkpoint
-                # anyway
-                await AsyncIOBackend.cancel_shielded_checkpoint()
+            try:
+                if self._tasks:
+                    with CancelScope() as wait_scope:
+                        while self._tasks:
+                            try:
+                                await _wait(self._tasks)
+                            except CancelledError as exc:
+                                # Shield the scope against further cancellation attempts,
+                                # as they're not productive (#695)
+                                wait_scope.shield = True
+                                self.cancel_scope.cancel()
 
-            self._active = False
-            if self._exceptions:
-                raise BaseExceptionGroup(
-                    "unhandled errors in a TaskGroup", self._exceptions
-                )
-            elif exc_val:
-                raise exc_val
-        except BaseException as exc:
-            if self.cancel_scope.__exit__(type(exc), exc, exc.__traceback__):
-                return True
+                                # Set exc_val from the cancellation exception if it was
+                                # previously unset. However, we should not replace a native
+                                # cancellation exception with one raise by a cancel scope.
+                                if exc_val is None or (
+                                    isinstance(exc_val, CancelledError)
+                                    and not is_anyio_cancellation(exc)
+                                ):
+                                    exc_val = exc
+                else:
+                    # If there are no child tasks to wait on, run at least one checkpoint
+                    # anyway
+                    await AsyncIOBackend.cancel_shielded_checkpoint()
 
-            raise
+                self._active = False
+                if self._exceptions:
+                    raise BaseExceptionGroup(
+                        "unhandled errors in a TaskGroup", self._exceptions
+                    )
+                elif exc_val:
+                    raise exc_val
+            except BaseException as exc:
+                if self.cancel_scope.__exit__(type(exc), exc, exc.__traceback__):
+                    return True
 
-        return self.cancel_scope.__exit__(exc_type, exc_val, exc_tb)
+                raise
+
+            return self.cancel_scope.__exit__(exc_type, exc_val, exc_tb)
+        finally:
+            del exc_val, exc_tb, self._exceptions
 
     def _spawn(
         self,

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -435,15 +435,15 @@ class CancelScope(BaseCancelScope):
                 "entered in"
             )
 
-        try:
-            assert self._host_task is not None
-            host_task_state = _task_states.get(self._host_task)
-            if host_task_state is None or host_task_state.cancel_scope is not self:
-                raise RuntimeError(
-                    "Attempted to exit a cancel scope that isn't the current tasks's "
-                    "current cancel scope"
-                )
+        assert self._host_task is not None
+        host_task_state = _task_states.get(self._host_task)
+        if host_task_state is None or host_task_state.cancel_scope is not self:
+            raise RuntimeError(
+                "Attempted to exit a cancel scope that isn't the current tasks's "
+                "current cancel scope"
+            )
 
+        try:
             self._active = False
             if self._timeout_handle:
                 self._timeout_handle.cancel()

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -183,16 +183,17 @@ class TaskGroup(abc.TaskGroup):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> bool | None:
+        rest = None
         try:
             return await self._nursery_manager.__aexit__(exc_type, exc_val, exc_tb)
         except BaseExceptionGroup as exc:
-            _, rest = exc.split(trio.Cancelled)
+            rest = exc.split(trio.Cancelled)[1]
             if not rest:
-                cancelled_exc = trio.Cancelled._create()
-                raise cancelled_exc from exc
+                raise trio.Cancelled._create() from exc
 
             raise
         finally:
+            del exc_val, exc_tb, rest
             self._active = False
 
     def start_soon(

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -183,17 +183,15 @@ class TaskGroup(abc.TaskGroup):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> bool | None:
-        rest = None
         try:
             return await self._nursery_manager.__aexit__(exc_type, exc_val, exc_tb)
         except BaseExceptionGroup as exc:
-            rest = exc.split(trio.Cancelled)[1]
-            if not rest:
+            if not exc.split(trio.Cancelled)[1]:
                 raise trio.Cancelled._create() from exc
 
             raise
         finally:
-            del exc_val, exc_tb, rest
+            del exc_val, exc_tb
             self._active = False
 
     def start_soon(

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1568,7 +1568,12 @@ else:
 )
 class TestRefcycles:
     async def test_exception_refcycles_direct(self) -> None:
-        """Test that TaskGroup doesn't keep a reference to the raised ExceptionGroup"""
+        """
+        Test that TaskGroup doesn't keep a reference to the raised ExceptionGroup
+
+        Note: This test never failed on anyio, but keeping this test to align
+        with the tests from cpython.
+        """
         tg = create_task_group()
         exc = None
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1585,7 +1585,7 @@ class TestRefcycles:
         assert gc.get_referrers(exc) == no_other_refs()
 
     async def test_exception_refcycles_errors(self) -> None:
-        """Test that TaskGroup deletes self._errors, and __aexit__ args"""
+        """Test that TaskGroup deletes self._exceptions, and __aexit__ args"""
         tg = create_task_group()
         exc = None
 
@@ -1602,7 +1602,7 @@ class TestRefcycles:
         assert gc.get_referrers(exc) == no_other_refs()
 
     async def test_exception_refcycles_parent_task(self) -> None:
-        """Test that TaskGroup deletes self._parent_task"""
+        """Test that TaskGroup's cancel_scope deletes self._host_task"""
         tg = create_task_group()
         exc = None
 
@@ -1623,7 +1623,7 @@ class TestRefcycles:
         assert gc.get_referrers(exc) == no_other_refs()
 
     async def test_exception_refcycles_propagate_cancellation_error(self) -> None:
-        """Test that TaskGroup deletes propagate_cancellation_error"""
+        """Test that TaskGroup deletes cancelled_exc"""
         tg = anyio.create_task_group()
         exc = None
 
@@ -1640,7 +1640,12 @@ class TestRefcycles:
         assert gc.get_referrers(exc) == no_other_refs()
 
     async def test_exception_refcycles_base_error(self) -> None:
-        """Test that TaskGroup deletes self._base_error"""
+        """
+        Test for BaseExceptions.
+
+        anyio doesn't treat these differently so this test is redundant
+        but copied from CPython's asyncio.TaskGroup tests for completion.
+        """
 
         class MyKeyboardInterrupt(KeyboardInterrupt):
             pass

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1549,6 +1549,16 @@ async def test_start_cancels_parent_scope() -> None:
     assert not tg.cancel_scope.cancel_called
 
 
+if sys.version_info <= (3, 11):
+
+    def no_other_refs() -> list[object]:
+        return [sys._getframe(1)]
+else:
+
+    def no_other_refs() -> list[object]:
+        return []
+
+
 async def test_exception_refcycles_direct() -> None:
     """Test that TaskGroup doesn't keep a reference to the raised ExceptionGroup"""
     tg = create_task_group()
@@ -1564,7 +1574,7 @@ async def test_exception_refcycles_direct() -> None:
         exc = e
 
     assert exc is not None
-    assert gc.get_referrers(exc) == []
+    assert gc.get_referrers(exc) == no_other_refs()
 
 
 async def test_exception_refcycles_errors() -> None:
@@ -1582,7 +1592,7 @@ async def test_exception_refcycles_errors() -> None:
         exc = excs.exceptions[0]
 
     assert isinstance(exc, _Done)
-    assert gc.get_referrers(exc) == []
+    assert gc.get_referrers(exc) == no_other_refs()
 
 
 async def test_exception_refcycles_parent_task() -> None:
@@ -1604,7 +1614,7 @@ async def test_exception_refcycles_parent_task() -> None:
         exc = excs.exceptions[0].exceptions[0]
 
     assert isinstance(exc, _Done)
-    assert gc.get_referrers(exc) == []
+    assert gc.get_referrers(exc) == no_other_refs()
 
 
 async def test_exception_refcycles_propagate_cancellation_error() -> None:
@@ -1622,7 +1632,7 @@ async def test_exception_refcycles_propagate_cancellation_error() -> None:
             raise
 
     assert isinstance(exc, get_cancelled_exc_class())
-    assert gc.get_referrers(exc) == []
+    assert gc.get_referrers(exc) == no_other_refs()
 
 
 async def test_exception_refcycles_base_error() -> None:
@@ -1641,7 +1651,7 @@ async def test_exception_refcycles_base_error() -> None:
         exc = excs.exceptions[0]
 
     assert isinstance(exc, MyKeyboardInterrupt)
-    assert gc.get_referrers(exc) == []
+    assert gc.get_referrers(exc) == no_other_refs()
 
 
 class TestTaskStatusTyping:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes
fix cyclic garbage that keeps traceback frames alive in taskgroup exceptions

This reproduces the behaviour in trio (the trio versions of the test pass with minor modifications of the anyio wrappers). Producing cyclic garbage is not usually a problem, however when an exception traceback references that exception again the entire traceback and therefore all frames in the stack remain alive until the garbage collector runs.


## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
