### PR TITLE
Rebind instance method fixtures to the same instance as the test

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,7 +8,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed acquring a lock twice in the same task on asyncio hanging instead of raising a
   ``RuntimeError`` (`#798 <https://github.com/agronholm/anyio/issues/798>`_)
 - Fixed an async fixture's ``self`` being different than the test's ``self`` in
-  unittest-style tests (`#633 <https://github.com/agronholm/anyio/issues/633>`_)
+  class-based tests (`#633 <https://github.com/agronholm/anyio/issues/633>`_)
   (PR by @agronholm and @graingert)
 
 **4.6.0**

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -9,6 +9,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``RuntimeError`` (`#798 <https://github.com/agronholm/anyio/issues/798>`_)
 - Fixed an async fixture's ``self`` being different than the test's ``self`` in
   unittest-style tests (`#633 <https://github.com/agronholm/anyio/issues/633>`_)
+  (PR by @agronholm and @graingert)
 
 **4.6.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Fixed acquring a lock twice in the same task on asyncio hanging instead of raising a
   ``RuntimeError`` (`#798 <https://github.com/agronholm/anyio/issues/798>`_)
+- Fixed ``self`` being different than the test's ``self`` for async instance method
+  fixtures in unittest-style tests
+  (`#633 <https://github.com/agronholm/anyio/issues/633>`_)
 
 **4.6.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,9 +7,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Fixed acquring a lock twice in the same task on asyncio hanging instead of raising a
   ``RuntimeError`` (`#798 <https://github.com/agronholm/anyio/issues/798>`_)
-- Fixed ``self`` being different than the test's ``self`` for async instance method
-  fixtures in unittest-style tests
-  (`#633 <https://github.com/agronholm/anyio/issues/633>`_)
+- Fixed an async fixture's ``self`` being different than the test's ``self`` in
+  unittest-style tests (`#633 <https://github.com/agronholm/anyio/issues/633>`_)
 
 **4.6.0**
 

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -119,7 +119,7 @@ def pytest_fixture_setup(fixturedef: Any, request: Any) -> Generator[Any]:
                 fixturedef.func = func
                 fixturedef.argnames = original_argname
 
-    yield
+    return (yield)
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import sys
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
-from inspect import isasyncgenfunction, iscoroutinefunction
+from inspect import isasyncgenfunction, iscoroutinefunction, ismethod
 from typing import Any, cast
 
 import pytest
 import sniffio
+from _pytest.fixtures import SubRequest
 from _pytest.outcomes import Exit
+from pytest import FixtureDef, FixtureRequest
 
 from ._core._eventloop import get_all_backends, get_async_backend
 from ._core._exceptions import iterate_exceptions
@@ -70,27 +72,45 @@ def pytest_configure(config: Any) -> None:
     )
 
 
-def pytest_fixture_setup(fixturedef: Any, request: Any) -> None:
-    def wrapper(*args, anyio_backend, **kwargs):  # type: ignore[no-untyped-def]
+def pytest_fixture_setup(fixturedef: FixtureDef, request: FixtureRequest) -> None:
+    def wrapper(
+        *args: Any, anyio_backend: Any, request: SubRequest, **kwargs: Any
+    ) -> Any:
+        # Rebind any fixture methods to the request instance
+        if (
+            request.instance
+            and ismethod(func)
+            and type(func.__self__) is type(request.instance)
+        ):
+            local_func = func.__func__.__get__(request.instance)
+        else:
+            local_func = func
+
         backend_name, backend_options = extract_backend_and_options(anyio_backend)
         if has_backend_arg:
             kwargs["anyio_backend"] = anyio_backend
 
+        if has_request_arg:
+            kwargs["request"] = anyio_backend
+
         with get_runner(backend_name, backend_options) as runner:
-            if isasyncgenfunction(func):
-                yield from runner.run_asyncgen_fixture(func, kwargs)
+            if isasyncgenfunction(local_func):
+                yield from runner.run_asyncgen_fixture(local_func, kwargs)
             else:
-                yield runner.run_fixture(func, kwargs)
+                yield runner.run_fixture(local_func, kwargs)
 
     # Only apply this to coroutine functions and async generator functions in requests
     # that involve the anyio_backend fixture
     func = fixturedef.func
     if isasyncgenfunction(func) or iscoroutinefunction(func):
         if "anyio_backend" in request.fixturenames:
-            has_backend_arg = "anyio_backend" in fixturedef.argnames
-            fixturedef.func = wrapper
-            if not has_backend_arg:
-                fixturedef.argnames += ("anyio_backend",)
+            fixturedef.func = wrapper  # type: ignore[misc]
+
+            if not (has_backend_arg := "anyio_backend" in fixturedef.argnames):
+                fixturedef.argnames += ("anyio_backend",)  # type: ignore[misc]
+
+            if not (has_request_arg := "request" in fixturedef.argnames):
+                fixturedef.argnames += ("request",)  # type: ignore[misc]
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -10,7 +10,6 @@ import pytest
 import sniffio
 from _pytest.fixtures import SubRequest
 from _pytest.outcomes import Exit
-from pytest import FixtureDef, FixtureRequest
 
 from ._core._eventloop import get_all_backends, get_async_backend
 from ._core._exceptions import iterate_exceptions
@@ -73,9 +72,7 @@ def pytest_configure(config: Any) -> None:
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_fixture_setup(
-    fixturedef: FixtureDef, request: FixtureRequest
-) -> Generator[Any]:
+def pytest_fixture_setup(fixturedef: Any, request: Any) -> Generator[Any]:
     def wrapper(
         *args: Any, anyio_backend: Any, request: SubRequest, **kwargs: Any
     ) -> Any:
@@ -107,20 +104,20 @@ def pytest_fixture_setup(
     func = fixturedef.func
     if isasyncgenfunction(func) or iscoroutinefunction(func):
         if "anyio_backend" in request.fixturenames:
-            fixturedef.func = wrapper  # type: ignore[misc]
+            fixturedef.func = wrapper
             original_argname = fixturedef.argnames
 
             if not (has_backend_arg := "anyio_backend" in fixturedef.argnames):
-                fixturedef.argnames += ("anyio_backend",)  # type: ignore[misc]
+                fixturedef.argnames += ("anyio_backend",)
 
             if not (has_request_arg := "request" in fixturedef.argnames):
-                fixturedef.argnames += ("request",)  # type: ignore[misc]
+                fixturedef.argnames += ("request",)
 
             try:
                 return (yield)
             finally:
-                fixturedef.func = func  # type: ignore[misc]
-                fixturedef.argnames = original_argname  # type: ignore[misc]
+                fixturedef.func = func
+                fixturedef.argnames = original_argname
 
     yield
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -517,3 +517,27 @@ def test_asyncgen_fixture_in_test_class(testdir: Pytester) -> None:
 
     result = testdir.runpytest_subprocess(*pytest_args)
     result.assert_outcomes(passed=len(get_all_backends()))
+
+
+def test_anyio_fixture_adoption_does_not_persist(testdir: Pytester) -> None:
+    testdir.makepyfile(
+        """
+        import inspect
+        import pytest
+
+        @pytest.fixture
+        async def fixt():
+            return 1
+
+        @pytest.mark.anyio
+        async def test_fixt(fixt):
+            assert fixt == 1
+
+        def test_no_mark(fixt):
+            assert inspect.iscoroutine(fixt)
+            fixt.close()
+        """
+    )
+
+    result = testdir.runpytest(*pytest_args)
+    result.assert_outcomes(passed=len(get_all_backends()) + 1)

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -468,3 +468,52 @@ def test_keyboardinterrupt_during_test(
     )
 
     testdir.runpytest_subprocess(*pytest_args, timeout=3)
+
+
+def test_async_fixture_in_test_class(testdir: Pytester) -> None:
+    # Regression test for #633
+    testdir.makepyfile(
+        """
+        import pytest
+
+
+        class TestAsyncFixtureMethod:
+            is_same_instance = False
+
+            @pytest.fixture(autouse=True)
+            async def async_fixture_method(self):
+                self.is_same_instance = True
+
+            @pytest.mark.anyio
+            async def test_async_fixture_method(self):
+                assert self.is_same_instance
+        """
+    )
+
+    result = testdir.runpytest_subprocess(*pytest_args)
+    result.assert_outcomes(passed=len(get_all_backends()))
+
+
+def test_asyncgen_fixture_in_test_class(testdir: Pytester) -> None:
+    # Regression test for #633
+    testdir.makepyfile(
+        """
+        import pytest
+
+
+        class TestAsyncFixtureMethod:
+            is_same_instance = False
+
+            @pytest.fixture(autouse=True)
+            async def async_fixture_method(self):
+                self.is_same_instance = True
+                yield
+
+            @pytest.mark.anyio
+            async def test_async_fixture_method(self):
+                assert self.is_same_instance
+        """
+    )
+
+    result = testdir.runpytest_subprocess(*pytest_args)
+    result.assert_outcomes(passed=len(get_all_backends()))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes instance method fixtures to run with the same `self` as the test.

Fixes #633. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
