### PR TITLE
Fixed shielded subtask cancel scope not protecting host from cancellation during start()

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,13 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed cancellation edge case on asyncio where a task spawning another with
+  ``TaskGroup.start()`` is not protected from external cancellation even when the
+  subtask has not yet called ``task_status.started()`` and is in a shielded cancel scope
+  (`#837 <https://github.com/agronholm/anyio/issues/837>`_)
+
 **4.7.0**
 
 - Updated ``TaskGroup`` to work with asyncio's eager task factories

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -18,6 +18,7 @@ import anyio
 from anyio import (
     TASK_STATUS_IGNORED,
     CancelScope,
+    Event,
     create_task_group,
     current_effective_deadline,
     current_time,
@@ -1600,6 +1601,40 @@ async def test_start_cancels_parent_scope() -> None:
 
     assert started
     assert not tg.cancel_scope.cancel_called
+
+
+async def test_cancel_shielding_start() -> None:
+    """
+    Test that if the host task that has spawned a subtask via ``start()`` is cancelled,
+    a shielded cancel scope in the child task will shield it from cancellation.
+
+    Regression test for #837.
+
+    """
+
+    async def taskfunc(*, task_status: TaskStatus[None]) -> None:
+        with CancelScope(shield=True):
+            entered_inner_scope.set()
+            try:
+                await checkpoint()
+                await checkpoint()
+            except get_cancelled_exc_class():
+                pytest.fail("Shouldn't be cancelled in a shielded scope")
+
+        # The cancellation should be triggered here, and not any earlier
+        await checkpoint()
+
+    async def start_inner_task() -> None:
+        await inner_tg.start(taskfunc)
+
+    entered_inner_scope = Event()
+    async with (
+        create_task_group() as tg,
+        create_task_group() as inner_tg,
+    ):
+        tg.start_soon(start_inner_task)
+        await entered_inner_scope.wait()
+        tg.cancel_scope.cancel()
 
 
 if sys.version_info <= (3, 11):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #837. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
