### PR TITLE
[Fix] Add support for task-like objects without strict asyncio.

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -56,7 +56,8 @@ from typing import (
     Any,
     Optional,
     TypeVar,
-    cast, Union,
+    Union,
+    cast,
 )
 from weakref import WeakKeyDictionary
 
@@ -692,9 +693,7 @@ class TaskStateStore(MutableMapping["Awaitable[Any] | asyncio.Task", TaskState])
                 if asyncio.iscoroutine(coro):
                     return coro
             except Exception as exc:
-                raise RuntimeError(
-                    "The task's coroutine was not available"
-                ) from exc
+                raise RuntimeError("The task's coroutine was not available") from exc
         return None
 
     def __getitem__(self, key: TaskLike) -> TaskState:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1796,7 +1796,7 @@ async def test_nest_asyncio_applied():
     nest_asyncio.apply()
 
     async def coro_task():
-        await sleep(0)
+        await asyncio.lowlevel.checkpoint()
 
     async with create_task_group() as tg:
         tg.start_soon(coro_task)
@@ -1849,7 +1849,7 @@ async def test_custom_task_like_object(monkeypatch: MonkeyPatch):
     original_task = asyncio.Task
 
     async def sample_coro():
-        await sleep(0)
+        await asyncio.lowlevel.checkpoint()
 
     async def task_factory(loop, coro):
         return CustomTask(coro)


### PR DESCRIPTION
## Changes
Instead of asserting isinstance(key, asyncio.Task), the store now relies on the presence of get_coro() and asyncio.iscoroutine() checks. This ensures that objects behaving like tasks (e.g., those provided by nest_asyncio or PyCharm’s debugger) are handled gracefully.

Additioanlly, by removing the strict type checks, this PR improves interoperability with non-standard or monkey-patched asyncio environments, as well as newer Python features like asyncio.eager_task_factory.

## Fixes:
* Fixes #840
* credits to @seedspirit

## Checklist

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
