### PR TITLE
refactor waiting for tasks to complete from task group on the asyncio backend

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -18,8 +18,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#840 <https://github.com/agronholm/anyio/issues/840>`_)
 - Fixed return type annotation of various context managers' ``__exit__`` method
   (`#847 <https://github.com/agronholm/anyio/issues/847>`_; PR by @Enegg)
-- Refactored TaskGroup task waiting on the asyncio backend
-  (`#854 <https://github.com/agronholm/anyio/pull/854>`_; PR by @graingert)
 
 **4.7.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -18,6 +18,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#840 <https://github.com/agronholm/anyio/issues/840>`_)
 - Fixed return type annotation of various context managers' ``__exit__`` method
   (`#847 <https://github.com/agronholm/anyio/issues/847>`_; PR by @Enegg)
+- Refactored TaskGroup task waiting on the asyncio backend
+  (`#854 <https://github.com/agronholm/anyio/pull/854>`_; PR by @graingert)
 
 **4.7.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -737,8 +737,7 @@ class TaskGroup(abc.TaskGroup):
                 if self._tasks:
                     with CancelScope() as wait_scope:
                         while self._tasks:
-                            if self._on_completed_fut is None:
-                                self._on_completed_fut = loop.create_future()
+                            self._on_completed_fut = loop.create_future()
 
                             try:
                                 await self._on_completed_fut

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -739,6 +739,7 @@ class TaskGroup(abc.TaskGroup):
                         while self._tasks:
                             if self._on_completed_fut is None:
                                 self._on_completed_fut = loop.create_future()
+
                             try:
                                 await self._on_completed_fut
                             except CancelledError as exc:
@@ -755,6 +756,7 @@ class TaskGroup(abc.TaskGroup):
                                     and not is_anyio_cancellation(exc)
                                 ):
                                     exc_val = exc
+
                             self._on_completed_fut = None
                 else:
                     # If there are no child tasks to wait on, run at least one checkpoint

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -795,8 +795,10 @@ class TaskGroup(abc.TaskGroup):
             del _task_states[_task]
 
             if self._on_completed_fut is not None and not self._tasks:
-                if not self._on_completed_fut.done():
+                try:
                     self._on_completed_fut.set_result(None)
+                except asyncio.InvalidStateError:
+                    pass
 
             try:
                 exc = _task.exception()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This uses the approach that asyncio uses for asyncio.TaskGroup, this means we only have one done callback per task which on the C implementation uses the efficient first callback slot, and further callbacks need to be added to a list - which is slower.

The old implementation added and removed a lot of callbacks on initiation and cancellation and is slower than it needs to be

<!-- Please give a short brief about these changes. -->

## Checklist
This is a simple refactor so no tests here, also no update to the docs - we probably save an event loop cycle here or there.

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
