### PR TITLE
Fix(asyncio): to_thread.async_run holding ref of Context

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -34,7 +34,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#873 <https://github.com/agronholm/anyio/issues/873>`_; PR by @cbornet and
   @agronholm)
 - Fixed ``anyio.to_thread.run_sync()`` needlessly holding on to references of the
-  context, function, arguments and others until the next work item (PR by @Wankupi)
+  context, function, arguments and others until the next work item on asyncio
+  (PR by @Wankupi)
 
 **4.8.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -33,6 +33,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``anyio.Path.iterdir()`` making a blocking call in Python 3.13
   (`#873 <https://github.com/agronholm/anyio/issues/873>`_; PR by @cbornet and
   @agronholm)
+- Fixed ``anyio.to_thread.run_sync()`` needlessly holding on to references of the
+  context, function, arguments and others until the next work item (PR by @Wankupi)
 
 **4.8.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -975,10 +975,10 @@ class WorkerThread(Thread):
                             self._report_result, future, result, exception
                         )
 
+                    del result, exception
+
                 self.queue.task_done()
-                # make sure no references after this epoch
-                # so that context can be garbage collected
-                del item, context, func, args, future, cancel_scope, result, exception
+                del item, context, func, args, future, cancel_scope
 
     def stop(self, f: asyncio.Task | None = None) -> None:
         self.stopping = True

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -386,4 +387,5 @@ async def test_run_async_with_context() -> None:
     res: list[int] = []
     for i in range(5):
         await one_request(i + 1, res)
+        gc.collect()
     assert res == [1, -1, 2, -2, 3, -3, 4, -4, 5, -5]


### PR DESCRIPTION
If the context had some objects,
after to_thread.async run,
the worker thread will keep one ref of the context,
which will cause the objects can not be released.

## Changes

This commit only fix the asyncio backend.
Create a new empty contextvars.Context when creating a new thread worker.

It should be checked for other backends.

## Checklist

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
