### PR TITLE
Make blockbuster test dependency optional

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,16 @@ import ssl
 import sys
 from collections.abc import Generator, Iterator
 from ssl import SSLContext
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
 import pytest
 import trustme
 from _pytest.fixtures import SubRequest
-from blockbuster import BlockBuster, blockbuster_ctx
 from trustme import CA
+
+if TYPE_CHECKING:
+    from blockbuster import BlockBuster
 
 uvloop_marks = []
 try:
@@ -55,6 +57,12 @@ if sys.version_info >= (3, 12):
 
 @pytest.fixture(autouse=True)
 def blockbuster() -> Iterator[BlockBuster]:
+    try:
+        from blockbuster import blockbuster_ctx
+    except ImportError:
+        yield
+        return
+
     with blockbuster_ctx(
         "anyio", excluded_modules=["anyio.pytest_plugin", "anyio._backends._asyncio"]
     ) as bb:
@@ -71,7 +79,8 @@ def blockbuster() -> Iterator[BlockBuster]:
 
 @pytest.fixture
 def deactivate_blockbuster(blockbuster: BlockBuster) -> None:
-    blockbuster.deactivate()
+    if blockbuster is not None:
+        blockbuster.deactivate()
 
 
 @pytest.fixture(params=[*asyncio_params, pytest.param("trio")])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ if sys.version_info >= (3, 12):
 
 
 @pytest.fixture(autouse=True)
-def blockbuster() -> Iterator[BlockBuster]:
+def blockbuster() -> Iterator[BlockBuster | None]:
     try:
         from blockbuster import blockbuster_ctx
     except ImportError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def blockbuster() -> Iterator[BlockBuster | None]:
     try:
         from blockbuster import blockbuster_ctx
     except ImportError:
-        yield
+        yield None
         return
 
     with blockbuster_ctx(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def blockbuster() -> Iterator[BlockBuster | None]:
 
 
 @pytest.fixture
-def deactivate_blockbuster(blockbuster: BlockBuster) -> None:
+def deactivate_blockbuster(blockbuster: BlockBuster | None) -> None:
     if blockbuster is not None:
         blockbuster.deactivate()
 


### PR DESCRIPTION
## Changes

Fixes #891

Make it possible to run the test suite without `blockbuster` installed, by avoiding unguarded imports, and handling `ImportError` within the fixture.


## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
