### PR TITLE
Fix `__exit__` return type of various context managers

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,6 +11,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#836 <https://github.com/agronholm/anyio/pull/836>`_; PR by @graingert)
 - Fixed ``AssertionError`` when using ``nest-asyncio``
   (`#840 <https://github.com/agronholm/anyio/issues/840>`_)
+- Fixed return type annotation of various context managers' ``__exit__`` method
+  (`#847 <https://github.com/agronholm/anyio/issues/847>`_)
 
 **4.7.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -12,7 +12,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``AssertionError`` when using ``nest-asyncio``
   (`#840 <https://github.com/agronholm/anyio/issues/840>`_)
 - Fixed return type annotation of various context managers' ``__exit__`` method
-  (`#847 <https://github.com/agronholm/anyio/issues/847>`_)
+  (`#847 <https://github.com/agronholm/anyio/issues/847>`_; PR by @Enegg)
 
 **4.7.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2119,7 +2119,6 @@ class _SignalReceiver:
     ) -> None:
         for sig in self._handled_signals:
             self._loop.remove_signal_handler(sig)
-        return None
 
     def __aiter__(self) -> _SignalReceiver:
         return self

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -449,7 +449,7 @@ class CancelScope(BaseCancelScope):
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> bool:
         del exc_tb
 
         if not self._active:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -449,7 +449,7 @@ class CancelScope(BaseCancelScope):
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool:
+    ) -> bool | None:
         del exc_tb
 
         if not self._active:
@@ -485,7 +485,7 @@ class CancelScope(BaseCancelScope):
             # scope if necessary
             self._restart_cancellation_in_parent()
 
-            # We only swallow the exception iff it was an AnyIO CancelledError, either
+            # We only swallow the exception if it was an AnyIO CancelledError, either
             # directly as exc_val or inside an exception group and there are no cancelled
             # parent cancel scopes visible to us here
             if self._cancel_called and not self._parent_cancellation_is_visible_to_us:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -485,7 +485,7 @@ class CancelScope(BaseCancelScope):
             # scope if necessary
             self._restart_cancellation_in_parent()
 
-            # We only swallow the exception if it was an AnyIO CancelledError, either
+            # We only swallow the exception iff it was an AnyIO CancelledError, either
             # directly as exc_val or inside an exception group and there are no cancelled
             # parent cancel scopes visible to us here
             if self._cancel_called and not self._parent_cancellation_is_visible_to_us:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -449,7 +449,7 @@ class CancelScope(BaseCancelScope):
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> bool:
         del exc_tb
 
         if not self._active:
@@ -2116,7 +2116,7 @@ class _SignalReceiver:
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> None:
         for sig in self._handled_signals:
             self._loop.remove_signal_handler(sig)
         return None

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2447,7 +2447,7 @@ class AsyncIOBackend(AsyncBackend):
         return CapacityLimiter(total_tokens)
 
     @classmethod
-    async def run_sync_in_worker_thread(
+    async def run_sync_in_worker_thread(  # type: ignore[return]
         cls,
         func: Callable[[Unpack[PosArgsT]], T_Retval],
         args: tuple[Unpack[PosArgsT]],
@@ -2469,7 +2469,7 @@ class AsyncIOBackend(AsyncBackend):
 
         async with limiter or cls.current_default_thread_limiter():
             with CancelScope(shield=not abandon_on_cancel) as scope:
-                future: asyncio.Future = asyncio.Future()
+                future = asyncio.Future[T_Retval]()
                 root_task = find_root_task()
                 if not idle_workers:
                     worker = WorkerThread(root_task, workers, idle_workers)

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -132,7 +132,7 @@ class CancelScope(BaseCancelScope):
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool:
+    ) -> bool | None:
         return self.__original.__exit__(exc_type, exc_val, exc_tb)
 
     def cancel(self) -> None:
@@ -187,7 +187,8 @@ class TaskGroup(abc.TaskGroup):
         exc_tb: TracebackType | None,
     ) -> bool:
         try:
-            return await self._nursery_manager.__aexit__(exc_type, exc_val, exc_tb)
+            # trio.Nursery.__exit__ returns bool; .open_nursery has wrong type
+            return await self._nursery_manager.__aexit__(exc_type, exc_val, exc_tb)  # type: ignore[return-value]
         except BaseExceptionGroup as exc:
             if not exc.split(trio.Cancelled)[1]:
                 raise trio.Cancelled._create() from exc

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -132,7 +132,7 @@ class CancelScope(BaseCancelScope):
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> bool:
         return self.__original.__exit__(exc_type, exc_val, exc_tb)
 
     def cancel(self) -> None:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -132,8 +132,7 @@ class CancelScope(BaseCancelScope):
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
-        # https://github.com/python-trio/trio-typing/pull/79
+    ) -> bool:
         return self.__original.__exit__(exc_type, exc_val, exc_tb)
 
     def cancel(self) -> None:
@@ -186,7 +185,7 @@ class TaskGroup(abc.TaskGroup):
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> bool:
         try:
             return await self._nursery_manager.__aexit__(exc_type, exc_val, exc_tb)
         except BaseExceptionGroup as exc:

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -730,4 +730,3 @@ class ResourceGuard:
         exc_tb: TracebackType | None,
     ) -> None:
         self._guarded = False
-        return None

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -728,6 +728,6 @@ class ResourceGuard:
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> None:
         self._guarded = False
         return None

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -88,7 +88,7 @@ class CancelScope:
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> bool:
         raise NotImplementedError
 
 

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -88,7 +88,7 @@ class CancelScope:
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool:
+    ) -> bool | None:
         raise NotImplementedError
 
 

--- a/src/anyio/to_process.py
+++ b/src/anyio/to_process.py
@@ -35,7 +35,7 @@ _process_pool_idle_workers: RunVar[deque[tuple[Process, float]]] = RunVar(
 _default_process_limiter: RunVar[CapacityLimiter] = RunVar("_default_process_limiter")
 
 
-async def run_sync(
+async def run_sync(  # type: ignore[return]
     func: Callable[[Unpack[PosArgsT]], T_Retval],
     *args: Unpack[PosArgsT],
     cancellable: bool = False,

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -853,7 +853,8 @@ async def test_shielding_mutate() -> None:
             completed = True
             scope.shield = False
             await sleep(1)
-            pytest.fail("Execution should not reach this point")
+
+        pytest.fail("Execution should not reach this point")
 
     async with create_task_group() as tg:
         await tg.start(task)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #847. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->
A few context managers which *can* suppress exceptions had their `__exit__` method's return type incorrectly annotated as `bool | None`, where according to [typing docs](https://typing.readthedocs.io/en/latest/spec/exceptions.html#context-managers) it should be `bool`.

I've also included changes for `bool | None` -> `None` in places where `bool` is never returned. This shouldn't have any effect.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
