### PR TITLE
Raise EndOfStream from None in MemoryObjectReceiveStream.receive()

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -21,6 +21,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Added the ``info`` property to ``anyio.Path`` on Python 3.14
 - Changed ``anyio.getaddrinfo()`` to ignore (invalid) IPv6 name resolution results when
   IPv6 support is disabled in Python
+- Changed ``EndOfStream`` raised from ``MemoryObjectReceiveStream.receive()`` to leave
+  out the ``AttributeError`` from the exception chain which was merely an implementation
+  detail and caused some confusion
 - Fixed traceback formatting growing quadratically with level of ``TaskGroup``
   nesting on asyncio due to exception chaining when raising ``ExceptionGroups``
   in ``TaskGroup.__aexit__``

--- a/src/anyio/streams/memory.py
+++ b/src/anyio/streams/memory.py
@@ -123,7 +123,7 @@ class MemoryObjectReceiveStream(Generic[T_co], ObjectReceiveStream[T_co]):
             try:
                 return receiver.item
             except AttributeError:
-                raise EndOfStream
+                raise EndOfStream from None
 
     def clone(self) -> MemoryObjectReceiveStream[T_co]:
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Changes `EndOfStream` to be raised from `None` to avoid `AttributeError: 'MemoryObjectItemReceiver' object has no attribute 'item'` to be included in the traceback, leading many to think this is a bug when in fact it was only an implementation detail.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
