### PR TITLE
use settings from trio for Selector waker socketpair

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -2,7 +2,11 @@ Version history
 ===============
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
-
+**UNRELEASED**
+- Configure ``SO_RCVBUF``, ``SO_SNDBUF`` and ``TCP_NODELAY`` on the selector
+  thread waker socket pair. This should improve the performance of ``wait_readable()``
+  and ``wait_writable()`` when using the ``ProactorEventLoop``
+  (`#836 <https://github.com/agronholm/anyio/pull/836>`_) (PR by @graingert)
 **4.7.0**
 
 - Updated ``TaskGroup`` to work with asyncio's eager task factories

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -2,11 +2,14 @@ Version history
 ===============
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
+
 **UNRELEASED**
+
 - Configure ``SO_RCVBUF``, ``SO_SNDBUF`` and ``TCP_NODELAY`` on the selector
   thread waker socket pair. This should improve the performance of ``wait_readable()``
   and ``wait_writable()`` when using the ``ProactorEventLoop``
-  (`#836 <https://github.com/agronholm/anyio/pull/836>`_) (PR by @graingert)
+  (`#836 <https://github.com/agronholm/anyio/pull/836>`_; PR by @graingert)
+
 **4.7.0**
 
 - Updated ``TaskGroup`` to work with asyncio's eager task factories


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Lifted from https://github.com/python-trio/trio/blob/da89ae850658fb365064cb12a47659c8a0ac44b5/src/trio/_core/_wakeup_socketpair.py#L12

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
