### PR TITLE
Make `anyio.run_process()` accept `stdin` argument

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,13 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Added ``stdin`` argument to ``anyio.run_process()`` akin to what
+  ``anyio.open_process()``, ``asyncio.create_subprocess_…()``, ``trio.run_process()``,
+  and ``subprocess.run()`` already accept.
+  (`#859 <https://github.com/agronholm/anyio/pull/859>`_; PR by @jmehnle)
+
 **4.8.0**
 
 - Added **experimental** support for running functions in subinterpreters on Python

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,8 +7,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added ``stdin`` argument to ``anyio.run_process()`` akin to what
   ``anyio.open_process()``, ``asyncio.create_subprocess_…()``, ``trio.run_process()``,
-  and ``subprocess.run()`` already accept.
-  (`#859 <https://github.com/agronholm/anyio/pull/859>`_; PR by @jmehnle)
+  and ``subprocess.run()`` already accept (PR by @jmehnle)
 
 **4.8.0**
 

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -4,7 +4,7 @@ import sys
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from io import BytesIO
 from os import PathLike
-from subprocess import DEVNULL, PIPE, CalledProcessError, CompletedProcess
+from subprocess import PIPE, CalledProcessError, CompletedProcess
 from typing import IO, Any, Union, cast
 
 from ..abc import Process
@@ -85,9 +85,12 @@ async def run_process(
 
         stream_contents[index] = buffer.getvalue()
 
+    if stdin is not None and input is not None:
+        raise ValueError("only one of stdin and input is allowed")
+
     async with await open_process(
         command,
-        stdin=(input and PIPE) or stdin or DEVNULL,
+        stdin=PIPE if input else stdin,
         stdout=stdout,
         stderr=stderr,
         cwd=cwd,

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -23,6 +23,7 @@ async def run_process(
     command: StrOrBytesPath | Sequence[StrOrBytesPath],
     *,
     input: bytes | None = None,
+    stdin: int | IO[Any] | None = None,
     stdout: int | IO[Any] | None = PIPE,
     stderr: int | IO[Any] | None = PIPE,
     check: bool = True,
@@ -45,6 +46,8 @@ async def run_process(
     :param command: either a string to pass to the shell, or an iterable of strings
         containing the executable name or path and its arguments
     :param input: bytes passed to the standard input of the subprocess
+    :param stdin: one of :data:`subprocess.PIPE`, :data:`subprocess.DEVNULL`,
+        a file-like object, or `None`; ``input`` overrides this
     :param stdout: one of :data:`subprocess.PIPE`, :data:`subprocess.DEVNULL`,
         a file-like object, or `None`
     :param stderr: one of :data:`subprocess.PIPE`, :data:`subprocess.DEVNULL`,
@@ -84,7 +87,7 @@ async def run_process(
 
     async with await open_process(
         command,
-        stdin=PIPE if input else DEVNULL,
+        stdin=(input and PIPE) or stdin or DEVNULL,
         stdout=stdout,
         stderr=stderr,
         cwd=cwd,

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -194,6 +194,13 @@ async def test_run_process_connect_to_file(tmp_path: Path) -> None:
     )
 
 
+async def test_stdin_input_both_passed(tmp_path: Path) -> None:
+    stdinfile = tmp_path / "stdin"
+    stdinfile.write_text("Hello, process!\n")
+    with pytest.raises(ValueError, match="only one of"), stdinfile.open("rb") as fin:
+        await run_process([sys.executable, "--version"], input=b"abc", stdin=fin)
+
+
 async def test_run_process_inherit_stdout(capfd: pytest.CaptureFixture[str]) -> None:
     await run_process(
         [


### PR DESCRIPTION
## Changes

Make `anyio.run_process()` accept a `stdin` argument.

This is consistent with what `asyncio.create_subprocess_exec()`, `trio.run_process()`, and `subprocess.run()`, which accept such an argument.

The handling of conflicts between `stdin` and `input` arguments is simplistic: the latter currently overrides the former without warning.

## Checklist

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [X] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).
