### PR TITLE
Add async support for temporary file handling. Closes #344

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -82,6 +82,23 @@ Async file I/O
 .. autoclass:: anyio.AsyncFile
 .. autoclass:: anyio.Path
 
+Temporary files and directories
+-------------------------------
+
+.. autofunction:: anyio.mkstemp
+.. autofunction:: anyio.mkdtemp
+.. autofunction:: anyio.gettempdir
+.. autofunction:: anyio.gettempdirb
+
+.. autoclass:: anyio.TemporaryFile
+
+.. autoclass:: anyio.NamedTemporaryFile
+
+.. autoclass:: anyio.SpooledTemporaryFile
+
+.. autoclass:: anyio.TemporaryDirectory
+
+
 Streams and stream wrappers
 ---------------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -91,13 +91,9 @@ Temporary files and directories
 .. autofunction:: anyio.gettempdirb
 
 .. autoclass:: anyio.TemporaryFile
-
 .. autoclass:: anyio.NamedTemporaryFile
-
 .. autoclass:: anyio.SpooledTemporaryFile
-
 .. autoclass:: anyio.TemporaryDirectory
-
 
 Streams and stream wrappers
 ---------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ The manual
    subprocesses
    subinterpreters
    fileio
+   tempfile
    signals
    testing
    api

--- a/docs/tempfile.rst
+++ b/docs/tempfile.rst
@@ -1,0 +1,119 @@
+Asynchronous Temporary File and Directory
+=========================================
+
+.. py:currentmodule:: anyio
+
+This module provides asynchronous wrappers for handling temporary files and directories
+using the :mod:`tempfile` module. The asynchronous methods execute blocking operations in worker threads.
+
+Temporary File
+--------------
+
+:class:`TemporaryFile` creates a temporary file that is automatically deleted upon closure.
+
+**Example:**
+
+.. code-block:: python
+
+    from anyio import TemporaryFile, run
+
+    async def main():
+        async with TemporaryFile(mode="w+") as f:
+            await f.write("Temporary file content")
+            await f.seek(0)
+            print(await f.read())  # Output: Temporary file content
+
+    run(main)
+
+Named Temporary File
+--------------------
+
+:class:`NamedTemporaryFile` works similarly to :class:`TemporaryFile`, but the file has a visible name in the filesystem.
+
+**Example:**
+
+.. code-block:: python
+
+    from anyio import NamedTemporaryFile, run
+
+    async def main():
+        async with NamedTemporaryFile(mode="w+", delete=True) as f:
+            print(f"Temporary file name: {f.name}")
+            await f.write("Named temp file content")
+            await f.seek(0)
+            print(await f.read())
+
+    run(main)
+
+Spooled Temporary File
+----------------------
+
+:class:`SpooledTemporaryFile` is useful when temporary data is small and should be kept in memory rather than written to disk.
+
+**Example:**
+
+.. code-block:: python
+
+    from anyio import SpooledTemporaryFile, run
+
+    async def main():
+        async with SpooledTemporaryFile(max_size=1024, mode="w+") as f:
+            await f.write("Spooled temp file content")
+            await f.seek(0)
+            print(await f.read())
+
+    run(main)
+
+Temporary Directory
+-------------------
+
+The :class:`TemporaryDirectory` provides an asynchronous way to create temporary directories.
+
+**Example:**
+
+.. code-block:: python
+
+    from anyio import TemporaryDirectory, run
+
+    async def main():
+        async with TemporaryDirectory() as temp_dir:
+            print(f"Temporary directory path: {temp_dir}")
+
+    run(main)
+
+Low-Level Temporary File and Directory Creation
+-----------------------------------------------
+
+For more control, the module provides lower-level functions:
+
+- :func:`mkstemp` - Creates a temporary file and returns a tuple of file descriptor and path.
+- :func:`mkdtemp` - Creates a temporary directory and returns the directory path.
+- :func:`gettempdir` - Returns the path of the default temporary directory.
+- :func:`gettempdirb` - Returns the path of the default temporary directory in bytes.
+
+**Example:**
+
+.. code-block:: python
+
+    from anyio import mkstemp, mkdtemp, gettempdir, run
+    import os
+
+    async def main():
+        fd, path = await mkstemp(suffix=".txt", prefix="mkstemp_", text=True)
+        print(f"Created temp file: {path}")
+
+        temp_dir = await mkdtemp(prefix="mkdtemp_")
+        print(f"Created temp dir: {temp_dir}")
+
+        print(f"Default temp dir: {await gettempdir()}")
+
+        os.remove(path)
+
+    run(main)
+
+.. note::
+    Using these functions requires manual cleanup of the created files and directories.
+
+.. seealso::
+
+    - Python Standard Library: :mod:`tempfile` (`official documentation <https://docs.python.org/3/library/tempfile.html>`_)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,9 @@ extend-select = [
 [tool.ruff.lint.isort]
 "required-imports" = ["from __future__ import annotations"]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/test_tempfile.py" = ["ASYNC230"]
+
 [tool.mypy]
 python_version = "3.13"
 strict = true

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -61,6 +61,16 @@ from ._core._tasks import create_task_group as create_task_group
 from ._core._tasks import current_effective_deadline as current_effective_deadline
 from ._core._tasks import fail_after as fail_after
 from ._core._tasks import move_on_after as move_on_after
+from ._core._tempfile import NamedTemporaryFile as NamedTemporaryFile
+from ._core._tempfile import SpooledTemporaryFile as SpooledTemporaryFile
+from ._core._tempfile import TemporaryDirectory as TemporaryDirectory
+from ._core._tempfile import TemporaryFile as TemporaryFile
+from ._core._tempfile import gettempdir as gettempdir
+from ._core._tempfile import gettempdirb as gettempdirb
+from ._core._tempfile import gettempprefix as gettempprefix
+from ._core._tempfile import gettempprefixb as gettempprefixb
+from ._core._tempfile import mkdtemp as mkdtemp
+from ._core._tempfile import mkstemp as mkstemp
 from ._core._testing import TaskInfo as TaskInfo
 from ._core._testing import get_current_task as get_current_task
 from ._core._testing import get_running_tasks as get_running_tasks

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -67,8 +67,6 @@ from ._core._tempfile import TemporaryDirectory as TemporaryDirectory
 from ._core._tempfile import TemporaryFile as TemporaryFile
 from ._core._tempfile import gettempdir as gettempdir
 from ._core._tempfile import gettempdirb as gettempdirb
-from ._core._tempfile import gettempprefix as gettempprefix
-from ._core._tempfile import gettempprefixb as gettempprefixb
 from ._core._tempfile import mkdtemp as mkdtemp
 from ._core._tempfile import mkstemp as mkstemp
 from ._core._testing import TaskInfo as TaskInfo

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -241,6 +241,9 @@ class Path:
     * :meth:`~pathlib.Path.relative_to` (the ``walk_up`` parameter is only available on
       Python 3.12 or later)
     * :meth:`~pathlib.Path.walk` (available on Python 3.12 or later)
+    * ``__open_rb__`` (available on Python 3.14 or later)
+    * ``__open_wb__`` (available on Python 3.14 or later)
+    * ``info`` (available on Python 3.14 or later)
 
     Any methods that do disk I/O need to be awaited on. These methods are:
 
@@ -377,6 +380,20 @@ class Path:
     @property
     def stem(self) -> str:
         return self._path.stem
+
+    if sys.version_info >= (3, 14):
+
+        @property
+        def __open_rb__(self) -> Any:
+            return self._path.__open_rb__
+
+        @property
+        def __open_wb__(self) -> Any:
+            return self._path.__open_wb__
+
+        @property
+        def info(self) -> Any:
+            return self._path.info
 
     async def absolute(self) -> Path:
         path = await to_thread.run_sync(self._path.absolute)

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -242,9 +242,6 @@ class Path:
     * :meth:`~pathlib.PurePath.relative_to` (the ``walk_up`` parameter is only available
       on Python 3.12 or later)
     * :meth:`~pathlib.Path.walk` (available on Python 3.12 or later)
-    * ``__open_rb__`` (available on Python 3.14 or later)
-    * ``__open_wb__`` (available on Python 3.14 or later)
-    * ``info`` (available on Python 3.14 or later)
 
     Any methods that do disk I/O need to be awaited on. These methods are:
 
@@ -381,20 +378,6 @@ class Path:
     @property
     def stem(self) -> str:
         return self._path.stem
-
-    if sys.version_info >= (3, 14):
-
-        @property
-        def __open_rb__(self) -> Any:
-            return self._path.__open_rb__
-
-        @property
-        def __open_wb__(self) -> Any:
-            return self._path.__open_wb__
-
-        @property
-        def info(self) -> Any:
-            return self._path.info
 
     async def absolute(self) -> Path:
         path = await to_thread.run_sync(self._path.absolute)

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -291,10 +291,10 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
         }
         self._max_size = max_size
         if "b" in mode:
-            super().__init__(BytesIO())
+            super().__init__(BytesIO())  # type: ignore[arg-type]
         else:
             super().__init__(
-                TextIOWrapper(
+                TextIOWrapper(  # type: ignore[arg-type]
                     BytesIO(),
                     encoding=encoding,
                     errors=errors,
@@ -337,7 +337,7 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
         if not self._rolled:
             return self._fp.read(size)
 
-        return await super().read(size)
+        return await super().read(size)  # type: ignore[return-value]
 
     async def read1(self: SpooledTemporaryFile[bytes], size: int = -1) -> bytes:
         if not self._rolled:
@@ -349,13 +349,13 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
         if not self._rolled:
             return self._fp.readline()
 
-        return await super().readline()
+        return await super().readline()  # type: ignore[return-value]
 
     async def readlines(self) -> list[AnyStr]:
         if not self._rolled:
             return self._fp.readlines()
 
-        return await super().readlines()
+        return await super().readlines()  # type: ignore[return-value]
 
     async def readinto(self: SpooledTemporaryFile[bytes], b: WriteableBuffer) -> int:
         if not self._rolled:
@@ -388,11 +388,11 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
         return await super().truncate(size)
 
     @overload
-    async def write(self: SpooledTemporaryFile[bytes], s: ReadableBuffer) -> int: ...
+    async def write(self: SpooledTemporaryFile[bytes], b: ReadableBuffer) -> int: ...
     @overload
-    async def write(self: SpooledTemporaryFile[str], s: str) -> int: ...
+    async def write(self: SpooledTemporaryFile[str], b: str) -> int: ...
 
-    async def write(self, s: str | ReadableBuffer) -> int:
+    async def write(self, b: ReadableBuffer | str) -> int:
         """
         Asynchronously write data to the spooled temporary file.
 
@@ -405,11 +405,11 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
 
         """
         if not self._rolled:
-            result = self._fp.write(s)
+            result = self._fp.write(b)
             await self._check()
             return result
 
-        return await super().write(s)
+        return await super().write(b)  # type: ignore[misc]
 
     @overload
     async def writelines(
@@ -436,7 +436,7 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
             await self._check()
             return result
 
-        return await super().writelines(lines)
+        return await super().writelines(lines)  # type: ignore[misc]
 
 
 class TemporaryDirectory(Generic[AnyStr]):

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -4,7 +4,7 @@ import sys
 import tempfile
 from functools import partial
 from types import TracebackType
-from typing import Any, AnyStr, Callable, Generic, cast
+from typing import Any, AnyStr, Callable, Generic, cast, overload
 
 from .. import to_thread
 from .._core._fileio import AsyncFile
@@ -273,6 +273,24 @@ class TemporaryDirectory(Generic[AnyStr]):
             await to_thread.run_sync(self._tempdir.cleanup)
 
 
+@overload
+async def mkstemp(
+    suffix: str | None = None,
+    prefix: str | None = None,
+    dir: str | None = None,
+    text: bool = False,
+) -> tuple[int, str]: ...
+
+
+@overload
+async def mkstemp(
+    suffix: bytes | None = None,
+    prefix: bytes | None = None,
+    dir: bytes | None = None,
+    text: bool = False,
+) -> tuple[int, bytes]: ...
+
+
 async def mkstemp(
     suffix: AnyStr | None = None,
     prefix: AnyStr | None = None,
@@ -280,6 +298,22 @@ async def mkstemp(
     text: bool = False,
 ) -> tuple[int, str | bytes]:
     return await to_thread.run_sync(lambda: tempfile.mkstemp(suffix, prefix, dir, text))
+
+
+@overload
+async def mkdtemp(
+    suffix: str | None = None,
+    prefix: str | None = None,
+    dir: str | None = None,
+) -> str: ...
+
+
+@overload
+async def mkdtemp(
+    suffix: bytes | None = None,
+    prefix: bytes | None = None,
+    dir: bytes | None = None,
+) -> bytes: ...
 
 
 async def mkdtemp(

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import sys
 import tempfile
 from functools import partial
-from os import PathLike
 from types import TracebackType
 from typing import Any, AnyStr, Callable, Generic, cast
 
-from .. import AsyncFile, to_thread
+from .. import to_thread
+from .._core._fileio import AsyncFile
 
 
 class TemporaryFile(Generic[AnyStr]):
@@ -68,9 +68,9 @@ class NamedTemporaryFile(Generic[AnyStr]):
         buffering: int = -1,
         encoding: str | None = None,
         newline: str | None = None,
-        suffix: (str | bytes) | None = None,
-        prefix: (str | bytes) | None = None,
-        dir: (str | bytes | PathLike[str]) | None = None,
+        suffix: AnyStr | None = None,
+        prefix: AnyStr | None = None,
+        dir: AnyStr | None = None,
         delete: bool = True,
         *,
         errors: str | None = None,
@@ -80,9 +80,9 @@ class NamedTemporaryFile(Generic[AnyStr]):
         self.buffering = buffering
         self.encoding = encoding
         self.newline = newline
-        self.suffix = suffix
-        self.prefix = prefix
-        self.dir = dir
+        self.suffix: AnyStr | None = suffix
+        self.prefix: AnyStr | None = prefix
+        self.dir: AnyStr | None = dir
         self.delete = delete
         self.errors = errors
         self.delete_on_close = delete_on_close
@@ -262,14 +262,6 @@ async def mkdtemp(
     dir: AnyStr | None = None,
 ) -> str | bytes:
     return await to_thread.run_sync(lambda: tempfile.mkdtemp(suffix, prefix, dir))
-
-
-async def gettempprefix() -> str:
-    return await to_thread.run_sync(tempfile.gettempprefix)
-
-
-async def gettempprefixb() -> bytes:
-    return await to_thread.run_sync(tempfile.gettempprefixb)
 
 
 async def gettempdir() -> str:

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -208,8 +208,8 @@ class SpooledTemporaryFile(Generic[AnyStr]):
                 self._fp.rollover()
 
             return result
-        else:
-            return await to_thread.run_sync(self._fp.writelines, lines)
+
+        return await to_thread.run_sync(self._fp.writelines, lines)
 
     async def __aexit__(
         self,

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -16,6 +16,7 @@ from typing import (
 
 from .. import to_thread
 from .._core._fileio import AsyncFile
+from ..lowlevel import checkpoint_if_cancelled
 
 if TYPE_CHECKING:
     from _typeshed import OpenBinaryMode, OpenTextMode, ReadableBuffer, WriteableBuffer
@@ -335,54 +336,63 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
 
     async def read(self, size: int = -1) -> AnyStr:
         if not self._rolled:
+            await checkpoint_if_cancelled()
             return self._fp.read(size)
 
         return await super().read(size)  # type: ignore[return-value]
 
     async def read1(self: SpooledTemporaryFile[bytes], size: int = -1) -> bytes:
         if not self._rolled:
+            await checkpoint_if_cancelled()
             return self._fp.read1(size)
 
         return await super().read1(size)
 
     async def readline(self) -> AnyStr:
         if not self._rolled:
+            await checkpoint_if_cancelled()
             return self._fp.readline()
 
         return await super().readline()  # type: ignore[return-value]
 
     async def readlines(self) -> list[AnyStr]:
         if not self._rolled:
+            await checkpoint_if_cancelled()
             return self._fp.readlines()
 
         return await super().readlines()  # type: ignore[return-value]
 
     async def readinto(self: SpooledTemporaryFile[bytes], b: WriteableBuffer) -> int:
         if not self._rolled:
+            await checkpoint_if_cancelled()
             self._fp.readinto(b)
 
         return await super().readinto(b)
 
     async def readinto1(self: SpooledTemporaryFile[bytes], b: WriteableBuffer) -> int:
         if not self._rolled:
+            await checkpoint_if_cancelled()
             self._fp.readinto(b)
 
         return await super().readinto1(b)
 
     async def seek(self, offset: int, whence: int | None = os.SEEK_SET) -> int:
         if not self._rolled:
+            await checkpoint_if_cancelled()
             return self._fp.seek(offset, whence)
 
         return await super().seek(offset, whence)
 
     async def tell(self) -> int:
         if not self._rolled:
+            await checkpoint_if_cancelled()
             return self._fp.tell()
 
         return await super().tell()
 
     async def truncate(self, size: int | None = None) -> int:
         if not self._rolled:
+            await checkpoint_if_cancelled()
             return self._fp.truncate(size)
 
         return await super().truncate(size)
@@ -405,6 +415,7 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
 
         """
         if not self._rolled:
+            await checkpoint_if_cancelled()
             result = self._fp.write(b)
             await self._check()
             return result
@@ -432,6 +443,7 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
 
         """
         if not self._rolled:
+            await checkpoint_if_cancelled()
             result = self._fp.writelines(lines)
             await self._check()
             return result
@@ -540,6 +552,7 @@ async def mkstemp(
     :param dir: Directory in which the temporary file is created.
     :param text: Whether the file is opened in text mode.
     :return: A tuple containing the file descriptor and the file name.
+
     """
     return await to_thread.run_sync(tempfile.mkstemp, suffix, prefix, dir, text)
 
@@ -574,6 +587,7 @@ async def mkdtemp(
     :param prefix: Prefix to be added to the directory name.
     :param dir: Parent directory where the temporary directory is created.
     :return: The path of the created temporary directory.
+
     """
     return await to_thread.run_sync(tempfile.mkdtemp, suffix, prefix, dir)
 
@@ -585,6 +599,7 @@ async def gettempdir() -> str:
     This function wraps `tempfile.gettempdir` and executes it in a background thread.
 
     :return: The path of the temporary directory as a string.
+
     """
     return await to_thread.run_sync(tempfile.gettempdir)
 
@@ -596,5 +611,6 @@ async def gettempdirb() -> bytes:
     This function wraps `tempfile.gettempdirb` and executes it in a background thread.
 
     :return: The path of the temporary directory as bytes.
+
     """
     return await to_thread.run_sync(tempfile.gettempdirb)

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+from functools import partial
+from os import PathLike
+from types import TracebackType
+from typing import Any, AnyStr, Callable, Generic, cast
+
+from .. import AsyncFile, to_thread
+
+
+class TemporaryFile(Generic[AnyStr]):
+    def __init__(
+        self,
+        mode: str = "w+b",
+        buffering: int = -1,
+        encoding: str | None = None,
+        newline: str | None = None,
+        suffix: AnyStr | None = None,
+        prefix: AnyStr | None = None,
+        dir: AnyStr | None = None,
+        *,
+        errors: str | None = None,
+    ) -> None:
+        self.mode = mode
+        self.buffering = buffering
+        self.encoding = encoding
+        self.newline = newline
+        self.suffix: AnyStr | None = suffix
+        self.prefix: AnyStr | None = prefix
+        self.dir: AnyStr | None = dir
+        self.errors = errors
+
+        self._async_file: AsyncFile | None = None
+
+    async def __aenter__(self) -> AsyncFile:
+        fp = await to_thread.run_sync(
+            lambda: tempfile.TemporaryFile(
+                self.mode,
+                self.buffering,
+                self.encoding,
+                self.newline,
+                self.suffix,
+                self.prefix,
+                self.dir,
+                errors=self.errors,
+            )
+        )
+        self._async_file = AsyncFile(fp)
+        return self._async_file
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        if self._async_file is not None:
+            await self._async_file.aclose()
+            self._async_file = None
+
+
+class NamedTemporaryFile(Generic[AnyStr]):
+    def __init__(
+        self,
+        mode: str = "w+b",
+        buffering: int = -1,
+        encoding: str | None = None,
+        newline: str | None = None,
+        suffix: (str | bytes) | None = None,
+        prefix: (str | bytes) | None = None,
+        dir: (str | bytes | PathLike[str]) | None = None,
+        delete: bool = True,
+        *,
+        errors: str | None = None,
+        delete_on_close: bool = True,
+    ) -> None:
+        self.mode = mode
+        self.buffering = buffering
+        self.encoding = encoding
+        self.newline = newline
+        self.suffix = suffix
+        self.prefix = prefix
+        self.dir = dir
+        self.delete = delete
+        self.errors = errors
+        self.delete_on_close = delete_on_close
+
+        self._async_file: AsyncFile | None = None
+
+    async def __aenter__(self) -> AsyncFile[AnyStr]:
+        params: dict[str, Any] = {
+            "mode": self.mode,
+            "buffering": self.buffering,
+            "encoding": self.encoding,
+            "newline": self.newline,
+            "suffix": self.suffix,
+            "prefix": self.prefix,
+            "dir": self.dir,
+            "delete": self.delete,
+            "errors": self.errors,
+        }
+        if sys.version_info >= (3, 12):
+            params["delete_on_close"] = self.delete_on_close
+
+        fp = await to_thread.run_sync(lambda: tempfile.NamedTemporaryFile(**params))
+
+        self._async_file = AsyncFile(fp)
+        return self._async_file
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        if self._async_file is not None:
+            await self._async_file.aclose()
+            self._async_file = None
+
+
+class SpooledTemporaryFile(Generic[AnyStr]):
+    def __init__(
+        self,
+        max_size: int = 0,
+        mode: str = "w+b",
+        buffering: int = -1,
+        encoding: str | None = None,
+        newline: str | None = None,
+        suffix: AnyStr | None = None,
+        prefix: AnyStr | None = None,
+        dir: AnyStr | None = None,
+        *,
+        errors: str | None = None,
+    ) -> None:
+        self.max_size = max_size
+        self.mode = mode
+        self.buffering = buffering
+        self.encoding = encoding
+        self.newline = newline
+        self.suffix: AnyStr | None = suffix
+        self.prefix: AnyStr | None = prefix
+        self.dir: AnyStr | None = dir
+        self.errors = errors
+
+        self._async_file: AsyncFile | None = None
+
+    async def __aenter__(self) -> SpooledTemporaryFile:
+        fp = await to_thread.run_sync(
+            partial(
+                tempfile.SpooledTemporaryFile,
+                self.max_size,
+                self.mode,
+                self.buffering,
+                self.encoding,
+                self.newline,
+                self.suffix,
+                self.prefix,
+                self.dir,
+                errors=self.errors,
+            )
+        )
+        self._async_file = AsyncFile(fp)
+        return self
+
+    async def rollover(self) -> None:
+        if self._async_file is None:
+            raise RuntimeError("Internal file is not initialized.")
+        await to_thread.run_sync(cast(Callable[[], None], self._async_file.rollover))
+
+    @property
+    def closed(self) -> bool:
+        if self._async_file is not None:
+            try:
+                return bool(self._async_file.closed)
+            except AttributeError:
+                f = getattr(self._async_file, "_f", None)
+                if f is None:
+                    return True
+                return bool(f.closed)
+        return True
+
+    def __getattr__(self, attr: str) -> Any:
+        if self._async_file is not None:
+            return getattr(self._async_file, attr)
+        raise AttributeError(f"{self.__class__.__name__} has no attribute {attr}")
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        if self._async_file is not None:
+            await self._async_file.aclose()
+            self._async_file = None
+
+
+class TemporaryDirectory(Generic[AnyStr]):
+    def __init__(
+        self,
+        suffix: AnyStr | None = None,
+        prefix: AnyStr | None = None,
+        dir: AnyStr | None = None,
+        *,
+        ignore_cleanup_errors: bool = False,
+        delete: bool = True,
+    ) -> None:
+        self.suffix: AnyStr | None = suffix
+        self.prefix: AnyStr | None = prefix
+        self.dir: AnyStr | None = dir
+        self.ignore_cleanup_errors = ignore_cleanup_errors
+        self.delete = delete
+
+        self._tempdir: tempfile.TemporaryDirectory | None = None
+
+    async def __aenter__(self) -> str:
+        params: dict[str, Any] = {
+            "suffix": self.suffix,
+            "prefix": self.prefix,
+            "dir": self.dir,
+        }
+        if sys.version_info >= (3, 10):
+            params["ignore_cleanup_errors"] = self.ignore_cleanup_errors
+        if sys.version_info >= (3, 12):
+            params["delete"] = self.delete
+
+        self._tempdir = await to_thread.run_sync(
+            lambda: tempfile.TemporaryDirectory(**params)
+        )
+        return await to_thread.run_sync(self._tempdir.__enter__)
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        if self._tempdir is not None:
+            await to_thread.run_sync(
+                self._tempdir.__exit__, exc_type, exc_value, traceback
+            )
+
+    async def cleanup(self) -> None:
+        if self._tempdir is not None:
+            await to_thread.run_sync(self._tempdir.cleanup)
+
+
+async def mkstemp(
+    suffix: AnyStr | None = None,
+    prefix: AnyStr | None = None,
+    dir: AnyStr | None = None,
+    text: bool = False,
+) -> tuple[int, str | bytes]:
+    return await to_thread.run_sync(lambda: tempfile.mkstemp(suffix, prefix, dir, text))
+
+
+async def mkdtemp(
+    suffix: AnyStr | None = None,
+    prefix: AnyStr | None = None,
+    dir: AnyStr | None = None,
+) -> str | bytes:
+    return await to_thread.run_sync(lambda: tempfile.mkdtemp(suffix, prefix, dir))
+
+
+async def gettempprefix() -> str:
+    return await to_thread.run_sync(tempfile.gettempprefix)
+
+
+async def gettempprefixb() -> bytes:
+    return await to_thread.run_sync(tempfile.gettempprefixb)
+
+
+async def gettempdir() -> str:
+    return await to_thread.run_sync(tempfile.gettempdir)
+
+
+async def gettempdirb() -> bytes:
+    return await to_thread.run_sync(tempfile.gettempdirb)

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -297,7 +297,7 @@ async def mkstemp(
     dir: AnyStr | None = None,
     text: bool = False,
 ) -> tuple[int, str | bytes]:
-    return await to_thread.run_sync(lambda: tempfile.mkstemp(suffix, prefix, dir, text))
+    return await to_thread.run_sync(tempfile.mkstemp, suffix, prefix, dir, text)
 
 
 @overload

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -195,8 +195,8 @@ class SpooledTemporaryFile(Generic[AnyStr]):
                 self._fp.rollover()
 
             return result
-        else:
-            return await to_thread.run_sync(self._fp.write, s)
+
+        return await to_thread.run_sync(self._fp.write, s)
 
     async def writelines(self, lines: Any) -> None:
         if self._fp is None:

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -321,7 +321,7 @@ async def mkdtemp(
     prefix: AnyStr | None = None,
     dir: AnyStr | None = None,
 ) -> str | bytes:
-    return await to_thread.run_sync(lambda: tempfile.mkdtemp(suffix, prefix, dir))
+    return await to_thread.run_sync(tempfile.mkdtemp, suffix, prefix, dir)
 
 
 async def gettempdir() -> str:

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -339,7 +339,7 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
 
         return await super().read(size)
 
-    async def read1(self: AsyncFile[bytes], size: int = -1) -> bytes:
+    async def read1(self: SpooledTemporaryFile[bytes], size: int = -1) -> bytes:
         if not self._rolled:
             return self._fp.read1(size)
 
@@ -357,13 +357,13 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
 
         return await super().readlines()
 
-    async def readinto(self: AsyncFile[bytes], b: WriteableBuffer) -> int:
+    async def readinto(self: SpooledTemporaryFile[bytes], b: WriteableBuffer) -> int:
         if not self._rolled:
             self._fp.readinto(b)
 
         return await super().readinto(b)
 
-    async def readinto1(self: AsyncFile[bytes], b: WriteableBuffer) -> int:
+    async def readinto1(self: SpooledTemporaryFile[bytes], b: WriteableBuffer) -> int:
         if not self._rolled:
             self._fp.readinto(b)
 

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -63,9 +63,7 @@ class TestSpooledTemporaryFile:
         async with SpooledTemporaryFile[bytes](max_size=10) as stf:
             await stf.write(data)
             await stf.seek(0)
-            result = await stf.read()
-
-            assert result == data
+            assert await stf.read() == data
 
             pos = await stf.tell()
             assert isinstance(pos, int)

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -14,8 +14,6 @@ from anyio import (
     TemporaryFile,
     gettempdir,
     gettempdirb,
-    gettempprefix,
-    gettempprefixb,
     mkdtemp,
     mkstemp,
     to_thread,
@@ -24,162 +22,159 @@ from anyio import (
 pytestmark = pytest.mark.anyio
 
 
-@pytest.mark.anyio
-async def test_temporary_file() -> None:
-    data = b"temporary file data"
-    async with TemporaryFile[bytes]() as af:
-        await af.write(data)
-        await af.seek(0)
-        result = await af.read()
-    assert result == data
-    assert af.closed
+class TestTemporaryFile:
+    async def test_temporary_file(self) -> None:
+        data = b"temporary file data"
+        async with TemporaryFile[bytes]() as af:
+            await af.write(data)
+            await af.seek(0)
+            result = await af.read()
 
-
-@pytest.mark.anyio
-async def test_named_temporary_file() -> None:
-    data = b"named temporary file data"
-    async with NamedTemporaryFile[bytes]() as af:
-        filename: str = str(af.name)
-        assert os.path.exists(filename)
-        await af.write(data)
-        await af.seek(0)
-        result = await af.read()
-    assert result == data
-    assert not os.path.exists(filename)
-
-
-@pytest.mark.anyio
-async def test_spooled_temporary_file_io_and_rollover() -> None:
-    data = b"spooled temporary file data" * 3
-    async with SpooledTemporaryFile[bytes](max_size=10) as stf:
-        await stf.write(data)
-        await stf.seek(0)
-        result = await stf.read()
         assert result == data
-        pos = await stf.tell()
-        assert isinstance(pos, int)
-        await stf.rollover()
-        assert not stf.closed
-    assert stf.closed
+
+        assert af.closed
 
 
-@pytest.mark.anyio
-async def test_spooled_temporary_file_error_conditions() -> None:
-    stf = SpooledTemporaryFile[bytes]()
-    with pytest.raises(RuntimeError):
-        await stf.rollover()
-    with pytest.raises(AttributeError):
-        _ = stf.nonexistent_attribute
+class TestNamedTemporaryFile:
+    async def test_named_temporary_file(self) -> None:
+        data = b"named temporary file data"
+        async with NamedTemporaryFile[bytes]() as af:
+            filename = str(af.name)
+            assert os.path.exists(filename)
+
+            await af.write(data)
+            await af.seek(0)
+            result = await af.read()
+
+        assert result == data
+
+        assert not os.path.exists(filename)
+
+    async def test_exception_handling(self) -> None:
+        async with NamedTemporaryFile[bytes]() as af:
+            filename = str(af.name)
+            assert os.path.exists(filename)
+
+        assert not os.path.exists(filename)
+
+        with pytest.raises(ValueError):
+            await af.write(b"should fail")
 
 
-@pytest.mark.anyio
-async def test_temporary_directory_context_manager() -> None:
-    async with TemporaryDirectory() as td:
-        td_path = pathlib.Path(td)
-        assert td_path.exists() and td_path.is_dir()
-        file_path = td_path / "test.txt"
-        file_path.write_text("temp dir test", encoding="utf-8")
-        assert file_path.exists()
-    assert not td_path.exists()
+class TestSpooledTemporaryFile:
+    async def test_io_and_rollover(self) -> None:
+        data = b"spooled temporary file data" * 3
+        async with SpooledTemporaryFile[bytes](max_size=10) as stf:
+            await stf.write(data)
+            await stf.seek(0)
+            result = await stf.read()
+
+            assert result == data
+
+            pos = await stf.tell()
+            assert isinstance(pos, int)
+
+            await stf.rollover()
+            assert not stf.closed
+
+        assert stf.closed
+
+    async def test_error_conditions(self) -> None:
+        stf = SpooledTemporaryFile[bytes]()
+
+        with pytest.raises(RuntimeError):
+            await stf.rollover()
+
+        with pytest.raises(AttributeError):
+            _ = stf.nonexistent_attribute
+
+    async def test_rollover_handling(self) -> None:
+        async with SpooledTemporaryFile[bytes](max_size=10) as stf:
+            await stf.write(b"1234567890")
+            await stf.rollover()
+            assert not stf.closed
+
+            await stf.write(b"more data")
+            await stf.seek(0)
+            result = await stf.read()
+
+            assert result == b"1234567890more data"
+
+    async def test_closed_state(self) -> None:
+        async with SpooledTemporaryFile[bytes](max_size=10) as stf:
+            assert not stf.closed
+
+        assert stf.closed
 
 
-@pytest.mark.anyio
-async def test_temporary_directory_cleanup_method() -> None:
-    td = TemporaryDirectory()
-    td_str = await td.__aenter__()
-    td_path = pathlib.Path(td_str)
-    file_path = td_path / "file.txt"
-    file_path.write_text("cleanup test", encoding="utf-8")
-    await td.cleanup()
-    assert not td_path.exists()
+class TestTemporaryDirectory:
+    async def test_context_manager(self) -> None:
+        async with TemporaryDirectory() as td:
+            td_path = pathlib.Path(td)
+            assert td_path.exists() and td_path.is_dir()
+
+            file_path = td_path / "test.txt"
+            file_path.write_text("temp dir test", encoding="utf-8")
+            assert file_path.exists()
+
+        assert not td_path.exists()
+
+    async def test_cleanup_method(self) -> None:
+        td = TemporaryDirectory()
+        td_str = await td.__aenter__()
+        td_path = pathlib.Path(td_str)
+
+        file_path = td_path / "file.txt"
+        file_path.write_text("cleanup test", encoding="utf-8")
+
+        await td.cleanup()
+        assert not td_path.exists()
+
+    async def test_exception_handling(self) -> None:
+        async with TemporaryDirectory() as td:
+            td_path = pathlib.Path(td)
+            assert td_path.exists() and td_path.is_dir()
+
+        assert not td_path.exists()
+
+        with pytest.raises(FileNotFoundError):
+            (td_path / "nonexistent.txt").write_text("should fail", encoding="utf-8")
 
 
-@pytest.mark.anyio
 async def test_mkstemp() -> None:
-    fd, path_ = await mkstemp(suffix=".txt", prefix="mkstemp_", text=True)
+    fd, path = await mkstemp(suffix=".txt", prefix="mkstemp_", text=True)
     assert isinstance(fd, int)
-    assert isinstance(path_, str)
+    assert isinstance(path, str)
 
-    def write_file() -> None:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write("mkstemp")
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write("mkstemp")
 
-    await to_thread.run_sync(write_file)
+    content = await to_thread.run_sync(
+        lambda: pathlib.Path(path).read_text(encoding="utf-8")
+    )
 
-    def read_file() -> str:
-        with open(path_, encoding="utf-8") as f:
-            return f.read()
-
-    content = await to_thread.run_sync(read_file)
     assert content == "mkstemp"
-    await to_thread.run_sync(lambda: os.remove(path_))
+
+    await to_thread.run_sync(lambda: os.remove(path))
 
 
-@pytest.mark.anyio
 async def test_mkdtemp() -> None:
     d = await mkdtemp(prefix="mkdtemp_")
+
     if isinstance(d, bytes):
         dp = pathlib.Path(os.fsdecode(d))
     else:
         dp = pathlib.Path(d)
+
     assert dp.exists() and dp.is_dir()
-    await to_thread.run_sync(lambda: shutil.rmtree(dp))
+
+    shutil.rmtree(dp)
     assert not dp.exists()
 
 
-@pytest.mark.anyio
 async def test_gettemp_functions() -> None:
-    pref = await gettempprefix()
-    prefb = await gettempprefixb()
     tdir = await gettempdir()
     tdirb = await gettempdirb()
-    assert isinstance(pref, str)
-    assert isinstance(prefb, bytes)
-    assert isinstance(tdir, str)
-    assert isinstance(tdirb, bytes)
-    assert pref == tempfile.gettempprefix()
-    assert prefb == tempfile.gettempprefixb()
+
     assert tdir == tempfile.gettempdir()
     assert tdirb == tempfile.gettempdirb()
-
-
-@pytest.mark.anyio
-async def test_named_temporary_file_exception_handling() -> None:
-    async with NamedTemporaryFile[bytes]() as af:
-        filename = str(af.name)
-        assert os.path.exists(filename)
-
-    assert not os.path.exists(filename)
-    with pytest.raises(ValueError):
-        await af.write(b"should fail")
-
-
-@pytest.mark.anyio
-async def test_temporary_directory_exception_handling() -> None:
-    async with TemporaryDirectory() as td:
-        td_path = pathlib.Path(td)
-        assert td_path.exists() and td_path.is_dir()
-
-    assert not td_path.exists()
-    with pytest.raises(FileNotFoundError):
-        (td_path / "nonexistent.txt").write_text("should fail", encoding="utf-8")
-
-
-@pytest.mark.anyio
-async def test_spooled_temporary_file_rollover_handling() -> None:
-    async with SpooledTemporaryFile[bytes](max_size=10) as stf:
-        await stf.write(b"1234567890")
-        await stf.rollover()
-        assert not stf.closed
-        await stf.write(b"more data")
-        await stf.seek(0)
-        result = await stf.read()
-        assert result == b"1234567890more data"
-
-
-@pytest.mark.anyio
-async def test_spooled_temporary_file_closed_state() -> None:
-    async with SpooledTemporaryFile[bytes](max_size=10) as stf:
-        assert not stf.closed
-
-    assert stf.closed

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -16,7 +16,6 @@ from anyio import (
     gettempdirb,
     mkdtemp,
     mkstemp,
-    to_thread,
 )
 
 pytestmark = pytest.mark.anyio
@@ -31,7 +30,6 @@ class TestTemporaryFile:
             result = await af.read()
 
         assert result == data
-
         assert af.closed
 
 
@@ -47,7 +45,6 @@ class TestNamedTemporaryFile:
             result = await af.read()
 
         assert result == data
-
         assert not os.path.exists(filename)
 
     async def test_exception_handling(self) -> None:
@@ -149,13 +146,12 @@ async def test_mkstemp() -> None:
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         f.write("mkstemp")
 
-    content = await to_thread.run_sync(
-        lambda: pathlib.Path(path).read_text(encoding="utf-8")
-    )
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
 
     assert content == "mkstemp"
 
-    await to_thread.run_sync(lambda: os.remove(path))
+    os.remove(path)
 
 
 async def test_mkdtemp() -> None:

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -37,7 +37,7 @@ class TestNamedTemporaryFile:
     async def test_named_temporary_file(self) -> None:
         data = b"named temporary file data"
         async with NamedTemporaryFile[bytes]() as af:
-            filename = str(af.name)
+            filename = af.name
             assert os.path.exists(filename)
 
             await af.write(data)

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -98,8 +98,7 @@ class TestSpooledTemporaryFile:
                 return original_rollover()
 
             stf._fp.rollover = fake_rollover
-            n1 = await stf.write(b"12345")
-            assert n1 == 5
+            assert await stf.write(b"12345") == 5
             assert not rollover_called
             await stf.write(b"67890X")
             assert rollover_called

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -76,15 +76,6 @@ class TestSpooledTemporaryFile:
 
         assert stf.closed
 
-    async def test_error_conditions(self) -> None:
-        stf = SpooledTemporaryFile[bytes]()
-
-        with pytest.raises(RuntimeError):
-            await stf.rollover()
-
-        with pytest.raises(AttributeError):
-            _ = stf.nonexistent_attribute
-
     async def test_rollover_handling(self) -> None:
         async with SpooledTemporaryFile[bytes](max_size=10) as stf:
             await stf.write(b"1234567890")

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -42,9 +42,8 @@ class TestNamedTemporaryFile:
 
             await af.write(data)
             await af.seek(0)
-            result = await af.read()
+            assert await af.read() == data
 
-        assert result == data
         assert not os.path.exists(filename)
 
     async def test_exception_handling(self) -> None:

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import tempfile
+
+import pytest
+
+from anyio import (
+    NamedTemporaryFile,
+    SpooledTemporaryFile,
+    TemporaryDirectory,
+    TemporaryFile,
+    gettempdir,
+    gettempdirb,
+    gettempprefix,
+    gettempprefixb,
+    mkdtemp,
+    mkstemp,
+    to_thread,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.mark.anyio
+async def test_temporary_file() -> None:
+    data = b"temporary file data"
+    async with TemporaryFile[bytes]() as af:
+        await af.write(data)
+        await af.seek(0)
+        result = await af.read()
+    assert result == data
+    assert af.closed
+
+
+@pytest.mark.anyio
+async def test_named_temporary_file() -> None:
+    data = b"named temporary file data"
+    async with NamedTemporaryFile[bytes]() as af:
+        filename: str = str(af.name)
+        assert os.path.exists(filename)
+        await af.write(data)
+        await af.seek(0)
+        result = await af.read()
+    assert result == data
+    assert not os.path.exists(filename)
+
+
+@pytest.mark.anyio
+async def test_spooled_temporary_file_io_and_rollover() -> None:
+    data = b"spooled temporary file data" * 3
+    async with SpooledTemporaryFile[bytes](max_size=10) as stf:
+        await stf.write(data)
+        await stf.seek(0)
+        result = await stf.read()
+        assert result == data
+        pos = await stf.tell()
+        assert isinstance(pos, int)
+        await stf.rollover()
+        assert not stf.closed
+    assert stf.closed
+
+
+@pytest.mark.anyio
+async def test_spooled_temporary_file_error_conditions() -> None:
+    stf = SpooledTemporaryFile[bytes]()
+    with pytest.raises(RuntimeError):
+        await stf.rollover()
+    with pytest.raises(AttributeError):
+        _ = stf.nonexistent_attribute
+
+
+@pytest.mark.anyio
+async def test_temporary_directory_context_manager() -> None:
+    async with TemporaryDirectory() as td:
+        td_path = pathlib.Path(td)
+        assert td_path.exists() and td_path.is_dir()
+        file_path = td_path / "test.txt"
+        file_path.write_text("temp dir test", encoding="utf-8")
+        assert file_path.exists()
+    assert not td_path.exists()
+
+
+@pytest.mark.anyio
+async def test_temporary_directory_cleanup_method() -> None:
+    td = TemporaryDirectory()
+    td_str = await td.__aenter__()
+    td_path = pathlib.Path(td_str)
+    file_path = td_path / "file.txt"
+    file_path.write_text("cleanup test", encoding="utf-8")
+    await td.cleanup()
+    assert not td_path.exists()
+
+
+@pytest.mark.anyio
+async def test_mkstemp() -> None:
+    fd, path_ = await mkstemp(suffix=".txt", prefix="mkstemp_", text=True)
+    assert isinstance(fd, int)
+    assert isinstance(path_, str)
+
+    def write_file() -> None:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write("mkstemp")
+
+    await to_thread.run_sync(write_file)
+
+    def read_file() -> str:
+        with open(path_, encoding="utf-8") as f:
+            return f.read()
+
+    content = await to_thread.run_sync(read_file)
+    assert content == "mkstemp"
+    await to_thread.run_sync(lambda: os.remove(path_))
+
+
+@pytest.mark.anyio
+async def test_mkdtemp() -> None:
+    d = await mkdtemp(prefix="mkdtemp_")
+    if isinstance(d, bytes):
+        dp = pathlib.Path(os.fsdecode(d))
+    else:
+        dp = pathlib.Path(d)
+    assert dp.exists() and dp.is_dir()
+    await to_thread.run_sync(lambda: shutil.rmtree(dp))
+    assert not dp.exists()
+
+
+@pytest.mark.anyio
+async def test_gettemp_functions() -> None:
+    pref = await gettempprefix()
+    prefb = await gettempprefixb()
+    tdir = await gettempdir()
+    tdirb = await gettempdirb()
+    assert isinstance(pref, str)
+    assert isinstance(prefb, bytes)
+    assert isinstance(tdir, str)
+    assert isinstance(tdirb, bytes)
+    assert pref == tempfile.gettempprefix()
+    assert prefb == tempfile.gettempprefixb()
+    assert tdir == tempfile.gettempdir()
+    assert tdirb == tempfile.gettempdirb()
+
+
+@pytest.mark.anyio
+async def test_named_temporary_file_exception_handling() -> None:
+    async with NamedTemporaryFile[bytes]() as af:
+        filename = str(af.name)
+        assert os.path.exists(filename)
+
+    assert not os.path.exists(filename)
+    with pytest.raises(ValueError):
+        await af.write(b"should fail")
+
+
+@pytest.mark.anyio
+async def test_temporary_directory_exception_handling() -> None:
+    async with TemporaryDirectory() as td:
+        td_path = pathlib.Path(td)
+        assert td_path.exists() and td_path.is_dir()
+
+    assert not td_path.exists()
+    with pytest.raises(FileNotFoundError):
+        (td_path / "nonexistent.txt").write_text("should fail", encoding="utf-8")
+
+
+@pytest.mark.anyio
+async def test_spooled_temporary_file_rollover_handling() -> None:
+    async with SpooledTemporaryFile[bytes](max_size=10) as stf:
+        await stf.write(b"1234567890")
+        await stf.rollover()
+        assert not stf.closed
+        await stf.write(b"more data")
+        await stf.seek(0)
+        result = await stf.read()
+        assert result == b"1234567890more data"
+
+
+@pytest.mark.anyio
+async def test_spooled_temporary_file_closed_state() -> None:
+    async with SpooledTemporaryFile[bytes](max_size=10) as stf:
+        assert not stf.closed
+
+    assert stf.closed

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -194,7 +194,7 @@ async def test_mkdtemp() -> None:
     else:
         dp = pathlib.Path(d)
 
-    assert dp.exists() and dp.is_dir()
+    assert dp.is_dir()
 
     shutil.rmtree(dp)
     assert not dp.exists()

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -48,7 +48,7 @@ class TestNamedTemporaryFile:
 
     async def test_exception_handling(self) -> None:
         async with NamedTemporaryFile[bytes]() as af:
-            filename = str(af.name)
+            filename = af.name
             assert os.path.exists(filename)
 
         assert not os.path.exists(filename)

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -120,8 +120,7 @@ class TestSpooledTemporaryFile:
             await stf.writelines([b"hello", b"world"])
             await stf.seek(0)
 
-            content = await stf.read()
-            assert content == b"helloworld"
+            assert await stf.read() == b"helloworld"
 
             await stf.writelines([b"1234567890123456"])
             assert rollover_called

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -197,7 +197,6 @@ async def test_mkdtemp() -> None:
     assert dp.is_dir()
 
     shutil.rmtree(dp)
-    assert not dp.exists()
 
 
 async def test_gettemp_functions() -> None:


### PR DESCRIPTION
## Changes

feat: Add async support for temporary file handling (#344)

- Implemented async support for TemporaryFile, NamedTemporaryFile, SpooledTemporaryFile, and TemporaryDirectory.
- Integrated `to_thread` for handling async operations with tempfiles.
- Added tests to ensure async compatibility.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch.
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new features). _(Pending)_
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`). _(Pending)_

### Updating the changelog

_(Changelog not updated)_

---

## Additional Notes

I have implemented async support for temporary file handling.  
Currently, I haven't updated the documentation or changelog yet.  

I'm unsure if this implementation follows the best approach, so I would appreciate feedback on the current implementation first.  
Once I receive input from the review, I will update the documentation and changelog accordingly if needed.
