### PR TITLE
Added context manager mix-in classes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -99,7 +99,10 @@ Context manager mix-in classes
 ------------------------------
 
 .. autoclass:: anyio.ContextManagerMixin
+   :special-members: __contextmanager__
+
 .. autoclass:: anyio.AsyncContextManagerMixin
+   :special-members: __asynccontextmanager__
 
 Streams and stream wrappers
 ---------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -95,6 +95,12 @@ Temporary files and directories
 .. autoclass:: anyio.SpooledTemporaryFile
 .. autoclass:: anyio.TemporaryDirectory
 
+Context manager mix-in classes
+------------------------------
+
+.. autoclass:: anyio.ContextManagerMixin
+.. autoclass:: anyio.AsyncContextManagerMixin
+
 Streams and stream wrappers
 ---------------------------
 

--- a/docs/cancellation.rst
+++ b/docs/cancellation.rst
@@ -216,10 +216,16 @@ context manager needs to use other context managers, you may find it convenient 
 :class:`AsyncContextManagerMixin` in order to avoid cumbersome code that calls
 ``__aenter__()`` and ``__aexit__()`` directly::
 
+    from __future__ import annotations
+
+    from collections.abc import AsyncGenerator
+
     from anyio import AsyncContextManagerMixin, create_task_group
 
 
-    class MyAsyncContextManager(AsyncContextManagerMixin):
-        async def __asynccontextmanager__(self):
+    # AsyncContextManagerMixin is parametrized this way because it returns 'self'
+    class MyAsyncContextManager(AsyncContextManagerMixin["MyAsyncContextManager"]):
+        async def __asynccontextmanager__(self) -> AsyncGenerator[MyAsyncContextManager]:
             async with create_task_group() as tg:
                 ...  # launch tasks
+                yield self

--- a/docs/cancellation.rst
+++ b/docs/cancellation.rst
@@ -157,6 +157,8 @@ cancelled scope::
 
             raise
 
+.. _cancel_scope_stack_corruption:
+
 Avoiding cancel scope stack corruption
 --------------------------------------
 
@@ -219,13 +221,16 @@ context manager needs to use other context managers, you may find it convenient 
     from __future__ import annotations
 
     from collections.abc import AsyncGenerator
+    from typing import Self
 
     from anyio import AsyncContextManagerMixin, create_task_group
 
 
-    # AsyncContextManagerMixin is parametrized this way because it returns 'self'
-    class MyAsyncContextManager(AsyncContextManagerMixin["MyAsyncContextManager"]):
-        async def __asynccontextmanager__(self) -> AsyncGenerator[MyAsyncContextManager]:
+    class MyAsyncContextManager(AsyncContextManagerMixin):
+        @asynccontextmanager
+        async def __asynccontextmanager__(self) -> AsyncGenerator[Self]:
             async with create_task_group() as tg:
                 ...  # launch tasks
                 yield self
+
+.. seealso:: :doc:`contextmanagers`

--- a/docs/cancellation.rst
+++ b/docs/cancellation.rst
@@ -196,8 +196,11 @@ Depending on how they are used, this pattern is, however, *usually* safe to use 
 asynchronous context managers, so long as you make sure that the same host task keeps
 running throughout the entire enclosed code block::
 
+    from contextlib import asynccontextmanager
+
+
     # Okay in most cases!
-    @async_context_manager
+    @asynccontextmanager
     async def some_context_manager():
         async with create_task_group() as tg:
             tg.start_soon(foo)
@@ -209,24 +212,14 @@ start to end in the same task, making it possible to have task groups or cancel 
 safely straddle the ``yield``.
 
 When you're implementing the async context manager protocol manually and your async
-context manager needs to use other context managers, you may find it necessary to call
-their ``__aenter__()`` and ``__aexit__()`` directly. In such cases, it is absolutely
-vital to ensure that their ``__aexit__()`` methods are called in the exact reverse order
-of the ``__aenter__()`` calls. To this end, you may find the
-:class:`~contextlib.AsyncExitStack` class very useful::
+context manager needs to use other context managers, you may find it convenient to use
+:class:`AsyncContextManagerMixin` in order to avoid cumbersome code that calls
+``__aenter__()`` and ``__aexit__()`` directly::
 
-    from contextlib import AsyncExitStack
-
-    from anyio import create_task_group
+    from anyio import AsyncContextManagerMixin, create_task_group
 
 
-    class MyAsyncContextManager:
-        async def __aenter__(self):
-            self._exitstack = AsyncExitStack()
-            await self._exitstack.__aenter__()
-            self._task_group = await self._exitstack.enter_async_context(
-                create_task_group()
-            )
-
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
-            return await self._exitstack.__aexit__(exc_type, exc_val, exc_tb)
+    class MyAsyncContextManager(AsyncContextManagerMixin):
+        async def __asynccontextmanager__(self):
+            async with create_task_group() as tg:
+                ...  # launch tasks

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,7 @@ from packaging.version import parse
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "sphinx_tabs.tabs",
     "sphinx_autodoc_typehints",
     "sphinx_rtd_theme",
 ]

--- a/docs/contextmanagers.rst
+++ b/docs/contextmanagers.rst
@@ -1,0 +1,101 @@
+Context manager mix-in classes
+==============================
+
+.. py:currentmodule:: anyio
+
+Python classes that want to offer context management functionality normally implement
+``__enter__()`` and ``__exit__()`` (for synchronous context managers) or
+``__aenter__()`` and ``__aexit__()`` (for asynchronous context managers). While this
+offers precise control and re-entrancy support, embedding _other_ context managers in
+this logic can be very error prone. To make this easier, AnyIO provides two context
+manager mix-in classes, :class:`ContextManagerMixin` and
+:class:`AsyncContextManagerMixin`. These classes provide implementations of
+``__enter__()``, ``__exit__()`` or ``__aenter__()``, and ``__aexit__()``, that provide
+another way to implement context managers similar to
+:func:`@contextmanager <contextlib.contextmanager>` and
+:func:`@asynccontextmanager <contextlib.asynccontextmanager>` - a generator-based
+approach where the ``yield`` statement signals that the context has been entered.
+
+Here's a trivial example of how to use the mix-in classes:
+
+.. tabs::
+
+   .. code-tab:: python Synchronous
+
+      from collections.abc import Generator
+      from contextlib import contextmanager
+      from typing import Self
+
+      from anyio import ContextManagerMixin
+
+      class MyContextManager(ContextManagerMixin):
+          @contextmanager
+          def __contextmanager__(self) -> Generator[Self]:
+              print("entering context")
+              yield self
+              print("exiting context")
+
+   .. code-tab:: python Asynchronous
+
+      from collections.abc import AsyncGenerator
+      from contextlib import asynccontextmanager
+      from typing import Self
+
+      from anyio import AsyncContextManagerMixin
+
+      class MyAsyncContextManager(AsyncContextManagerMixin):
+          @asynccontextmanager
+          async def __asynccontextmanager__(self) -> AsyncGenerator[Self]:
+              print("entering context")
+              yield self
+              print("exiting context")
+
+Rationale
+---------
+
+When embedding other context managers, a common mistake is forgetting about error
+handling when entering the context. Consider this example::
+
+    from typing import Self
+
+    from anyio import create_task_group
+
+    class MyBrokenContextManager:
+        async def __aenter__(self) -> Self:
+            self._task_group = await create_task_group()
+            # BOOM: missing the "arg" argument here to my_background_func!
+            self._task_group.start_soon(self.my_background_func)
+            return self
+
+        async def __aexit__(self, exc_type, exc_value, traceback) -> bool | None:
+            return await self._task_group.__aexit__(exc_type, exc_value, traceback)
+
+        async my_background_func(self, arg: int) -> None:
+            ...
+
+It's easy to think that you have everything covered with ``__aexit__()`` here, but what
+if something goes wrong in ``__aenter__()``?  The ``__aexit__()`` method will never be
+called.
+
+The mix-in classes solve this problem by providing a robust implementation of
+``__enter__()``/``__exit__()`` or ``__aenter__()``/``__aexit__()`` that handles errors
+correctly. Thus, the above code should be written as::
+
+    from collections.abc import AsyncGenerator
+    from contextlib import asynccontextmanager
+    from typing import Self
+
+    from anyio import create_task_group
+
+    class MyBetterContextManager:
+        @asynccontextmanager
+        async def __asynccontextmanager__(self) -> AsyncGenerator[Self]:
+            async with create_task_group() as task_group:
+                # Still crashes, but at least now the task group is exited
+                task_group.start_soon(self.my_background_func)
+                yield self
+
+        async my_background_func(self, arg: int) -> None:
+            ...
+
+.. seealso:: :ref:`cancel_scope_stack_corruption`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ The manual
    fileio
    tempfile
    signals
+   contextmanagers
    testing
    api
    migration

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,12 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Added context manager mix-in classes (``anyio.ContextManagerMixin`` and
+  ``anyio.AsyncContextManagerMixin``) to help write classes that embed other context
+  managers (particularly cancel scopes or task groups)
+
 **4.9.0**
 
 - Added async support for temporary file handling

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,7 +7,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added context manager mix-in classes (``anyio.ContextManagerMixin`` and
   ``anyio.AsyncContextManagerMixin``) to help write classes that embed other context
-  managers (particularly cancel scopes or task groups)
+  managers, particularly cancel scopes or task groups
+  (`#905 <https://github.com/agronholm/anyio/pull/905>`_; PR by by @agronholm and
+  @tapetersen)
 - Added the ability to specify the thread name in ``start_blocking_portal()``
   (`#818 <https://github.com/agronholm/anyio/issues/818>`_; PR by @davidbrochart)
 - Added ``anyio.notify_closing`` to allow waking ``anyio.wait_readable``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,10 @@ relative_files = true
 
 [tool.coverage.report]
 show_missing = true
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "@(abc\\.)?abstractmethod",
+]
 
 [tool.tox]
 env_list = ["pre-commit", "py39", "py310", "py311", "py312", "py313", "py314", "pypy3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ doc = [
     "Sphinx ~= 8.2",
     "sphinx_rtd_theme",
     "sphinx-autodoc-typehints >= 1.2.0",
+    "sphinx-tabs >= 3.3.1",
 ]
 
 [project.entry-points]

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from ._core._contextmanagers import AsyncContextManagerMixin as AsyncContextManagerMixin
+from ._core._contextmanagers import ContextManagerMixin as ContextManagerMixin
 from ._core._eventloop import current_time as current_time
 from ._core._eventloop import get_all_backends as get_all_backends
 from ._core._eventloop import get_cancelled_exc_class as get_cancelled_exc_class

--- a/src/anyio/_core/_contextmanagers.py
+++ b/src/anyio/_core/_contextmanagers.py
@@ -62,7 +62,7 @@ class ContextManagerMixin(Generic[_T_co]):
 
         # Prevent circular references
         cm = self.__cm
-        self.__cm = None
+        del self.__cm
 
         if exc_val is not None:
             try:

--- a/src/anyio/_core/_contextmanagers.py
+++ b/src/anyio/_core/_contextmanagers.py
@@ -31,6 +31,8 @@ class ContextManagerMixin:
 
     .. note:: Classes using this mix-in are not reentrant as context managers, meaning
         that once you enter it, you can't re-enter before first exiting it.
+
+    .. seealso:: :doc:`contextmanagers`
     """
 
     __cm: AbstractContextManager[object, bool | None] | None = None
@@ -115,6 +117,8 @@ class AsyncContextManagerMixin:
 
     .. note:: Classes using this mix-in are not reentrant as context managers, meaning
         that once you enter it, you can't re-enter before first exiting it.
+
+    .. seealso:: :doc:`contextmanagers`
     """
 
     __cm: AbstractAsyncContextManager[object, bool | None] | None = None

--- a/src/anyio/_core/_contextmanagers.py
+++ b/src/anyio/_core/_contextmanagers.py
@@ -6,10 +6,10 @@ from inspect import isasyncgen, iscoroutine
 from types import TracebackType
 from typing import Generic, TypeVar, final
 
-T = TypeVar("T")
+_T_co = TypeVar("_T_co", covariant=True)
 
 
-class ContextManagerMixin(Generic[T]):
+class ContextManagerMixin(Generic[_T_co]):
     """
     Mixin class providing context manager functionality via a generator-based
     implementation.
@@ -20,7 +20,7 @@ class ContextManagerMixin(Generic[T]):
     """
 
     @final
-    def __enter__(self) -> T:
+    def __enter__(self) -> _T_co:
         gen = self.__contextmanager__()
         if not isinstance(gen, Generator):
             raise TypeError(
@@ -64,7 +64,7 @@ class ContextManagerMixin(Generic[T]):
         raise RuntimeError("the __contextmanager__() generator didn't stop")
 
     @abstractmethod
-    def __contextmanager__(self) -> Generator[T, None, None]:
+    def __contextmanager__(self) -> Generator[_T_co, None, None]:
         """
         Implement your context manager logic here, as you would with
         :func:`@contextmanager <contextlib.contextmanager>`.
@@ -80,7 +80,7 @@ class ContextManagerMixin(Generic[T]):
         """
 
 
-class AsyncContextManagerMixin(Generic[T]):
+class AsyncContextManagerMixin(Generic[_T_co]):
     """
     Mixin class providing async context manager functionality via a generator-based
     implementation.
@@ -91,7 +91,7 @@ class AsyncContextManagerMixin(Generic[T]):
     """
 
     @final
-    async def __aenter__(self) -> T:
+    async def __aenter__(self) -> _T_co:
         gen = self.__asynccontextmanager__()
         if not isasyncgen(gen):
             if iscoroutine(gen):
@@ -143,7 +143,7 @@ class AsyncContextManagerMixin(Generic[T]):
         raise RuntimeError("the __asynccontextmanager__() generator didn't stop")
 
     @abstractmethod
-    def __asynccontextmanager__(self) -> AsyncGenerator[T, None]:
+    def __asynccontextmanager__(self) -> AsyncGenerator[_T_co, None]:
         """
         Implement your async context manager logic here, as you would with
         :func:`@asynccontextmanager <contextlib.asynccontextmanager>`.

--- a/src/anyio/_core/_contextmanagers.py
+++ b/src/anyio/_core/_contextmanagers.py
@@ -14,19 +14,9 @@ class ContextManagerMixin(Generic[T]):
     Mixin class providing context manager functionality via a generator-based
     implementation.
 
-    This class allows you to implement a context manager using a generator, similar to
-    :func:`contextlib.contextmanager`, but for classes that need to embed other context
-    managers.
-
-    This class is designed to streamline the use of context management by
-    requiring the implementation of the `__contextmanager__` method, which
-    should yield instances of the class itself. It then wraps this generator
-    with the standard `__enter__` and `__exit__` methods to make the class
-    work seamlessly in `with` statements.
-
-    The mixin enforces type checking to ensure consistency and correctness,
-    validating that the yielded value from the generator is an instance of the
-    class itself.
+    This class allows you to implement a context manager via :meth:`__contextmanager__`
+    which should return a generator. The mechanics are meant to mirror those of
+    :func:`@contextmanager <contextlib.contextmanager>`.
     """
 
     @final
@@ -75,10 +65,31 @@ class ContextManagerMixin(Generic[T]):
 
     @abstractmethod
     def __contextmanager__(self) -> Generator[T, None, None]:
-        pass
+        """
+        Implement your context manager logic here, as you would with
+        :func:`@contextmanager <contextlib.contextmanager>`.
+
+        Any code up to the ``yield`` will be run in ``__enter__()``, and any code after
+        it is run in ``__exit__()``.
+
+        .. note:: If an exception is raised in the context block, it is reraised from
+            the ``yield``, just like with
+            :func:`@contextmanager <contextlib.contextmanager>`.
+
+        :return: a generator that yields exactly once
+        """
 
 
 class AsyncContextManagerMixin(Generic[T]):
+    """
+    Mixin class providing async context manager functionality via a generator-based
+    implementation.
+
+    This class allows you to implement a context manager via
+    :meth:`__asynccontextmanager__`. The mechanics are meant to mirror those of
+    :func:`@asynccontextmanager <contextlib.asynccontextmanager>`.
+    """
+
     @final
     async def __aenter__(self) -> T:
         gen = self.__asynccontextmanager__()
@@ -133,4 +144,16 @@ class AsyncContextManagerMixin(Generic[T]):
 
     @abstractmethod
     def __asynccontextmanager__(self) -> AsyncGenerator[T, None]:
-        pass
+        """
+        Implement your async context manager logic here, as you would with
+        :func:`@asynccontextmanager <contextlib.asynccontextmanager>`.
+
+        Any code up to the ``yield`` will be run in ``__aenter__()``, and any code after
+        it is run in ``__aexit__()``.
+
+        .. note:: If an exception is raised in the context block, it is reraised from
+            the ``yield``, just like with
+            :func:`@asynccontextmanager <contextlib.asynccontextmanager>`.
+
+        :return: an async generator that yields exactly once
+        """

--- a/src/anyio/_core/_contextmanagers.py
+++ b/src/anyio/_core/_contextmanagers.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import AsyncGenerator, Generator
+from inspect import isasyncgen, iscoroutine
+from types import TracebackType
+from typing import Generic, TypeVar, final
+
+T = TypeVar("T")
+
+
+class ContextManagerMixin(Generic[T]):
+    """
+    Mixin class providing context manager functionality via a generator-based
+    implementation.
+
+    This class allows you to implement a context manager using a generator, similar to
+    :func:`contextlib.contextmanager`, but for classes that need to embed other context
+    managers.
+
+    This class is designed to streamline the use of context management by
+    requiring the implementation of the `__contextmanager__` method, which
+    should yield instances of the class itself. It then wraps this generator
+    with the standard `__enter__` and `__exit__` methods to make the class
+    work seamlessly in `with` statements.
+
+    The mixin enforces type checking to ensure consistency and correctness,
+    validating that the yielded value from the generator is an instance of the
+    class itself.
+    """
+
+    @final
+    def __enter__(self) -> T:
+        gen = self.__contextmanager__()
+        if not isinstance(gen, Generator):
+            raise TypeError(
+                f"__contextmanager__() did not return a generator object, "
+                f"but {gen.__class__!r}"
+            )
+
+        try:
+            value = gen.send(None)
+        except StopIteration:
+            raise RuntimeError(
+                "the __contextmanager__() generator returned without yielding a value"
+            ) from None
+
+        self.__cm = gen
+        return value
+
+    @final
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        # Prevent circular references
+        cm = self.__cm
+        del self.__cm
+
+        if exc_val is not None:
+            try:
+                cm.throw(exc_val)
+            except StopIteration:
+                return True
+        else:
+            try:
+                cm.send(None)
+            except StopIteration:
+                return None
+
+        cm.close()
+        raise RuntimeError("the __contextmanager__() generator didn't stop")
+
+    @abstractmethod
+    def __contextmanager__(self) -> Generator[T, None, None]:
+        pass
+
+
+class AsyncContextManagerMixin(Generic[T]):
+    @final
+    async def __aenter__(self) -> T:
+        gen = self.__asynccontextmanager__()
+        if not isasyncgen(gen):
+            if iscoroutine(gen):
+                gen.close()
+                raise TypeError(
+                    "__asynccontextmanager__() returned a coroutine object instead of "
+                    "an async generator. Did you forget to add 'yield'?"
+                )
+
+            raise TypeError(
+                f"__asynccontextmanager__() did not return an async generator object, "
+                f"but {gen.__class__!r}"
+            )
+
+        try:
+            value = await gen.asend(None)
+        except StopAsyncIteration:
+            raise RuntimeError(
+                "the __asynccontextmanager__() generator returned without yielding a "
+                "value"
+            ) from None
+
+        self.__cm = gen
+        return value
+
+    @final
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        # Prevent circular references
+        cm = self.__cm
+        del self.__cm
+
+        if exc_val is not None:
+            try:
+                await cm.athrow(exc_val)
+            except StopAsyncIteration:
+                return True
+        else:
+            try:
+                await cm.asend(None)
+            except StopAsyncIteration:
+                return None
+
+        await cm.aclose()
+        raise RuntimeError("the __asynccontextmanager__() generator didn't stop")
+
+    @abstractmethod
+    def __asynccontextmanager__(self) -> AsyncGenerator[T, None]:
+        pass

--- a/tests/test_contextmanagers.py
+++ b/tests/test_contextmanagers.py
@@ -22,7 +22,7 @@ from anyio import AsyncContextManagerMixin, ContextManagerMixin
 pytestmark = pytest.mark.anyio
 
 
-class DummyContextManager(ContextManagerMixin["DummyContextManager"]):
+class DummyContextManager(ContextManagerMixin):
     def __init__(self, handle_exc: bool = False) -> None:
         self.started = False
         self.finished = False
@@ -40,7 +40,7 @@ class DummyContextManager(ContextManagerMixin["DummyContextManager"]):
         self.finished = True
 
 
-class DummyAsyncContextManager(AsyncContextManagerMixin["DummyAsyncContextManager"]):
+class DummyAsyncContextManager(AsyncContextManagerMixin):
     def __init__(self, handle_exc: bool = False) -> None:
         self.started = False
         self.finished = False
@@ -79,7 +79,7 @@ class TestContextManagerMixin:
         assert cm.finished == handle_exc
 
     def test_return_bad_type(self) -> None:
-        class BadContextManager(ContextManagerMixin[None]):
+        class BadContextManager(ContextManagerMixin):
             def __contextmanager__(self) -> AbstractContextManager[None]:
                 return None  # type: ignore[return-value]
 
@@ -88,7 +88,7 @@ class TestContextManagerMixin:
                 pass
 
     def test_return_generator(self) -> None:
-        class BadContextManager(ContextManagerMixin["BadContextManager"]):
+        class BadContextManager(ContextManagerMixin):
             def __contextmanager__(self):  # type: ignore[no-untyped-def]
                 yield self
 
@@ -97,7 +97,7 @@ class TestContextManagerMixin:
                 pass
 
     def test_return_self(self) -> None:
-        class BadContextManager(ContextManagerMixin["BadContextManager"]):
+        class BadContextManager(ContextManagerMixin):
             def __contextmanager__(self):  # type: ignore[no-untyped-def]
                 return self
 
@@ -173,7 +173,7 @@ class TestAsyncContextManagerMixin:
         assert cm.finished == handle_exc
 
     async def test_return_bad_type(self) -> None:
-        class BadContextManager(AsyncContextManagerMixin[None]):
+        class BadContextManager(AsyncContextManagerMixin):
             def __asynccontextmanager__(self):  # type: ignore[no-untyped-def]
                 return None
 
@@ -182,7 +182,7 @@ class TestAsyncContextManagerMixin:
                 pass
 
     async def test_return_async_generator(self) -> None:
-        class BadContextManager(AsyncContextManagerMixin["BadContextManager"]):
+        class BadContextManager(AsyncContextManagerMixin):
             async def __asynccontextmanager__(self):  # type: ignore[no-untyped-def]
                 yield self
 
@@ -191,7 +191,7 @@ class TestAsyncContextManagerMixin:
                 pass
 
     async def test_return_self(self) -> None:
-        class BadContextManager(AsyncContextManagerMixin["BadContextManager"]):
+        class BadContextManager(AsyncContextManagerMixin):
             def __asynccontextmanager__(self):  # type: ignore[no-untyped-def]
                 return self
 
@@ -200,7 +200,7 @@ class TestAsyncContextManagerMixin:
                 pass
 
     async def test_return_coroutine(self) -> None:
-        class BadContextManager(AsyncContextManagerMixin["BadContextManager"]):
+        class BadContextManager(AsyncContextManagerMixin):
             async def __asynccontextmanager__(self):  # type: ignore[no-untyped-def]
                 return self
 

--- a/tests/test_contextmanagers.py
+++ b/tests/test_contextmanagers.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Generator
+from contextlib import AsyncExitStack, ExitStack
+
+import pytest
+
+from anyio import AsyncContextManagerMixin, ContextManagerMixin
+
+pytestmark = pytest.mark.anyio
+
+
+class DummyContextManager(ContextManagerMixin["DummyContextManager"]):
+    def __init__(self, handle_exc: bool = False) -> None:
+        self.started = False
+        self.finished = False
+        self.handle_exc = handle_exc
+
+    def __contextmanager__(self) -> Generator[DummyContextManager, None, None]:
+        self.started = True
+        try:
+            yield self
+        except RuntimeError:
+            if not self.handle_exc:
+                raise
+
+        self.finished = True
+
+
+class DummyAsyncContextManager(AsyncContextManagerMixin["DummyAsyncContextManager"]):
+    def __init__(self, handle_exc: bool = False) -> None:
+        self.started = False
+        self.finished = False
+        self.handle_exc = handle_exc
+
+    async def __asynccontextmanager__(
+        self,
+    ) -> AsyncGenerator[DummyAsyncContextManager, None]:
+        self.started = True
+        try:
+            yield self
+        except RuntimeError:
+            if not self.handle_exc:
+                raise
+
+        self.finished = True
+
+
+class TestContextManagerMixin:
+    def test_contextmanager(self) -> None:
+        with DummyContextManager() as cm:
+            assert cm.started
+            assert not cm.finished
+
+        assert cm.finished
+
+    @pytest.mark.parametrize("handle_exc", [True, False])
+    def test_exception(self, handle_exc: bool) -> None:
+        with ExitStack() as stack:
+            if not handle_exc:
+                stack.enter_context(pytest.raises(RuntimeError, match="^foo$"))
+
+            cm = stack.enter_context(DummyContextManager(handle_exc))
+            raise RuntimeError("foo")
+
+        assert cm.started
+        assert cm.finished == handle_exc
+
+    def test_bad_return_type(self) -> None:
+        class BadContextManager(ContextManagerMixin[None]):
+            def __contextmanager__(self) -> Generator[None, None, None]:
+                return self  # type: ignore[return-value]
+
+        with pytest.raises(TypeError, match="did not return a generator object"):
+            with BadContextManager():
+                pass
+
+    def test_no_initial_yield(self) -> None:
+        class BadContextManager(ContextManagerMixin["BadContextManager"]):
+            def __contextmanager__(self) -> Generator[BadContextManager, None, None]:
+                if False:
+                    yield self
+
+        with pytest.raises(RuntimeError, match="generator returned without yielding"):
+            with BadContextManager():
+                pass
+
+    def test_too_many_yields(self) -> None:
+        class BadContextManager(ContextManagerMixin[None]):
+            def __contextmanager__(self) -> Generator[None, None, None]:
+                yield
+                yield
+
+        with pytest.raises(RuntimeError, match="generator didn't stop$"):
+            with BadContextManager():
+                pass
+
+
+class TestAsyncContextManagerMixin:
+    async def test_contextmanager(self) -> None:
+        async with DummyAsyncContextManager() as cm:
+            assert cm.started
+            assert not cm.finished
+
+        assert cm.finished
+
+    @pytest.mark.parametrize("handle_exc", [True, False])
+    async def test_exception(self, handle_exc: bool) -> None:
+        async with AsyncExitStack() as stack:
+            if not handle_exc:
+                stack.enter_context(pytest.raises(RuntimeError, match="^foo$"))
+
+            cm = await stack.enter_async_context(DummyAsyncContextManager(handle_exc))
+            raise RuntimeError("foo")
+
+        assert cm.started
+        assert cm.finished == handle_exc
+
+    async def test_bad_return_type(self) -> None:
+        class BadContextManager(AsyncContextManagerMixin[None]):
+            def __asynccontextmanager__(self) -> AsyncGenerator[None, None]:
+                return None  # type: ignore[return-value]
+
+        with pytest.raises(TypeError, match="did not return an async generator object"):
+            async with BadContextManager():
+                pass
+
+    async def test_return_coroutine(self) -> None:
+        class BadContextManager(AsyncContextManagerMixin[None]):
+            async def __asynccontextmanager__(self) -> AsyncGenerator[None, None]:  # type: ignore[override]
+                return None  # type: ignore[return-value]
+
+        with pytest.raises(TypeError, match="returned a coroutine object instead of"):
+            async with BadContextManager():
+                pass
+
+    async def test_no_initial_yield(self) -> None:
+        class BadContextManager(AsyncContextManagerMixin[None]):
+            async def __asynccontextmanager__(self) -> AsyncGenerator[None, None]:
+                if False:
+                    yield
+
+        with pytest.raises(RuntimeError, match="generator returned without yielding"):
+            async with BadContextManager():
+                pass
+
+    async def test_too_many_yields(self) -> None:
+        class BadContextManager(AsyncContextManagerMixin[None]):
+            async def __asynccontextmanager__(self) -> AsyncGenerator[None, None]:
+                yield
+                yield
+
+        with pytest.raises(RuntimeError, match="generator didn't stop$"):
+            async with BadContextManager():
+                pass

--- a/tests/test_contextmanagers.py
+++ b/tests/test_contextmanagers.py
@@ -95,6 +95,22 @@ class TestContextManagerMixin:
             with BadContextManager():
                 pass
 
+    def test_enter_twice(self) -> None:
+        with DummyContextManager() as cm:
+            with pytest.raises(
+                RuntimeError,
+                match="^this DummyContextManager has already been entered$",
+            ):
+                with cm:
+                    pass
+
+    def test_exit_before_enter(self) -> None:
+        cm = DummyContextManager()
+        with pytest.raises(
+            RuntimeError, match="^this DummyContextManager has not been entered yet$"
+        ):
+            cm.__exit__(None, None, None)
+
 
 class TestAsyncContextManagerMixin:
     async def test_contextmanager(self) -> None:
@@ -153,3 +169,20 @@ class TestAsyncContextManagerMixin:
         with pytest.raises(RuntimeError, match="generator didn't stop$"):
             async with BadContextManager():
                 pass
+
+    async def test_enter_twice(self) -> None:
+        async with DummyAsyncContextManager() as cm:
+            with pytest.raises(
+                RuntimeError,
+                match="^this DummyAsyncContextManager has already been entered$",
+            ):
+                async with cm:
+                    pass
+
+    async def test_exit_before_enter(self) -> None:
+        cm = DummyAsyncContextManager()
+        with pytest.raises(
+            RuntimeError,
+            match="^this DummyAsyncContextManager has not been entered yet$",
+        ):
+            await cm.__aexit__(None, None, None)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This adds two new mix-in classes: `ContextManagerMixin` and `AsyncContextManagerMixin`. They're meant to enable users to write context manager classes in the same way as `@contextmanager` and `@asynccontextmanager`, respectively. The aim is to enable users to more easily embed cancel scopes and task groups into other context manager classes.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [X] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
