### PR TITLE
remove win32 ResourceWarning ignores on 3.10+

### DIFF
--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -149,7 +149,7 @@ _ignore_win32_resource_warnings = (
         "ignore:unclosed <socket.socket:ResourceWarning",
         "ignore:unclosed transport <_ProactorSocketTransport closing:ResourceWarning",
     )
-    if sys.platform == "win32"
+    if sys.version_info <= (3, 9) and sys.platform == "win32"
     else _identity
 )
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -149,7 +149,7 @@ _ignore_win32_resource_warnings = (
         "ignore:unclosed <socket.socket:ResourceWarning",
         "ignore:unclosed transport <_ProactorSocketTransport closing:ResourceWarning",
     )
-    if sys.version_info <= (3, 9) and sys.platform == "win32"
+    if sys.version_info < (3, 10) and sys.platform == "win32"
     else _identity
 )
 


### PR DESCRIPTION
Just a minor change, doesn't need changelog/tests/docs