### PR TITLE
Allowed wait_socket_readable/writable to accept a file descriptor

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -127,6 +127,8 @@ Sockets and networking
 .. autofunction:: anyio.create_connected_udp_socket
 .. autofunction:: anyio.getaddrinfo
 .. autofunction:: anyio.getnameinfo
+.. autofunction:: anyio.wait_readable
+.. autofunction:: anyio.wait_writable
 .. autofunction:: anyio.wait_socket_readable
 .. autofunction:: anyio.wait_socket_writable
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -128,9 +128,9 @@ Sockets and networking
 .. autofunction:: anyio.getaddrinfo
 .. autofunction:: anyio.getnameinfo
 .. autofunction:: anyio.wait_readable
-.. autofunction:: anyio.wait_writable
 .. autofunction:: anyio.wait_socket_readable
 .. autofunction:: anyio.wait_socket_writable
+.. autofunction:: anyio.wait_writable
 
 .. autoclass:: anyio.abc.SocketAttribute
 .. autoclass:: anyio.abc.SocketStream()

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,9 +7,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Fixed a misleading ``ValueError`` in the context of DNS failures
   (`#815 <https://github.com/agronholm/anyio/issues/815>`_; PR by @graingert)
-- Allowed ``wait_socket_readable`` and ``wait_socket_writable`` to accept a socket
-  file descriptor (`#824 <https://github.com/agronholm/anyio/pull/824>`_)
-  (PR by @davidbrochart)
+- Added ``wait_readable`` and ``wait_writable`` functions that accept an object with a
+  ``.fileno()`` method or an integer handle, and deprecated ``wait_socket_readable``
+  and ``wait_socket_writable``.
+  (`#824 <https://github.com/agronholm/anyio/pull/824>`_) (PR by @davidbrochart)
 
 **4.6.2**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,10 +7,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Fixed a misleading ``ValueError`` in the context of DNS failures
   (`#815 <https://github.com/agronholm/anyio/issues/815>`_; PR by @graingert)
-- Added ``wait_readable`` and ``wait_writable`` functions that accept an object with a
-  ``.fileno()`` method or an integer handle, and deprecated ``wait_socket_readable``
-  and ``wait_socket_writable``.
-  (`#824 <https://github.com/agronholm/anyio/pull/824>`_; PR by @davidbrochart)
+- Added the ``wait_readable()`` and ``wait_writable()`` functions which will accept
+  an object with a ``.fileno()`` method or an integer handle, and deprecated
+  their now obsolete versions (``wait_socket_readable()`` and
+  ``wait_socket_writable()`` (PR by @davidbrochart)
 
 **4.6.2**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Fixed a misleading ``ValueError`` in the context of DNS failures
   (`#815 <https://github.com/agronholm/anyio/issues/815>`_; PR by @graingert)
+- Allowed ``wait_socket_readable`` and ``wait_socket_writable`` to accept a socket
+  file descriptor
 
 **4.6.2**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,7 +8,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed a misleading ``ValueError`` in the context of DNS failures
   (`#815 <https://github.com/agronholm/anyio/issues/815>`_; PR by @graingert)
 - Allowed ``wait_socket_readable`` and ``wait_socket_writable`` to accept a socket
-  file descriptor
+  file descriptor (`#824 <https://github.com/agronholm/anyio/pull/824>`_)
+  (PR by @davidbrochart)
 
 **4.6.2**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,7 +10,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Added ``wait_readable`` and ``wait_writable`` functions that accept an object with a
   ``.fileno()`` method or an integer handle, and deprecated ``wait_socket_readable``
   and ``wait_socket_writable``.
-  (`#824 <https://github.com/agronholm/anyio/pull/824>`_) (PR by @davidbrochart)
+  (`#824 <https://github.com/agronholm/anyio/pull/824>`_; PR by @davidbrochart)
 
 **4.6.2**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "exceptiongroup >= 1.0.2; python_version < '3.11'",
     "idna >= 2.8",
     "sniffio >= 1.1",
-    "typing_extensions >= 4.1; python_version < '3.11'",
+    "typing_extensions >= 4.5; python_version < '3.13'",
 ]
 dynamic = ["version"]
 

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -34,8 +34,10 @@ from ._core._sockets import create_unix_datagram_socket as create_unix_datagram_
 from ._core._sockets import create_unix_listener as create_unix_listener
 from ._core._sockets import getaddrinfo as getaddrinfo
 from ._core._sockets import getnameinfo as getnameinfo
+from ._core._sockets import wait_readable as wait_readable
 from ._core._sockets import wait_socket_readable as wait_socket_readable
 from ._core._sockets import wait_socket_writable as wait_socket_writable
+from ._core._sockets import wait_writable as wait_writable
 from ._core._streams import create_memory_object_stream as create_memory_object_stream
 from ._core._subprocesses import open_process as open_process
 from ._core._subprocesses import run_process as run_process

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2671,7 +2671,7 @@ class AsyncIOBackend(AsyncBackend):
         return await get_running_loop().getnameinfo(sockaddr, flags)
 
     @classmethod
-    async def wait_socket_readable(cls, sock: socket.socket) -> None:
+    async def wait_socket_readable(cls, sock: socket.socket | int) -> None:
         await cls.checkpoint()
         try:
             read_events = _read_events.get()
@@ -2698,7 +2698,7 @@ class AsyncIOBackend(AsyncBackend):
             raise ClosedResourceError
 
     @classmethod
-    async def wait_socket_writable(cls, sock: socket.socket) -> None:
+    async def wait_socket_writable(cls, sock: socket.socket | int) -> None:
         await cls.checkpoint()
         try:
             write_events = _write_events.get()
@@ -2711,7 +2711,7 @@ class AsyncIOBackend(AsyncBackend):
 
         loop = get_running_loop()
         event = write_events[sock] = asyncio.Event()
-        loop.add_writer(sock.fileno(), event.set)
+        loop.add_writer(sock, event.set)
         try:
             await event.wait()
         finally:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -28,6 +28,7 @@ from socket import AddressFamily, SocketKind
 from types import TracebackType
 from typing import (
     IO,
+    TYPE_CHECKING,
     Any,
     Generic,
     NoReturn,
@@ -79,6 +80,9 @@ from .._core._tasks import CancelScope as BaseCancelScope
 from ..abc import IPSockAddrType, UDPPacketType, UNIXDatagramPacketType
 from ..abc._eventloop import AsyncBackend, StrOrBytesPath
 from ..streams.memory import MemoryObjectSendStream
+
+if TYPE_CHECKING:
+    from _typeshed import HasFileno
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
@@ -1260,7 +1264,7 @@ class TrioBackend(AsyncBackend):
         return await trio.socket.getnameinfo(sockaddr, flags)
 
     @classmethod
-    async def wait_socket_readable(cls, sock: socket.socket | int) -> None:
+    async def wait_socket_readable(cls, sock: HasFileno | int) -> None:
         try:
             await wait_readable(sock)
         except trio.ClosedResourceError as exc:
@@ -1269,7 +1273,7 @@ class TrioBackend(AsyncBackend):
             raise BusyResourceError("reading from") from None
 
     @classmethod
-    async def wait_socket_writable(cls, sock: socket.socket | int) -> None:
+    async def wait_socket_writable(cls, sock: HasFileno | int) -> None:
         try:
             await wait_writable(sock)
         except trio.ClosedResourceError as exc:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1260,7 +1260,7 @@ class TrioBackend(AsyncBackend):
         return await trio.socket.getnameinfo(sockaddr, flags)
 
     @classmethod
-    async def wait_socket_readable(cls, sock: socket.socket) -> None:
+    async def wait_socket_readable(cls, sock: socket.socket | int) -> None:
         try:
             await wait_readable(sock)
         except trio.ClosedResourceError as exc:
@@ -1269,7 +1269,7 @@ class TrioBackend(AsyncBackend):
             raise BusyResourceError("reading from") from None
 
     @classmethod
-    async def wait_socket_writable(cls, sock: socket.socket) -> None:
+    async def wait_socket_writable(cls, sock: socket.socket | int) -> None:
         try:
             await wait_writable(sock)
         except trio.ClosedResourceError as exc:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1264,24 +1264,6 @@ class TrioBackend(AsyncBackend):
         return await trio.socket.getnameinfo(sockaddr, flags)
 
     @classmethod
-    async def wait_socket_readable(cls, sock: socket.socket) -> None:
-        try:
-            await wait_readable(sock)
-        except trio.ClosedResourceError as exc:
-            raise ClosedResourceError().with_traceback(exc.__traceback__) from None
-        except trio.BusyResourceError:
-            raise BusyResourceError("reading from") from None
-
-    @classmethod
-    async def wait_socket_writable(cls, sock: socket.socket) -> None:
-        try:
-            await wait_writable(sock)
-        except trio.ClosedResourceError as exc:
-            raise ClosedResourceError().with_traceback(exc.__traceback__) from None
-        except trio.BusyResourceError:
-            raise BusyResourceError("writing to") from None
-
-    @classmethod
     async def wait_readable(cls, obj: HasFileno | int) -> None:
         try:
             await wait_readable(obj)

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -601,7 +601,7 @@ def getnameinfo(sockaddr: IPSockAddrType, flags: int = 0) -> Awaitable[tuple[str
     return get_async_backend().getnameinfo(sockaddr, flags)
 
 
-@deprecated("This function is deprecated; use `wait_readable` instead", stacklevel=2)
+@deprecated("This function is deprecated; use `wait_readable` instead")
 def wait_socket_readable(sock: socket.socket) -> Awaitable[None]:
     """
     Deprecated, use `wait_readable` instead.
@@ -621,10 +621,10 @@ def wait_socket_readable(sock: socket.socket) -> Awaitable[None]:
         to become readable
 
     """
-    return get_async_backend().wait_socket_readable(sock)
+    return get_async_backend().wait_readable(sock.fileno())
 
 
-@deprecated("This function is deprecated; use `wait_writable` instead", stacklevel=2)
+@deprecated("This function is deprecated; use `wait_writable` instead")
 def wait_socket_writable(sock: socket.socket) -> Awaitable[None]:
     """
     Deprecated, use `wait_writable` instead.
@@ -644,7 +644,7 @@ def wait_socket_writable(sock: socket.socket) -> Awaitable[None]:
         to become writable
 
     """
-    return get_async_backend().wait_socket_writable(sock)
+    return get_async_backend().wait_writable(sock.fileno())
 
 
 def wait_readable(obj: HasFileno | int) -> Awaitable[None]:

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -10,7 +10,7 @@ from collections.abc import Awaitable
 from ipaddress import IPv6Address, ip_address
 from os import PathLike, chmod
 from socket import AddressFamily, SocketKind
-from typing import Any, Literal, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from .. import to_thread
 from ..abc import (
@@ -30,6 +30,11 @@ from ._eventloop import get_async_backend
 from ._resources import aclose_forcefully
 from ._synchronization import Event
 from ._tasks import create_task_group, move_on_after
+
+if TYPE_CHECKING:
+    from _typeshed import HasFileno
+else:
+    HasFileno = object
 
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
@@ -591,7 +596,7 @@ def getnameinfo(sockaddr: IPSockAddrType, flags: int = 0) -> Awaitable[tuple[str
     return get_async_backend().getnameinfo(sockaddr, flags)
 
 
-def wait_socket_readable(sock: socket.socket | int) -> Awaitable[None]:
+def wait_socket_readable(sock: HasFileno | int) -> Awaitable[None]:
     """
     Wait until the given socket has data to be read.
 
@@ -611,7 +616,7 @@ def wait_socket_readable(sock: socket.socket | int) -> Awaitable[None]:
     return get_async_backend().wait_socket_readable(sock)
 
 
-def wait_socket_writable(sock: socket.socket | int) -> Awaitable[None]:
+def wait_socket_writable(sock: HasFileno | int) -> Awaitable[None]:
     """
     Wait until the given socket can be written to.
 

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -628,7 +628,8 @@ def wait_socket_readable(sock: socket.socket) -> Awaitable[None]:
 @deprecated("This function is deprecated; use `wait_writable` instead")
 def wait_socket_writable(sock: socket.socket) -> Awaitable[None]:
     """
-    Deprecated, use `wait_writable` instead.
+    .. deprecated:: 4.7.0
+       Use :func:`wait_writable` instead.
 
     Wait until the given socket can be written to.
 

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -669,7 +669,7 @@ def wait_readable(obj: HasFileno | int) -> Awaitable[None]:
     .. warning:: Only use this on raw sockets that have not been wrapped by any higher
         level constructs like socket streams!
 
-    :param obj: an object with a ``.fileno()`` method or an integer handle.
+    :param obj: an object with a ``.fileno()`` method or an integer handle
     :raises ~anyio.ClosedResourceError: if the object was closed while waiting for the
         object to become readable
     :raises ~anyio.BusyResourceError: if another task is already waiting for the object
@@ -683,15 +683,15 @@ def wait_writable(obj: HasFileno | int) -> Awaitable[None]:
     """
     Wait until the given object can be written to.
 
-    See `wait_readable` for the definition of ``obj``.
-
     This does **NOT** work on Windows when using the asyncio backend with a proactor
     event loop (default on py3.8+).
+
+    .. seealso:: See the documentation of :func:`wait_readable` for the definition of ``obj``.
 
     .. warning:: Only use this on raw sockets that have not been wrapped by any higher
         level constructs like socket streams!
 
-    :param obj: an object with a ``.fileno()`` method or an integer handle.
+    :param obj: an object with a ``.fileno()`` method or an integer handle
     :raises ~anyio.ClosedResourceError: if the object was closed while waiting for the
         object to become writable
     :raises ~anyio.BusyResourceError: if another task is already waiting for the object

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -11,7 +11,6 @@ from ipaddress import IPv6Address, ip_address
 from os import PathLike, chmod
 from socket import AddressFamily, SocketKind
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
-from warnings import warn
 
 from .. import to_thread
 from ..abc import (
@@ -39,6 +38,11 @@ else:
 
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
+
+if sys.version_info < (3, 13):
+    from typing_extensions import deprecated
+else:
+    from warnings import deprecated
 
 IPPROTO_IPV6 = getattr(socket, "IPPROTO_IPV6", 41)  # https://bugs.python.org/issue29515
 
@@ -597,6 +601,7 @@ def getnameinfo(sockaddr: IPSockAddrType, flags: int = 0) -> Awaitable[tuple[str
     return get_async_backend().getnameinfo(sockaddr, flags)
 
 
+@deprecated("This function is deprecated; use `wait_readable` instead", stacklevel=2)
 def wait_socket_readable(sock: socket.socket) -> Awaitable[None]:
     """
     Deprecated, use `wait_readable` instead.
@@ -616,14 +621,10 @@ def wait_socket_readable(sock: socket.socket) -> Awaitable[None]:
         to become readable
 
     """
-    warn(
-        "This function is deprecated; use `wait_readable` instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     return get_async_backend().wait_socket_readable(sock)
 
 
+@deprecated("This function is deprecated; use `wait_writable` instead", stacklevel=2)
 def wait_socket_writable(sock: socket.socket) -> Awaitable[None]:
     """
     Deprecated, use `wait_writable` instead.
@@ -643,11 +644,6 @@ def wait_socket_writable(sock: socket.socket) -> Awaitable[None]:
         to become writable
 
     """
-    warn(
-        "This function is deprecated; use `wait_writable` instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     return get_async_backend().wait_socket_writable(sock)
 
 

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -686,7 +686,8 @@ def wait_writable(obj: HasFileno | int) -> Awaitable[None]:
     This does **NOT** work on Windows when using the asyncio backend with a proactor
     event loop (default on py3.8+).
 
-    .. seealso:: See the documentation of :func:`wait_readable` for the definition of ``obj``.
+    .. seealso:: See the documentation of :func:`wait_readable` for the definition of
+       ``obj``.
 
     .. warning:: Only use this on raw sockets that have not been wrapped by any higher
         level constructs like socket streams!

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -591,7 +591,7 @@ def getnameinfo(sockaddr: IPSockAddrType, flags: int = 0) -> Awaitable[tuple[str
     return get_async_backend().getnameinfo(sockaddr, flags)
 
 
-def wait_socket_readable(sock: socket.socket) -> Awaitable[None]:
+def wait_socket_readable(sock: socket.socket | int) -> Awaitable[None]:
     """
     Wait until the given socket has data to be read.
 
@@ -601,7 +601,7 @@ def wait_socket_readable(sock: socket.socket) -> Awaitable[None]:
     .. warning:: Only use this on raw sockets that have not been wrapped by any higher
         level constructs like socket streams!
 
-    :param sock: a socket object
+    :param sock: a socket object or its file descriptor
     :raises ~anyio.ClosedResourceError: if the socket was closed while waiting for the
         socket to become readable
     :raises ~anyio.BusyResourceError: if another task is already waiting for the socket
@@ -611,7 +611,7 @@ def wait_socket_readable(sock: socket.socket) -> Awaitable[None]:
     return get_async_backend().wait_socket_readable(sock)
 
 
-def wait_socket_writable(sock: socket.socket) -> Awaitable[None]:
+def wait_socket_writable(sock: socket.socket | int) -> Awaitable[None]:
     """
     Wait until the given socket can be written to.
 
@@ -621,7 +621,7 @@ def wait_socket_writable(sock: socket.socket) -> Awaitable[None]:
     .. warning:: Only use this on raw sockets that have not been wrapped by any higher
         level constructs like socket streams!
 
-    :param sock: a socket object
+    :param sock: a socket object or its file descriptor
     :raises ~anyio.ClosedResourceError: if the socket was closed while waiting for the
         socket to become writable
     :raises ~anyio.BusyResourceError: if another task is already waiting for the socket

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -604,7 +604,8 @@ def getnameinfo(sockaddr: IPSockAddrType, flags: int = 0) -> Awaitable[tuple[str
 @deprecated("This function is deprecated; use `wait_readable` instead")
 def wait_socket_readable(sock: socket.socket) -> Awaitable[None]:
     """
-    Deprecated, use `wait_readable` instead.
+    .. deprecated:: 4.7.0
+       Use :func:`wait_readable` instead.
 
     Wait until the given socket has data to be read.
 

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -333,12 +333,12 @@ class AsyncBackend(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    async def wait_socket_readable(cls, sock: socket) -> None:
+    async def wait_socket_readable(cls, sock: socket | int) -> None:
         pass
 
     @classmethod
     @abstractmethod
-    async def wait_socket_writable(cls, sock: socket) -> None:
+    async def wait_socket_writable(cls, sock: socket | int) -> None:
         pass
 
     @classmethod

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -28,6 +28,8 @@ else:
     from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
+    from _typeshed import HasFileno
+
     from .._core._synchronization import CapacityLimiter, Event, Lock, Semaphore
     from .._core._tasks import CancelScope
     from .._core._testing import TaskInfo
@@ -333,12 +335,12 @@ class AsyncBackend(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    async def wait_socket_readable(cls, sock: socket | int) -> None:
+    async def wait_socket_readable(cls, sock: HasFileno | int) -> None:
         pass
 
     @classmethod
     @abstractmethod
-    async def wait_socket_writable(cls, sock: socket | int) -> None:
+    async def wait_socket_writable(cls, sock: HasFileno | int) -> None:
         pass
 
     @classmethod

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -335,12 +335,22 @@ class AsyncBackend(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    async def wait_socket_readable(cls, sock: HasFileno | int) -> None:
+    async def wait_socket_readable(cls, sock: socket) -> None:
         pass
 
     @classmethod
     @abstractmethod
-    async def wait_socket_writable(cls, sock: HasFileno | int) -> None:
+    async def wait_socket_writable(cls, sock: socket) -> None:
+        pass
+
+    @classmethod
+    @abstractmethod
+    async def wait_readable(cls, obj: HasFileno | int) -> None:
+        pass
+
+    @classmethod
+    @abstractmethod
+    async def wait_writable(cls, obj: HasFileno | int) -> None:
         pass
 
     @classmethod

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -335,16 +335,6 @@ class AsyncBackend(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    async def wait_socket_readable(cls, sock: socket) -> None:
-        pass
-
-    @classmethod
-    @abstractmethod
-    async def wait_socket_writable(cls, sock: socket) -> None:
-        pass
-
-    @classmethod
-    @abstractmethod
     async def wait_readable(cls, obj: HasFileno | int) -> None:
         pass
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1861,7 +1861,7 @@ async def test_connect_tcp_getaddrinfo_context() -> None:
 async def test_wait_socket(
     anyio_backend_name: str, event: str, socket_type: str
 ) -> None:
-    if anyio_backend_name == "asyncio" and sys.platform == "win32":
+    if anyio_backend_name == "asyncio" and platform.system() == "Windows":
         import asyncio
 
         policy = asyncio.get_event_loop_policy()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1902,6 +1902,7 @@ async def test_deprecated_wait_socket(anyio_backend_name: str) -> None:
             with move_on_after(0.1):
                 await wait_socket_readable(sock)
 
+
         with pytest.warns(
             DeprecationWarning,
             match="This function is deprecated; use `wait_writable` instead",

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1881,12 +1881,13 @@ async def test_wait_socket(
         sock.listen()
         thread = Thread(target=client, args=(port,), daemon=True)
         thread.start()
-        thread.join()
         conn, addr = sock.accept()
         with conn:
             sock_or_fd: HasFileno | int = conn.fileno() if socket_type == "fd" else conn
             with fail_after(10):
                 await wait(sock_or_fd)
+                assert conn.recv(1024) == b"Hello, world"
+        thread.join()
 
 
 async def test_deprecated_wait_socket(anyio_backend_name: str) -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1902,7 +1902,6 @@ async def test_deprecated_wait_socket(anyio_backend_name: str) -> None:
             with move_on_after(0.1):
                 await wait_socket_readable(sock)
 
-
         with pytest.warns(
             DeprecationWarning,
             match="This function is deprecated; use `wait_writable` instead",

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1879,8 +1879,7 @@ async def test_wait_socket(anyio_backend_name: str, event: str, use_fd: bool) ->
             thread.start()
             conn, addr = sock.accept()
             with conn:
-                sock_or_fd = conn.fileno() if use_fd else conn
-                assert type(sock_or_fd) in (int, socket.socket)
+                sock_or_fd: socket.socket | int = conn.fileno() if use_fd else conn
                 await wait_socket(sock_or_fd)
                 socket_ready = True
 


### PR DESCRIPTION
## Changes

Fixes #821.

It seems that `anyio.wait_socket_readable(sock)` and `anyio.wait_socket_writable(sock)` can not only accept a `socket.socket` but also the socket's file descriptor (`int`):
- On asyncio, [add_reader](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.add_reader) and [add_writer](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.add_writer) accept a file descriptor.
- On trio, [wait_readable](https://trio.readthedocs.io/en/stable/reference-lowlevel.html#trio.lowlevel.wait_readable) and [wait_writable](https://trio.readthedocs.io/en/stable/reference-lowlevel.html#trio.lowlevel.wait_writable) accept a file descriptor or an object with a `.fileno()` method returning a file descriptor.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).