### PR TITLE
Changed TaskGroup to always spawn tasks lazily with eager task factories

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added support for the ``copy()``, ``copy_into()``, ``move()`` and ``move_into()``
   methods in ``anyio.Path``, available in Python 3.14
+- Changed ``TaskGroup`` on asyncio to always spawn tasks non-eagerly, even if using a
+  task factory created via ``asyncio.create_eager_task_factory()``, to preserve expected
+  Trio-like task scheduling semantics (PR by @agronholm and @graingert)
 - Configure ``SO_RCVBUF``, ``SO_SNDBUF`` and ``TCP_NODELAY`` on the selector
   thread waker socket pair. This should improve the performance of ``wait_readable()``
   and ``wait_writable()`` when using the ``ProactorEventLoop``

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import ssl
+import sys
 from collections.abc import Generator
 from ssl import SSLContext
 from typing import Any
@@ -28,21 +29,30 @@ else:
 
 pytest_plugins = ["pytester"]
 
+asyncio_params = [
+    pytest.param(("asyncio", {"debug": True}), id="asyncio"),
+    pytest.param(
+        ("asyncio", {"debug": True, "loop_factory": uvloop.new_event_loop}),
+        marks=uvloop_marks,
+        id="asyncio+uvloop",
+    ),
+]
+if sys.version_info >= (3, 12):
 
-@pytest.fixture(
-    params=[
+    def eager_task_loop_factory() -> asyncio.AbstractEventLoop:
+        loop = asyncio.new_event_loop()
+        loop.set_task_factory(asyncio.eager_task_factory)
+        return loop
+
+    asyncio_params.append(
         pytest.param(
-            ("asyncio", {"debug": True, "loop_factory": None}),
-            id="asyncio",
+            ("asyncio", {"debug": True, "loop_factory": eager_task_loop_factory}),
+            id="asyncio+eager",
         ),
-        pytest.param(
-            ("asyncio", {"debug": True, "loop_factory": uvloop.new_event_loop}),
-            marks=uvloop_marks,
-            id="asyncio+uvloop",
-        ),
-        pytest.param("trio"),
-    ]
-)
+    )
+
+
+@pytest.fixture(params=[*asyncio_params, pytest.param("trio")])
 def anyio_backend(request: SubRequest) -> tuple[str, dict[str, Any]]:
     return request.param
 

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -24,6 +24,8 @@ from anyio.streams.memory import (
     MemoryObjectSendStream,
 )
 
+from ..conftest import asyncio_params
+
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
 
@@ -486,7 +488,7 @@ async def test_not_closed_warning() -> None:
         gc.collect()
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_send_to_natively_cancelled_receiver() -> None:
     """
     Test that if a task waiting on receive.receive() is cancelled and then another

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -19,6 +19,8 @@ from anyio import (
 )
 from anyio.abc import TaskStatus
 
+from .conftest import asyncio_params
+
 pytestmark = pytest.mark.anyio
 
 
@@ -127,7 +129,7 @@ def test_wait_generator_based_task_blocked(
     asyncio_event_loop.run_until_complete(native_coro_part())
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_wait_all_tasks_blocked_asend(anyio_backend: str) -> None:
     """Test that wait_all_tasks_blocked() does not crash on an `asend()` object."""
 

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -33,6 +33,8 @@ from anyio.abc import TaskStatus
 from anyio.from_thread import BlockingPortal, start_blocking_portal
 from anyio.lowlevel import checkpoint
 
+from .conftest import asyncio_params
+
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
 
@@ -595,7 +597,7 @@ class TestBlockingPortal:
 
         assert propagated_value == 6
 
-    @pytest.mark.parametrize("anyio_backend", ["asyncio"])
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
     async def test_asyncio_run_sync_called(self, caplog: LogCaptureFixture) -> None:
         """Regression test for #357."""
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -5,6 +5,7 @@ import gc
 import io
 import os
 import platform
+import re
 import socket
 import sys
 import tempfile
@@ -60,6 +61,8 @@ from anyio.abc import (
 )
 from anyio.lowlevel import checkpoint
 from anyio.streams.stapled import MultiListener
+
+from .conftest import asyncio_params
 
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
@@ -488,16 +491,19 @@ class TestTCPStream:
         thread.join()
         assert thread_exception is None
 
-    @pytest.mark.parametrize("anyio_backend", ["asyncio"])
+    @pytest.fixture
+    def gc_collect(self) -> None:
+        gc.collect()
+
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
     async def test_unretrieved_future_exception_server_crash(
-        self, family: AnyIPAddressFamily, caplog: LogCaptureFixture
+        self, family: AnyIPAddressFamily, caplog: LogCaptureFixture, gc_collect: None
     ) -> None:
         """
         Test that there won't be any leftover Futures that don't get their exceptions
         retrieved.
 
         See https://github.com/encode/httpcore/issues/382 for details.
-
         """
 
         def serve() -> None:
@@ -523,7 +529,12 @@ class TestTCPStream:
 
             thread.join()
             gc.collect()
-            assert not caplog.text
+            caplog_text = "\n".join(
+                msg
+                for msg in caplog.messages
+                if not re.search("took [0-9.]+ seconds", msg)
+            )
+            assert not caplog_text
 
 
 @pytest.mark.network

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -20,6 +20,8 @@ from anyio import (
 )
 from anyio.abc import CapacityLimiter, TaskStatus
 
+from .conftest import asyncio_params
+
 pytestmark = pytest.mark.anyio
 
 
@@ -162,7 +164,7 @@ class TestLock:
         assert not lock.statistics().locked
         assert lock.statistics().tasks_waiting == 0
 
-    @pytest.mark.parametrize("anyio_backend", ["asyncio"])
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
     async def test_asyncio_deadlock(self) -> None:
         """Regression test for #398."""
         lock = Lock()
@@ -178,7 +180,7 @@ class TestLock:
         task1.cancel()
         await asyncio.wait_for(task2, 1)
 
-    @pytest.mark.parametrize("anyio_backend", ["asyncio"])
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
     async def test_cancel_after_release(self) -> None:
         """
         Test that a native asyncio cancellation will not cause a lock ownership
@@ -565,7 +567,7 @@ class TestSemaphore:
             semaphore.release()
             pytest.raises(WouldBlock, semaphore.acquire_nowait)
 
-    @pytest.mark.parametrize("anyio_backend", ["asyncio"])
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
     async def test_asyncio_deadlock(self) -> None:
         """Regression test for #398."""
         semaphore = Semaphore(1)
@@ -581,7 +583,7 @@ class TestSemaphore:
         task1.cancel()
         await asyncio.wait_for(task2, 1)
 
-    @pytest.mark.parametrize("anyio_backend", ["asyncio"])
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
     async def test_cancel_after_release(self) -> None:
         """
         Test that a native asyncio cancellation will not cause a semaphore ownership
@@ -731,7 +733,7 @@ class TestCapacityLimiter:
         assert limiter.statistics().tasks_waiting == 0
         assert limiter.statistics().borrowed_tokens == 0
 
-    @pytest.mark.parametrize("anyio_backend", ["asyncio"])
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
     async def test_asyncio_deadlock(self) -> None:
         """Regression test for #398."""
         limiter = CapacityLimiter(1)

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -32,6 +32,8 @@ from anyio import (
 from anyio.abc import TaskGroup, TaskStatus
 from anyio.lowlevel import checkpoint
 
+from .conftest import asyncio_params
+
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 
@@ -200,7 +202,7 @@ async def test_start_cancelled() -> None:
     assert not finished
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_start_native_host_cancelled() -> None:
     started = finished = False
 
@@ -224,7 +226,7 @@ async def test_start_native_host_cancelled() -> None:
     assert not finished
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_start_native_child_cancelled() -> None:
     task = None
     finished = False
@@ -248,7 +250,7 @@ async def test_start_native_child_cancelled() -> None:
     assert not finished
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_propagate_native_cancellation_from_taskgroup() -> None:
     async def taskfunc() -> None:
         async with create_task_group() as tg:
@@ -261,7 +263,7 @@ async def test_propagate_native_cancellation_from_taskgroup() -> None:
         await task
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_cancel_with_nested_task_groups() -> None:
     """Regression test for #695."""
 
@@ -703,7 +705,7 @@ async def test_shielded_cleanup_after_cancel() -> None:
             assert get_current_task().has_pending_cancellation()
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_cleanup_after_native_cancel() -> None:
     """Regression test for #832."""
     # See also https://github.com/python/cpython/pull/102815.
@@ -803,7 +805,7 @@ async def test_empty_taskgroup_contains_yield_point() -> None:
         assert outer_task_ran
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_cancel_host_asyncgen() -> None:
     done = False
 
@@ -1159,7 +1161,7 @@ def test_cancel_generator_based_task() -> None:
 @pytest.mark.filterwarnings(
     'ignore:"@coroutine" decorator is deprecated:DeprecationWarning'
 )
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_schedule_old_style_coroutine_func() -> None:
     """
     Test that we give a sensible error when a user tries to spawn a task from a
@@ -1182,7 +1184,7 @@ async def test_schedule_old_style_coroutine_func() -> None:
             tg.start_soon(corofunc)
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_cancel_native_future_tasks() -> None:
     async def wait_native_future() -> None:
         loop = asyncio.get_running_loop()
@@ -1193,7 +1195,7 @@ async def test_cancel_native_future_tasks() -> None:
         tg.cancel_scope.cancel()
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_cancel_native_future_tasks_cancel_scope() -> None:
     async def wait_native_future() -> None:
         with anyio.CancelScope():
@@ -1205,7 +1207,7 @@ async def test_cancel_native_future_tasks_cancel_scope() -> None:
         tg.cancel_scope.cancel()
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_cancel_completed_task() -> None:
     loop = asyncio.get_running_loop()
     old_exception_handler = loop.get_exception_handler()
@@ -1301,7 +1303,7 @@ async def test_cancelscope_exit_before_enter() -> None:
 
 
 @pytest.mark.parametrize(
-    "anyio_backend", ["asyncio"]
+    "anyio_backend", asyncio_params
 )  # trio does not check for this yet
 async def test_cancelscope_exit_in_wrong_task() -> None:
     async def enter_scope(scope: CancelScope) -> None:
@@ -1416,7 +1418,7 @@ async def test_start_parent_id() -> None:
     sys.version_info < (3, 11),
     reason="Task uncancelling is only supported on Python 3.11",
 )
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 class TestUncancel:
     async def test_uncancel_after_native_cancel(self) -> None:
         task = cast(asyncio.Task, asyncio.current_task())
@@ -1792,23 +1794,41 @@ class TestTaskStatusTyping:
     reason="Eager task factories require Python 3.12",
 )
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
-async def test_eager_task_factory(request: FixtureRequest) -> None:
+@pytest.mark.parametrize("use_custom_eager_factory", [False, True])
+async def test_eager_task_factory(
+    request: FixtureRequest, use_custom_eager_factory: bool
+) -> None:
+    ran = False
+
     async def sync_coro() -> None:
+        nonlocal ran
+        ran = True
+
         # This should trigger fetching the task state
         with CancelScope():  # noqa: ASYNC100
             pass
 
+    def create_custom_task(
+        coro: Coroutine[Any, Any, Any], /, **kwargs: Any
+    ) -> asyncio.Task[Any]:
+        return asyncio.Task(coro, **kwargs)
+
     loop = asyncio.get_running_loop()
     old_task_factory = loop.get_task_factory()
-    loop.set_task_factory(asyncio.eager_task_factory)
+    if use_custom_eager_factory:
+        loop.set_task_factory(asyncio.create_eager_task_factory(create_custom_task))
+    else:
+        loop.set_task_factory(asyncio.eager_task_factory)
+
     request.addfinalizer(lambda: loop.set_task_factory(old_task_factory))
 
     async with create_task_group() as tg:
         tg.start_soon(sync_coro)
+        assert not ran
         tg.cancel_scope.cancel()
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_patched_asyncio_task(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(
         asyncio,

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -23,6 +23,8 @@ from anyio import (
 )
 from anyio.from_thread import BlockingPortalProvider
 
+from .conftest import asyncio_params
+
 pytestmark = pytest.mark.anyio
 
 
@@ -159,7 +161,7 @@ async def test_asynclib_detection() -> None:
         await to_thread.run_sync(sniffio.current_async_library)
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_asyncio_cancel_native_task() -> None:
     task: asyncio.Task[None] | None = None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Changed asyncio `TaskFactory` to detect eager task factories and force non-eager start for the task.

This does away with earlier workarounds for eager task factories.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
