### PR TITLE
Fixed getaddrinfo tests failing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,18 @@ jobs:
         cache-dependency-path: pyproject.toml
     - name: Install dependencies
       run: pip install -e .[test]
+    - name: Patch /etc/hosts
+      if: runner.os != 'Windows'
+      run: |
+        sudo echo "1.2.3.4 xn--fa-hia.de" >> /etc/hosts
+        sudo echo "5.6.7.8 fass.de" >> /etc/hosts
+    - name: Patch C:\Windows\System32\drivers\etc\hosts
+      if: runner.os == 'Windows'
+      run: |
+        Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "1.2.3.4 xn--fa-hia.de"
+        Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "5.6.7.8 fass.de"
+    - name: Install coverage
+      run: pip install coverage
     - name: Test with pytest
       run: coverage run -m pytest -v
       timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,8 +101,6 @@ jobs:
       run: |
         Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "1.2.3.4 xn--fa-hia.de"
         Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "5.6.7.8 fass.de"
-    - name: Install coverage
-      run: pip install coverage
     - name: Test with pytest
       run: coverage run -m pytest -v
       timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,8 +94,8 @@ jobs:
     - name: Patch /etc/hosts
       if: runner.os != 'Windows'
       run: |
-        sudo echo "1.2.3.4 xn--fa-hia.de" >> /etc/hosts
-        sudo echo "5.6.7.8 fass.de" >> /etc/hosts
+        echo "1.2.3.4 xn--fa-hia.de" | sudo tee -a /etc/hosts
+        echo "5.6.7.8 fass.de" | sudo tee -a /etc/hosts
     - name: Patch C:\Windows\System32\drivers\etc\hosts
       if: runner.os == 'Windows'
       run: |

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -14,7 +14,7 @@ import time
 from collections.abc import Generator, Iterable, Iterator
 from contextlib import suppress
 from pathlib import Path
-from socket import AddressFamily
+from socket import AddressFamily, SocketKind
 from ssl import SSLContext, SSLError
 from threading import Thread
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeVar, cast
@@ -1842,8 +1842,29 @@ class TestConnectedUNIXDatagramSocket:
             await udp.send(b"foo")
 
 
-@pytest.mark.network
-async def test_getaddrinfo() -> None:
+async def test_getaddrinfo(monkeypatch: MonkeyPatch) -> None:
+    def fake_getaddrinfo(
+        host: str | bytes,
+        port: int | str,
+        family: int = 0,
+        type: int = 0,
+        proto: int = 0,
+        flags: int = 0,
+    ) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+        if host == b"xn--fa-hia.de":
+            address = "1.2.3.4"
+        else:
+            assert host == b"fass.de"
+            address = "5.6.7.8"
+
+        return [
+            (AddressFamily.AF_INET, SocketKind.SOCK_RAW, 6, "", (address, 0)),
+            (AddressFamily.AF_INET, SocketKind.SOCK_RAW, 17, "", (address, 0)),
+            (AddressFamily.AF_INET, SocketKind.SOCK_RAW, 0, "", (address, 0)),
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
     # IDNA 2003 gets this wrong
     correct = await getaddrinfo("faß.de", 0)
     wrong = await getaddrinfo("fass.de", 0)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes sporadically failing `test_getaddrinfo()` due to external DNS issues.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
