### PR TITLE
Use `list.extend()` with an async comprehension to create a transformed list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,15 +78,18 @@ src = ["src"]
 [tool.ruff.lint]
 extend-select = [
     "ASYNC",        # flake8-async
-    "W",            # pycodestyle warnings
+    "C4",           # flake8-comprehensions
     "G",            # flake8-logging-format
     "I",            # isort
     "ISC",          # flake8-implicit-str-concat
+    "PERF",         # flake8-performance
     "PGH",          # pygrep-hooks
     "RUF100",       # unused noqa (yesqa)
     "T201",         # print
     "UP",           # pyupgrade
+    "W",            # pycodestyle warnings
 ]
+ignore = ["PERF203"]
 
 [tool.ruff.lint.isort]
 "required-imports" = ["from __future__ import annotations"]

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -122,8 +122,7 @@ async def test_send_nowait_then_receive_nowait() -> None:
 
 async def test_iterate() -> None:
     async def receiver() -> None:
-        async for item in receive:
-            received_objects.append(item)
+        received_objects.extend([item async for item in receive])
 
     send, receive = create_memory_object_stream[str]()
     received_objects: list[str] = []

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1010,11 +1010,8 @@ class TestUNIXStream:
 
         thread = Thread(target=serve, daemon=True)
         thread.start()
-        chunks = []
         async with await connect_unix(socket_path) as stream:
-            async for chunk in stream:
-                chunks.append(chunk)
-
+            chunks = [chunk async for chunk in stream]
         thread.join()
         assert chunks == [b"bl", b"ah"]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

These trivial changes only modify test code.

% `ruff rule PERF401 ` # [manual-list-comprehension](https://docs.astral.sh/ruff/rules/manual-list-comprehension/#manual-list-comprehension-perf401)
> List comprehensions are more readable and more performant.
If you're appending to an existing list, use the `.extend()` method instead:

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

