### PR TITLE
Avoid chaining current exception when exiting task-groups on asyncio

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,12 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+ **UNRELEASED**
+- Fixed traceback formatting growing quadratically with level of ``TaskGroup``
+  nesting on asyncio due to exception chaining when raising ``ExceptionGroups``
+  in ``TaskGroup.__aexit__``
+  (`#863 <https://github.com/agronholm/anyio/issues/863>`_; PR by @tapetersen)
+
 **4.8.0**
 
 - Added **experimental** support for running functions in subinterpreters on Python

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -4,6 +4,7 @@ Version history
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
  **UNRELEASED**
+
 - Fixed traceback formatting growing quadratically with level of ``TaskGroup``
   nesting on asyncio due to exception chaining when raising ``ExceptionGroups``
   in ``TaskGroup.__aexit__``

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -772,7 +772,7 @@ class TaskGroup(abc.TaskGroup):
                         "unhandled errors in a TaskGroup", self._exceptions
                     ) from None
                 elif exc_val:
-                    raise exc_val from None
+                    raise exc_val
             except BaseException as exc:
                 if self.cancel_scope.__exit__(type(exc), exc, exc.__traceback__):
                     return True

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -764,11 +764,15 @@ class TaskGroup(abc.TaskGroup):
 
                 self._active = False
                 if self._exceptions:
+                    # The exception that got us here should already have been
+                    # added to self._exceptions so it's ok to break exception
+                    # chaining and avoid adding a "During handling of above..."
+                    # for each nesting level.
                     raise BaseExceptionGroup(
                         "unhandled errors in a TaskGroup", self._exceptions
-                    )
+                    ) from None
                 elif exc_val:
-                    raise exc_val
+                    raise exc_val from None
             except BaseException as exc:
                 if self.cancel_scope.__exit__(type(exc), exc, exc.__traceback__):
                     return True

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1839,7 +1839,6 @@ async def test_patched_asyncio_task(monkeypatch: MonkeyPatch) -> None:
         tg.start_soon(sleep, 0)
 
 
-@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_exception_groups_suppresses_exc_context() -> None:
     with pytest.raises(
         cast(type[ExceptionGroup[Exception]], ExceptionGroup)

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1837,3 +1837,14 @@ async def test_patched_asyncio_task(monkeypatch: MonkeyPatch) -> None:
     )
     async with create_task_group() as tg:
         tg.start_soon(sleep, 0)
+
+
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
+async def test_exception_groups_suppresses_exc_context() -> None:
+    with pytest.raises(
+        cast(type[ExceptionGroup[Exception]], ExceptionGroup)
+    ) as exc_info:
+        async with create_task_group():
+            raise Exception("Error")
+
+    assert exc_info.value.__suppress_context__


### PR DESCRIPTION
Fixes #863

## Changes

Fixes #863

Break exception context chaining when exiting `TaskGroup` on asyncio

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
