### PR TITLE
Detect blocking calls in coroutines using BlockBuster

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ Changelog = "https://anyio.readthedocs.io/en/stable/versionhistory.html"
 trio = ["trio >= 0.26.1"]
 test = [
     "anyio[trio]",
+    "blockbuster >= 1.5.23",
     "coverage[toml] >= 7",
     "exceptiongroup >= 1.2.0",
     "hypothesis >= 4.0",

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import re
 import ssl
@@ -15,6 +14,7 @@ from .. import (
     EndOfStream,
     aclose_forcefully,
     get_cancelled_exc_class,
+    to_thread,
 )
 from .._core._typedattr import TypedAttributeSet, typed_attribute
 from ..abc import AnyByteStream, ByteStream, Listener, TaskGroup
@@ -125,12 +125,13 @@ class TLSStream(ByteStream):
                 bio_in, bio_out, server_side=server_side, server_hostname=hostname
             )
         else:
-            ssl_object = await asyncio.to_thread(
+            ssl_object = await to_thread.run_sync(
                 ssl_context.wrap_bio,
                 bio_in,
                 bio_out,
-                server_side=server_side,
-                server_hostname=hostname,
+                server_side,
+                hostname,
+                None,
             )
         wrapper = cls(
             transport_stream=transport_stream,

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import ssl
@@ -119,9 +120,18 @@ class TLSStream(ByteStream):
 
         bio_in = ssl.MemoryBIO()
         bio_out = ssl.MemoryBIO()
-        ssl_object = ssl_context.wrap_bio(
-            bio_in, bio_out, server_side=server_side, server_hostname=hostname
-        )
+        if type(ssl_context) is ssl.SSLContext:
+            ssl_object = ssl_context.wrap_bio(
+                bio_in, bio_out, server_side=server_side, server_hostname=hostname
+            )
+        else:
+            ssl_object = await asyncio.to_thread(
+                ssl_context.wrap_bio,
+                bio_in,
+                bio_out,
+                server_side=server_side,
+                server_hostname=hostname,
+            )
         wrapper = cls(
             transport_stream=transport_stream,
             standard_compatible=standard_compatible,

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -133,6 +133,7 @@ class TLSStream(ByteStream):
                 hostname,
                 None,
             )
+
         wrapper = cls(
             transport_stream=transport_stream,
             standard_compatible=standard_compatible,

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -120,6 +120,9 @@ class TLSStream(ByteStream):
 
         bio_in = ssl.MemoryBIO()
         bio_out = ssl.MemoryBIO()
+
+        # External SSLContext implementations may do blocking I/O in wrap_bio(),
+        # but the standard library implementation won't
         if type(ssl_context) is ssl.SSLContext:
             ssl_object = ssl_context.wrap_bio(
                 bio_in, bio_out, server_side=server_side, server_hostname=hostname

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,9 @@ def blockbuster() -> Iterator[BlockBuster]:
         "anyio", excluded_modules=["anyio.pytest_plugin", "anyio._backends._asyncio"]
     ) as bb:
         bb.functions["os.stat"].can_block_in("anyio/streams/tls.py", "wrap")
+        bb.functions["socket.socket.accept"].can_block_in(
+            "anyio/_core/_asyncio_selector_thread.py", {"get_selector"}
+        )
         for func in ["os.stat", "os.unlink"]:
             bb.functions[func].can_block_in(
                 "anyio/_core/_sockets.py", "setup_unix_local_socket"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,6 @@ def blockbuster() -> Iterator[BlockBuster]:
     with blockbuster_ctx(
         "anyio", excluded_modules=["anyio.pytest_plugin", "anyio._backends._asyncio"]
     ) as bb:
-        bb.functions["os.stat"].can_block_in("anyio/streams/tls.py", "wrap")
         bb.functions["socket.socket.accept"].can_block_in(
             "anyio/_core/_asyncio_selector_thread.py", {"get_selector"}
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import ssl
 import sys
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from ssl import SSLContext
 from typing import Any
 from unittest.mock import Mock
@@ -11,6 +11,7 @@ from unittest.mock import Mock
 import pytest
 import trustme
 from _pytest.fixtures import SubRequest
+from blockbuster import BlockBuster, blockbuster_ctx
 from trustme import CA
 
 uvloop_marks = []
@@ -50,6 +51,23 @@ if sys.version_info >= (3, 12):
             id="asyncio+eager",
         ),
     )
+
+
+@pytest.fixture(autouse=True)
+def blockbuster() -> Iterator[BlockBuster]:
+    with blockbuster_ctx(
+        "anyio", excluded_modules=["anyio.pytest_plugin", "anyio._backends._asyncio"]
+    ) as bb:
+        for func in ["os.stat", "os.unlink"]:
+            bb.functions[func].can_block_in(
+                "anyio/_core/_sockets.py", "setup_unix_local_socket"
+            )
+        yield bb
+
+
+@pytest.fixture
+def deactivate_blockbuster(blockbuster: BlockBuster) -> None:
+    blockbuster.deactivate()
 
 
 @pytest.fixture(params=[*asyncio_params, pytest.param("trio")])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ def blockbuster() -> Iterator[BlockBuster]:
             bb.functions[func].can_block_in(
                 "anyio/_core/_sockets.py", "setup_unix_local_socket"
             )
+
         yield bb
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ def blockbuster() -> Iterator[BlockBuster]:
     with blockbuster_ctx(
         "anyio", excluded_modules=["anyio.pytest_plugin", "anyio._backends._asyncio"]
     ) as bb:
+        bb.functions["os.stat"].can_block_in("anyio/streams/tls.py", "wrap")
         for func in ["os.stat", "os.unlink"]:
             bb.functions[func].can_block_in(
                 "anyio/_core/_sockets.py", "setup_unix_local_socket"

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -628,6 +628,7 @@ class TestBlockingPortal:
             assert exc.value.__context__ is None
 
     @pytest.mark.parametrize("portal_backend_name", get_all_backends())
+    @pytest.mark.usefixtures("deactivate_blockbuster")
     async def test_from_async(
         self, anyio_backend_name: str, portal_backend_name: str
     ) -> None:

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -73,6 +73,7 @@ async def test_cancel_before() -> None:
     pytest.raises(LookupError, to_process._process_pool_workers.get)
 
 
+@pytest.mark.usefixtures("deactivate_blockbuster")
 async def test_cancel_during() -> None:
     """
     Test that cancelling an operation on the worker process causes the process to be


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This PR uses the [blockbuster](https://github.com/cbornet/blockbuster) library to detect blocking calls made in the asyncio event loop during unit tests.
Avoiding blocking calls is hard as these can be deeply buried in the code or made in 3rd party libraries.
Blockbuster makes it easier to detect them by raising an exception when a call is made to a known blocking function (eg: `time.sleep`).

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).
<!--
If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```
-->

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
