### PR TITLE
Fix iterdir making blocking call in Python 3.13

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,8 +5,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Fix ``iterdir`` making blocking call in Python 3.13
-  (`#873 <https://github.com/agronholm/anyio/issues/873>`_; PR by @cbornet)
 - Added ``stdin`` argument to ``anyio.run_process()`` akin to what
   ``anyio.open_process()``, ``asyncio.create_subprocess_…()``, ``trio.run_process()``,
   and ``subprocess.run()`` already accept (PR by @jmehnle)
@@ -15,6 +13,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   nesting on asyncio due to exception chaining when raising ``ExceptionGroups``
   in ``TaskGroup.__aexit__``
   (`#863 <https://github.com/agronholm/anyio/issues/863>`_; PR by @tapetersen)
+- Fixed ``anyio.Path.iterdir()`` making a blocking call in Python 3.13
+  (`#873 <https://github.com/agronholm/anyio/issues/873>`_; PR by @cbornet and
+  @agronholm)
 
 **4.8.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fix ``iterdir`` making blocking call in Python 3.13
+  (`#873 <https://github.com/agronholm/anyio/issues/873>`_; PR by @cbornet)
 - Added ``stdin`` argument to ``anyio.run_process()`` akin to what
   ``anyio.open_process()``, ``asyncio.create_subprocess_…()``, ``trio.run_process()``,
   and ``subprocess.run()`` already accept (PR by @jmehnle)

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -209,7 +209,9 @@ class _PathIterator(AsyncIterator["Path"]):
     async def __anext__(self) -> Path:
         if self._iterator is None:
             if callable(self.iterator):
-                self._iterator = await to_thread.run_sync(self.iterator)
+                self._iterator = await to_thread.run_sync(
+                    self.iterator, abandon_on_cancel=True
+                )
             else:
                 self._iterator = self.iterator
 

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -554,6 +554,10 @@ class Path:
         return await to_thread.run_sync(self._path.is_symlink, abandon_on_cancel=True)
 
     def iterdir(self) -> AsyncIterator[Path]:
+        # Path.iterdir() does I/O when called on Python 3.13+
+        if sys.version_info < (3, 12):
+            return _PathIterator(self._path.iterdir())
+
         return _PathIterator(self._path.iterdir)
 
     def joinpath(self, *args: str | PathLike[str]) -> Path:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #873
<!-- Please give a short brief about these changes. -->
In Python 3.13 `pathlib.Path.iterdir` makes a blocking call to `os.scandir` and then exhausts the `ScandirIterator` with each iteration being again a blocking call.
This change replaces the use of `pathlib.Path.iterdir` by a copy of Python 3.13's `pathlib.Path.iterdir` but with a lazy evaluation of `os.scandir` which will be done at the first iteration of `anyio.Path.iterdir`, thus in a thread.

Note: the change in Python 3.13 was done this way to get an OS error if the path on which `iterdir` is called doesn't exist.
This change will make anyio's `iterdir` behave like in Python 3.12, raising the OS error only at the first iteration.
Changing this would probably mean make `iterdir` async as it would need to check the FS for the existence of the path.

Tested by existing `test_fileio.py::test_iterdir`.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

<!-- 
If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
 -->