### PR TITLE
Changed getaddrinfo() to filter out invalid IPv6 results when IPv6 is disabled

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: mypy
         additional_dependencies:
           - pytest
-          - trio >= 0.23
+          - trio >= 0.26
           - packaging
 
   - repo: https://github.com/pre-commit/pygrep-hooks

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -9,6 +9,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``anyio.open_process()``, ``asyncio.create_subprocess_…()``, ``trio.run_process()``,
   and ``subprocess.run()`` already accept (PR by @jmehnle)
 - Added the ``info`` property to ``anyio.Path`` on Python 3.14
+- Changed ``anyio.getaddrinfo()`` to ignore (invalid) IPv6 name resolution results when
+  IPv6 support is disabled in Python
 - Fixed traceback formatting growing quadratically with level of ``TaskGroup``
   nesting on asyncio due to exception chaining when raising ``ExceptionGroups``
   in ``TaskGroup.__aexit__``

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2674,13 +2674,13 @@ class AsyncIOBackend(AsyncBackend):
         type: int | SocketKind = 0,
         proto: int = 0,
         flags: int = 0,
-    ) -> list[
+    ) -> Sequence[
         tuple[
             AddressFamily,
             SocketKind,
             int,
             str,
-            tuple[str, int] | tuple[str, int, int, int],
+            tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes],
         ]
     ]:
         return await get_running_loop().getaddrinfo(

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1246,13 +1246,13 @@ class TrioBackend(AsyncBackend):
         type: int | SocketKind = 0,
         proto: int = 0,
         flags: int = 0,
-    ) -> list[
+    ) -> Sequence[
         tuple[
             AddressFamily,
             SocketKind,
             int,
             str,
-            tuple[str, int] | tuple[str, int, int, int],
+            tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes],
         ]
     ]:
         return await trio.socket.getaddrinfo(host, port, family, type, proto, flags)

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -584,6 +584,8 @@ async def getaddrinfo(
     return [
         (family, type, proto, canonname, convert_ipv6_sockaddr(sockaddr))
         for family, type, proto, canonname, sockaddr in gai_res
+        # filter out IPv6 results when IPv6 is disabled
+        if not isinstance(sockaddr[0], int)
     ]
 
 

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -315,13 +315,13 @@ class AsyncBackend(metaclass=ABCMeta):
         type: int | SocketKind = 0,
         proto: int = 0,
         flags: int = 0,
-    ) -> list[
+    ) -> Sequence[
         tuple[
             AddressFamily,
             SocketKind,
             int,
             str,
-            tuple[str, int] | tuple[str, int, int, int],
+            tuple[str, int] | tuple[str, int, int, int] | tuple[int, bytes],
         ]
     ]:
         pass

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -25,6 +25,7 @@ from _pytest.fixtures import SubRequest
 from _pytest.logging import LogCaptureFixture
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.tmpdir import TempPathFactory
+from pytest_mock import MockerFixture
 
 from anyio import (
     BrokenResourceError,
@@ -52,6 +53,7 @@ from anyio import (
     wait_socket_writable,
     wait_writable,
 )
+from anyio._core._eventloop import get_async_backend
 from anyio.abc import (
     IPSockAddrType,
     Listener,
@@ -1844,6 +1846,14 @@ async def test_getaddrinfo_ipv6addr(
             ("::1", 0),
         )
     ]
+
+
+async def test_getaddrinfo_ipv6_disabled(mocker: MockerFixture) -> None:
+    gai_result = [
+        (AddressFamily.AF_INET6, socket.SocketKind.SOCK_STREAM, 6, "", (1, b""))
+    ]
+    mocker.patch.object(get_async_backend(), "getaddrinfo", return_value=gai_result)
+    assert await getaddrinfo("::1", 0) == []
 
 
 async def test_getnameinfo() -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -18,6 +18,7 @@ from socket import AddressFamily
 from ssl import SSLContext, SSLError
 from threading import Thread
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeVar, cast
+from unittest import mock
 
 import psutil
 import pytest
@@ -25,7 +26,6 @@ from _pytest.fixtures import SubRequest
 from _pytest.logging import LogCaptureFixture
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.tmpdir import TempPathFactory
-from pytest_mock import MockerFixture
 
 from anyio import (
     BrokenResourceError,
@@ -1848,12 +1848,12 @@ async def test_getaddrinfo_ipv6addr(
     ]
 
 
-async def test_getaddrinfo_ipv6_disabled(mocker: MockerFixture) -> None:
+async def test_getaddrinfo_ipv6_disabled() -> None:
     gai_result = [
         (AddressFamily.AF_INET6, socket.SocketKind.SOCK_STREAM, 6, "", (1, b""))
     ]
-    mocker.patch.object(get_async_backend(), "getaddrinfo", return_value=gai_result)
-    assert await getaddrinfo("::1", 0) == []
+    with mock.patch.object(get_async_backend(), "getaddrinfo", return_value=gai_result):
+        assert await getaddrinfo("::1", 0) == []
 
 
 async def test_getnameinfo() -> None:


### PR DESCRIPTION
This also fixes the internal type annotations for AsyncBackend.getaddrinfo().

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
