### PR TITLE
Made asyncio TaskGroup work with eager task factories

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,14 +22,14 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.7.1
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.13.0
     hooks:
       - id: mypy
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.1
+    rev: v0.8.1
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added support for asyncio's eager task factories:
+
+  * Updated the annotation of ``TaskInfo.coro`` to allow it to be ``None``
+  * Updated ``TaskGroup`` to work with asyncio eager task factories
+
+  (`#764 <https://github.com/agronholm/anyio/issues/764>`_)
 - Fixed a misleading ``ValueError`` in the context of DNS failures
   (`#815 <https://github.com/agronholm/anyio/issues/815>`_; PR by @graingert)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,7 +5,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Added support for asyncio's eager task factories:
+- Improved compatibility with asyncio's eager task factories:
 
   * Updated the annotation of ``TaskInfo.coro`` to allow it to be ``None``
   * Updated ``TaskGroup`` to work with asyncio eager task factories

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,11 +5,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Improved compatibility with asyncio's eager task factories:
-
-  * Updated the annotation of ``TaskInfo.coro`` to allow it to be ``None``
-  * Updated ``TaskGroup`` to work with asyncio eager task factories
-
+- Updated ``TaskGroup`` to work with asyncio's eager task factories
   (`#764 <https://github.com/agronholm/anyio/issues/764>`_)
 - Fixed a misleading ``ValueError`` in the context of DNS failures
   (`#815 <https://github.com/agronholm/anyio/issues/815>`_; PR by @graingert)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -415,8 +415,10 @@ class CancelScope(BaseCancelScope):
             self._parent_scope = task_state.cancel_scope
             task_state.cancel_scope = self
             if self._parent_scope is not None:
+                # If using an eager task factory, the parent scope may not even contain
+                # the host task
                 self._parent_scope._child_scopes.add(self)
-                self._parent_scope._tasks.remove(host_task)
+                self._parent_scope._tasks.discard(host_task)
 
         self._timeout()
         self._active = True

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -853,7 +853,13 @@ class TaskGroup(abc.TaskGroup):
         )
         self.cancel_scope._tasks.add(task)
         self._tasks.add(task)
-        task.add_done_callback(task_done)
+
+        if task.done():
+            # This can happen with eager task factories
+            task_done(task)
+        else:
+            task.add_done_callback(task_done)
+
         return task
 
     def start_soon(

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2142,7 +2142,9 @@ class AsyncIOTaskInfo(TaskInfo):
         else:
             parent_id = task_state.parent_id
 
-        super().__init__(id(task), parent_id, task.get_name(), task.get_coro())
+        coro = task.get_coro()
+        assert coro is not None, "created TaskInfo from a completed Task"
+        super().__init__(id(task), parent_id, task.get_name(), coro)
         self._task = weakref.ref(task)
 
     def has_pending_cancellation(self) -> bool:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -895,15 +895,13 @@ class TaskGroup(abc.TaskGroup):
         name = get_callable_name(func) if name is None else str(name)
         try:
             task = create_task(coro, name=name)
-        except BaseException:
+        finally:
             del _task_states[coro]
-            raise
 
+        _task_states[task] = task_state
         self.cancel_scope._tasks.add(task)
         self._tasks.add(task)
 
-        del _task_states[coro]
-        _task_states[task] = task_state
         if task.done():
             # This can happen with eager task factories
             task_done(task)

--- a/src/anyio/_core/_testing.py
+++ b/src/anyio/_core/_testing.py
@@ -24,14 +24,14 @@ class TaskInfo:
         id: int,
         parent_id: int | None,
         name: str | None,
-        coro: Generator[Any, Any, Any] | Awaitable[Any],
+        coro: Generator[Any, Any, Any] | Awaitable[Any] | None,
     ):
         func = get_current_task
         self._name = f"{func.__module__}.{func.__qualname__}"
         self.id: int = id
         self.parent_id: int | None = parent_id
         self.name: str | None = name
-        self.coro: Generator[Any, Any, Any] | Awaitable[Any] = coro
+        self.coro: Generator[Any, Any, Any] | Awaitable[Any] | None = coro
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, TaskInfo):

--- a/src/anyio/_core/_testing.py
+++ b/src/anyio/_core/_testing.py
@@ -24,14 +24,14 @@ class TaskInfo:
         id: int,
         parent_id: int | None,
         name: str | None,
-        coro: Generator[Any, Any, Any] | Awaitable[Any] | None,
+        coro: Generator[Any, Any, Any] | Awaitable[Any],
     ):
         func = get_current_task
         self._name = f"{func.__module__}.{func.__qualname__}"
         self.id: int = id
         self.parent_id: int | None = parent_id
         self.name: str | None = name
-        self.coro: Generator[Any, Any, Any] | Awaitable[Any] | None = coro
+        self.coro: Generator[Any, Any, Any] | Awaitable[Any] = coro
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, TaskInfo):

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -40,6 +40,12 @@ class TaskGroup(metaclass=ABCMeta):
 
     :ivar cancel_scope: the cancel scope inherited by all child tasks
     :vartype cancel_scope: CancelScope
+
+    .. note:: On asyncio, support for eager task factories is considered to be
+        **experimental**. In particular, they don't follow the usual semantics of new
+        tasks being scheduled on the next iteration of the event loop, and may thus
+        cause unexpected behavior in code that wasn't written with such semantics in
+        mind.
     """
 
     cancel_scope: CancelScope

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -144,7 +144,7 @@ _ignore_win32_resource_warnings = (
 )
 
 
-@_ignore_win32_resource_warnings  # type: ignore[operator]
+@_ignore_win32_resource_warnings
 class TestTCPStream:
     @pytest.fixture
     def server_sock(self, family: AnyIPAddressFamily) -> Iterator[socket.socket]:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1724,4 +1724,3 @@ async def test_eager_task_factory(request: FixtureRequest) -> None:
     async with create_task_group() as tg:
         tg.start_soon(sync_coro)
         tg.cancel_scope.cancel()
-        await checkpoint()

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1714,7 +1714,9 @@ class TestTaskStatusTyping:
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_eager_task_factory(request: FixtureRequest) -> None:
     async def sync_coro() -> None:
-        pass
+        # This should trigger fetching the task state
+        with CancelScope():  # noqa: ASYNC100
+            pass
 
     loop = asyncio.get_running_loop()
     old_task_factory = loop.get_task_factory()

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -783,7 +783,7 @@ async def test_cancel_host_asyncgen() -> None:
     host_agen = host_agen_fn()
     try:
         loop = asyncio.get_running_loop()
-        await loop.create_task(host_agen.__anext__())  # type: ignore[arg-type]
+        await loop.create_task(host_agen.__anext__())
     finally:
         await host_agen.aclose()
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1707,11 +1707,11 @@ class TestTaskStatusTyping:
         task_status.started(1)
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
 @pytest.mark.skipif(
     sys.version_info < (3, 12),
     reason="Eager task factories require Python 3.12",
 )
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_eager_task_factory(request: FixtureRequest) -> None:
     async def sync_coro() -> None:
         pass


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #764.

<!-- Please give a short brief about these changes. -->

This updates the task group code and type annotations to accommodate eager task factories.

Additionally, this updates pre-commit modules. The updated `mypy` catches the annotation issues due to its updated `typeshed`.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #123, the entry should look like this:

`* Fix big bad boo-boo in task groups (#123
<https://github.com/agronholm/anyio/issues/123>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
