### PR TITLE
[typing] Fix return annotation of `__aexit__`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -12,6 +12,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   this prevents an OSError on the ``ProactorEventLoop``.
   (`#896 <https://github.com/agronholm/anyio/pull/896>`_; PR by @graingert)
 - Fixed ``anyio.Path.copy()`` and ``anyio.Path.copy_into()`` failing on Python 3.14.0a7
+- Fixed return annotation of ``__aexit__`` on async context managers. CMs which can
+  suppress exceptions should return ``bool``, or ``None`` otherwise.
+  (`#913 <https://github.com/agronholm/anyio/pull/913>`_; PR by @Enegg)
 
 **4.9.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -726,7 +726,7 @@ class TaskGroup(abc.TaskGroup):
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> bool:
         try:
             if exc_val is not None:
                 self.cancel_scope.cancel()

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -505,7 +505,7 @@ class CapacityLimiter:
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> None:
         raise NotImplementedError
 
     @property
@@ -630,7 +630,7 @@ class CapacityLimiterAdapter(CapacityLimiter):
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> None:
         return await self._limiter.__aexit__(exc_type, exc_val, exc_tb)
 
     @property

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -35,7 +35,7 @@ class _NullAsyncContextManager:
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> None:
         return None
 
 

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -97,5 +97,5 @@ class TaskGroup(metaclass=ABCMeta):
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> bool:
         """Exit the task group context waiting for all tasks to finish."""

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -163,7 +163,7 @@ class BlockingPortal:
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> bool | None:
+    ) -> bool:
         await self.stop()
         return await self._task_group.__aexit__(exc_type, exc_val, exc_tb)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

A follow-up to #849. I had done a search for `def __exit__` in the prior PR, forgetting that `__aexit__` is also a thing.

I tried adding the following "test" (static assert, not supposed to be run), but what works with pyright fails with mypy ¯\\\_(ツ)\_/¯
```py
from typing import assert_type

async def assert_context_manager_reachability() -> None:
    # typing-only check
    tg_var = ()

    async with create_task_group():
        tg_var = int("123")

    assert_type(tg_var, "int | tuple[()]")

    cs_var = ()
    with CancelScope():  # noqa: ASYNC100
        cs_var = int("123")

    assert_type(cs_var, "int | tuple[()]")
```

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
