### PR TITLE
add notify_closing

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,13 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Added ``anyio.notify_closing`` to allow waking ``anyio.wait_readable``
+  and ``anyio.wait_writable`` before closing a socket. Among other things
+  this prevents an OSError on the ``ProactorEventLoop``.
+  (`#123 <https://github.com/agronholm/anyio/pull/896>`_; PR by @graingert)
+
 **4.9.0**
 
 - Added async support for temporary file handling

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -35,6 +35,7 @@ from ._core._sockets import create_unix_datagram_socket as create_unix_datagram_
 from ._core._sockets import create_unix_listener as create_unix_listener
 from ._core._sockets import getaddrinfo as getaddrinfo
 from ._core._sockets import getnameinfo as getnameinfo
+from ._core._sockets import notify_closing as notify_closing
 from ._core._sockets import wait_readable as wait_readable
 from ._core._sockets import wait_socket_readable as wait_socket_readable
 from ._core._sockets import wait_socket_writable as wait_socket_writable

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2719,7 +2719,6 @@ class AsyncIOBackend(AsyncBackend):
 
     @classmethod
     async def wait_readable(cls, obj: FileDescriptorLike) -> None:
-        await cls.checkpoint()
         try:
             read_events = _read_events.get()
         except LookupError:
@@ -2747,6 +2746,7 @@ class AsyncIOBackend(AsyncBackend):
 
         read_events[obj] = event
         try:
+            await cls.checkpoint()
             await event.wait()
         finally:
             remove_reader(obj)
@@ -2754,7 +2754,6 @@ class AsyncIOBackend(AsyncBackend):
 
     @classmethod
     async def wait_writable(cls, obj: FileDescriptorLike) -> None:
-        await cls.checkpoint()
         try:
             write_events = _write_events.get()
         except LookupError:
@@ -2782,6 +2781,7 @@ class AsyncIOBackend(AsyncBackend):
 
         write_events[obj] = event
         try:
+            await cls.checkpoint()
             await event.wait()
         finally:
             del write_events[obj]

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2733,7 +2733,7 @@ class AsyncIOBackend(AsyncBackend):
         finally:
             removed = remove_reader(obj)
             del read_events[obj]
-        if removed:
+        if not removed:
             raise ClosedResourceError
 
     @classmethod
@@ -2770,7 +2770,7 @@ class AsyncIOBackend(AsyncBackend):
         finally:
             del write_events[obj]
             removed = remove_writer(obj)
-        if removed:
+        if not removed:
             raise ClosedResourceError
 
     @classmethod

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2721,6 +2721,7 @@ class AsyncIOBackend(AsyncBackend):
                 pass
             else:
                 remove_reader(fd)
+
             try:
                 fut.set_result(True)
             except asyncio.InvalidStateError:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2748,6 +2748,7 @@ class AsyncIOBackend(AsyncBackend):
                 pass
             else:
                 remove_reader(fd)
+
         if not success:
             raise ClosedResourceError
 
@@ -2800,6 +2801,7 @@ class AsyncIOBackend(AsyncBackend):
                 pass
             else:
                 remove_writer(fd)
+
         if not success:
             raise ClosedResourceError
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2737,8 +2737,12 @@ class AsyncIOBackend(AsyncBackend):
         try:
             success = await fut
         finally:
-            remove_reader(obj)
-            del read_events[obj]
+            try:
+                del read_events[obj]
+            except KeyError:
+                pass
+            else:
+                remove_reader(obj)
         if not success:
             raise ClosedResourceError
 
@@ -2780,8 +2784,12 @@ class AsyncIOBackend(AsyncBackend):
         try:
             success = await fut
         finally:
-            del write_events[obj]
-            remove_writer(obj)
+            try:
+                del write_events[obj]
+            except KeyError:
+                pass
+            else:
+                remove_writer(obj)
         if not success:
             raise ClosedResourceError
 
@@ -2798,7 +2806,7 @@ class AsyncIOBackend(AsyncBackend):
             pass
         else:
             try:
-                fut = write_events[obj]
+                fut = write_events.pop(obj)
             except KeyError:
                 pass
             else:
@@ -2820,7 +2828,7 @@ class AsyncIOBackend(AsyncBackend):
             pass
         else:
             try:
-                fut = read_events[obj]
+                fut = read_events.pop(obj)
             except KeyError:
                 pass
             else:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2760,7 +2760,6 @@ class AsyncIOBackend(AsyncBackend):
             _write_events.set(write_events)
 
         fd = obj if isinstance(obj, int) else obj.fileno()
-
         if write_events.get(fd):
             raise BusyResourceError("writing to")
 
@@ -2807,7 +2806,6 @@ class AsyncIOBackend(AsyncBackend):
     @classmethod
     def notify_closing(cls, obj: FileDescriptorLike) -> None:
         fd = obj if isinstance(obj, int) else obj.fileno()
-
         loop = get_running_loop()
 
         try:
@@ -2824,13 +2822,13 @@ class AsyncIOBackend(AsyncBackend):
                     fut.set_result(False)
                 except asyncio.InvalidStateError:
                     pass
+
                 try:
                     loop.remove_writer(fd)
                 except NotImplementedError:
                     from anyio._core._asyncio_selector_thread import get_selector
 
-                    selector = get_selector()
-                    selector.remove_writer(fd)
+                    get_selector().remove_writer(fd)
 
         try:
             read_events = _read_events.get()
@@ -2846,13 +2844,13 @@ class AsyncIOBackend(AsyncBackend):
                     fut.set_result(False)
                 except asyncio.InvalidStateError:
                     pass
+
                 try:
                     loop.remove_reader(fd)
                 except NotImplementedError:
                     from anyio._core._asyncio_selector_thread import get_selector
 
-                    selector = get_selector()
-                    selector.remove_reader(fd)
+                    get_selector().remove_reader(fd)
 
     @classmethod
     def current_default_thread_limiter(cls) -> CapacityLimiter:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2746,7 +2746,6 @@ class AsyncIOBackend(AsyncBackend):
 
         read_events[obj] = event
         try:
-            await cls.checkpoint()
             await event.wait()
         finally:
             remove_reader(obj)
@@ -2781,7 +2780,6 @@ class AsyncIOBackend(AsyncBackend):
 
         write_events[obj] = event
         try:
-            await cls.checkpoint()
             await event.wait()
         finally:
             del write_events[obj]

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2708,7 +2708,6 @@ class AsyncIOBackend(AsyncBackend):
             _read_events.set(read_events)
 
         fd = obj if isinstance(obj, int) else obj.fileno()
-
         if read_events.get(fd):
             raise BusyResourceError("reading from")
 

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -43,6 +43,7 @@ from outcome import Error, Outcome, Value
 from trio.lowlevel import (
     current_root_task,
     current_task,
+    notify_closing,
     wait_readable,
     wait_writable,
 )
@@ -1280,6 +1281,10 @@ class TrioBackend(AsyncBackend):
             raise ClosedResourceError().with_traceback(exc.__traceback__) from None
         except trio.BusyResourceError:
             raise BusyResourceError("writing to") from None
+
+    @classmethod
+    def notify_closing(cls, obj: HasFileno | int) -> None:
+        notify_closing(obj)
 
     @classmethod
     def current_default_thread_limiter(cls) -> CapacityLimiter:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -83,7 +83,7 @@ from ..abc._eventloop import AsyncBackend, StrOrBytesPath
 from ..streams.memory import MemoryObjectSendStream
 
 if TYPE_CHECKING:
-    from _typeshed import HasFileno
+    from _typeshed import FileDescriptorLike
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
@@ -1265,7 +1265,7 @@ class TrioBackend(AsyncBackend):
         return await trio.socket.getnameinfo(sockaddr, flags)
 
     @classmethod
-    async def wait_readable(cls, obj: HasFileno | int) -> None:
+    async def wait_readable(cls, obj: FileDescriptorLike) -> None:
         try:
             await wait_readable(obj)
         except trio.ClosedResourceError as exc:
@@ -1274,7 +1274,7 @@ class TrioBackend(AsyncBackend):
             raise BusyResourceError("reading from") from None
 
     @classmethod
-    async def wait_writable(cls, obj: HasFileno | int) -> None:
+    async def wait_writable(cls, obj: FileDescriptorLike) -> None:
         try:
             await wait_writable(obj)
         except trio.ClosedResourceError as exc:
@@ -1283,7 +1283,7 @@ class TrioBackend(AsyncBackend):
             raise BusyResourceError("writing to") from None
 
     @classmethod
-    def notify_closing(cls, obj: HasFileno | int) -> None:
+    def notify_closing(cls, obj: FileDescriptorLike) -> None:
         notify_closing(obj)
 
     @classmethod

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -703,6 +703,31 @@ def wait_writable(obj: FileDescriptorLike) -> Awaitable[None]:
 
 
 def notify_closing(obj: FileDescriptorLike) -> None:
+    """
+    Call this before closing a file descriptor (on Unix) or socket (on
+    Windows). This will cause any `wait_readable` or `wait_writable`
+    calls on the given object to immediately wake up and raise
+    `~anyio.ClosedResourceError`.
+
+    This doesn't actually close the object – you still have to do that
+    yourself afterwards. Also, you want to be careful to make sure no
+    new tasks start waiting on the object in between when you call this
+    and when it's actually closed. So to close something properly, you
+    usually want to do these steps in order:
+
+    1. Explicitly mark the object as closed, so that any new attempts
+       to use it will abort before they start.
+    2. Call `notify_closing` to wake up any already-existing users.
+    3. Actually close the object.
+
+    It's also possible to do them in a different order if that's more
+    convenient, *but only if* you make sure not to have any checkpoints in
+    between the steps. This way they all happen in a single atomic
+    step, so other tasks won't be able to tell what order they happened
+    in anyway.
+
+    :param obj: an object with a ``.fileno()`` method or an integer handle
+    """
     get_async_backend().notify_closing(obj)
 
 

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -727,6 +727,7 @@ def notify_closing(obj: FileDescriptorLike) -> None:
     in anyway.
 
     :param obj: an object with a ``.fileno()`` method or an integer handle
+
     """
     get_async_backend().notify_closing(obj)
 

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -702,6 +702,10 @@ def wait_writable(obj: FileDescriptorLike) -> Awaitable[None]:
     return get_async_backend().wait_writable(obj)
 
 
+def notify_closing(obj: FileDescriptorLike) -> None:
+    get_async_backend().notify_closing(obj)
+
+
 #
 # Private API
 #

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -28,7 +28,7 @@ else:
     from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
-    from _typeshed import HasFileno
+    from _typeshed import FileDescriptorLike
 
     from .._core._synchronization import CapacityLimiter, Event, Lock, Semaphore
     from .._core._tasks import CancelScope
@@ -335,17 +335,17 @@ class AsyncBackend(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    async def wait_readable(cls, obj: HasFileno | int) -> None:
+    async def wait_readable(cls, obj: FileDescriptorLike) -> None:
         pass
 
     @classmethod
     @abstractmethod
-    async def wait_writable(cls, obj: HasFileno | int) -> None:
+    async def wait_writable(cls, obj: FileDescriptorLike) -> None:
         pass
 
     @classmethod
     @abstractmethod
-    def notify_closing(cls, obj: HasFileno | int) -> None:
+    def notify_closing(cls, obj: FileDescriptorLike) -> None:
         pass
 
     @classmethod

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -345,6 +345,11 @@ class AsyncBackend(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
+    def notify_closing(cls, obj: HasFileno | int) -> None:
+        pass
+
+    @classmethod
+    @abstractmethod
     def current_default_thread_limiter(cls) -> CapacityLimiter:
         pass
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1960,11 +1960,7 @@ async def test_interrupted_by_close(socket_type: str) -> None:
             with pytest.raises(ClosedResourceError):
                 await wait_writable(a)
 
-        try:
-            while True:
-                a_sock.send(b"x" * 65536)
-        except BlockingIOError:
-            pass
+        fill_socket(a_sock)
 
         async with create_task_group() as tg:
             tg.start_soon(reader)

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -47,6 +47,7 @@ from anyio import (
     getaddrinfo,
     getnameinfo,
     move_on_after,
+    notify_closing,
     wait_all_tasks_blocked,
     wait_readable,
     wait_socket_readable,
@@ -1932,3 +1933,42 @@ async def test_deprecated_wait_socket(anyio_backend_name: str) -> None:
         ):
             with move_on_after(0.1):
                 await wait_socket_writable(sock)
+
+
+def fill_socket(sock: socket.socket) -> None:
+    try:
+        while True:
+            sock.send(b"x" * 65536)
+    except BlockingIOError:
+        pass
+
+
+@pytest.mark.parametrize("socket_type", ["socket", "fd"])
+async def test_interrupted_by_close(socket_type: str) -> None:
+    a_sock, b = socket.socketpair()
+    with a_sock, b:
+        a_sock.setblocking(False)
+        b.setblocking(False)
+
+        a: FileDescriptorLike = a_sock.fileno() if socket_type == "fd" else a_sock
+
+        async def reader() -> None:
+            with pytest.raises(ClosedResourceError):
+                await wait_readable(a)
+
+        async def writer() -> None:
+            with pytest.raises(ClosedResourceError):
+                await wait_writable(a)
+
+        try:
+            while True:
+                a_sock.send(b"x" * 65536)
+        except BlockingIOError:
+            pass
+
+        async with create_task_group() as tg:
+            tg.start_soon(reader)
+            tg.start_soon(writer)
+            await wait_all_tasks_blocked()
+            notify_closing(a_sock)
+            a_sock.close()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -143,6 +143,14 @@ def _identity(v: _T) -> _T:
     return v
 
 
+def fill_socket(sock: socket.socket) -> None:
+    try:
+        while True:
+            sock.send(b"x" * 65536)
+    except BlockingIOError:
+        pass
+
+
 #  _ProactorBasePipeTransport.abort() after _ProactorBasePipeTransport.close()
 # does not cancel writes: https://bugs.python.org/issue44428
 _ignore_win32_resource_warnings = (
@@ -1933,14 +1941,6 @@ async def test_deprecated_wait_socket(anyio_backend_name: str) -> None:
         ):
             with move_on_after(0.1):
                 await wait_socket_writable(sock)
-
-
-def fill_socket(sock: socket.socket) -> None:
-    try:
-        while True:
-            sock.send(b"x" * 65536)
-    except BlockingIOError:
-        pass
 
 
 @pytest.mark.parametrize("socket_type", ["socket", "fd"])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

* add anyio.notify_closing
* adjust wait_readable/wait_writable to checkpoint after registration and before waiting on the event.

anyio-zmq needs this feature to handle ZmqSocket.close calls

we expose the trio implemenation which is simple enough, and emulate the feature on asyncio. If someone is using add_reader themselves on an FD then you can't use it with anyio wait_readable/wait_writiable/notify_closing

<!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
