### PR TITLE
fix(tempfile): correct SpooledTemporaryFile rollover boundary

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed rollover boundary check in ``SpooledTemporaryFile`` so that rollover
+  only occurs when the buffer size exceeds ``max_size``
+  (`#915 <https://github.com/agronholm/anyio/pull/915>`_; PR by @11kkw)
 - Added the ability to specify the thread name in ``start_blocking_portal()``
   (`#818 <https://github.com/agronholm/anyio/issues/818>`_; PR by @davidbrochart)
 - Added ``anyio.notify_closing`` to allow waking ``anyio.wait_readable``

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -312,7 +312,7 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
         await super().aclose()
 
     async def _check(self) -> None:
-        if self._rolled or self._fp.tell() < self._max_size:
+        if self._rolled or self._fp.tell() <= self._max_size:
             return
 
         await self.rollover()

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -102,7 +102,6 @@ class TestSpooledTemporaryFile:
 
         assert stf.closed
 
-
     async def test_exact_boundary_no_rollover(self) -> None:
         async with SpooledTemporaryFile(max_size=10) as stf:
             await stf.write(b"0123456789")

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -102,6 +102,24 @@ class TestSpooledTemporaryFile:
 
         assert stf.closed
 
+    async def test_exact_boundary_no_rollover(self) -> None:
+        rollover_called = False
+
+        async def fake_rollover() -> None:
+            nonlocal rollover_called
+            rollover_called = True
+            await original_rollover()
+
+        async with SpooledTemporaryFile(max_size=10) as stf:
+            original_rollover = stf.rollover
+            with patch.object(stf, "rollover", fake_rollover):
+                await stf.write(b"0123456789")
+                assert not rollover_called
+
+                more = b"x"
+                await stf.write(more)
+                assert rollover_called
+
 
 class TestTemporaryDirectory:
     async def test_context_manager(self) -> None:

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -40,20 +40,20 @@ class TestNamedTemporaryFile:
         data = b"named temporary file data"
         async with NamedTemporaryFile[bytes]() as af:
             filename = af.name
-            assert os.path.exists(filename)  # type: ignore[arg-type]
+            assert os.path.exists(filename)
 
             await af.write(data)
             await af.seek(0)
             assert await af.read() == data
 
-        assert not os.path.exists(filename)  # type: ignore[arg-type]
+        assert not os.path.exists(filename)
 
     async def test_exception_handling(self) -> None:
         async with NamedTemporaryFile[bytes]() as af:
             filename = af.name
-            assert os.path.exists(filename)  # type: ignore[arg-type]
+            assert os.path.exists(filename)
 
-        assert not os.path.exists(filename)  # type: ignore[arg-type]
+        assert not os.path.exists(filename)
 
         with pytest.raises(ValueError):
             await af.write(b"should fail")
@@ -103,22 +103,12 @@ class TestSpooledTemporaryFile:
         assert stf.closed
 
     async def test_exact_boundary_no_rollover(self) -> None:
-        rollover_called = False
-
-        async def fake_rollover() -> None:
-            nonlocal rollover_called
-            rollover_called = True
-            await original_rollover()
-
         async with SpooledTemporaryFile(max_size=10) as stf:
-            original_rollover = stf.rollover
-            with patch.object(stf, "rollover", fake_rollover):
-                await stf.write(b"0123456789")
-                assert not rollover_called
+            await stf.write(b"0123456789")
+            assert not stf._rolled
 
-                more = b"x"
-                await stf.write(more)
-                assert rollover_called
+            await stf.write(b"x")
+            assert stf._rolled
 
 
 class TestTemporaryDirectory:
@@ -178,14 +168,14 @@ async def test_mkstemp(
 
     if text:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(content)
+            f.write(content)  # type: ignore[arg-type]
         with open(path, encoding="utf-8") as f:
             read_content = f.read()
     else:
         with os.fdopen(fd, "wb") as f:
-            f.write(content)
+            f.write(content)  # type: ignore[arg-type]
         with open(os.fsdecode(path), "rb") as f:
-            read_content = f.read()
+            assert f.read() == content
 
     assert read_content == content
 

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -40,20 +40,20 @@ class TestNamedTemporaryFile:
         data = b"named temporary file data"
         async with NamedTemporaryFile[bytes]() as af:
             filename = af.name
-            assert os.path.exists(filename)
+            assert os.path.exists(filename)  # type: ignore[arg-type]
 
             await af.write(data)
             await af.seek(0)
             assert await af.read() == data
 
-        assert not os.path.exists(filename)
+        assert not os.path.exists(filename)  # type: ignore[arg-type]
 
     async def test_exception_handling(self) -> None:
         async with NamedTemporaryFile[bytes]() as af:
             filename = af.name
-            assert os.path.exists(filename)
+            assert os.path.exists(filename)  # type: ignore[arg-type]
 
-        assert not os.path.exists(filename)
+        assert not os.path.exists(filename)  # type: ignore[arg-type]
 
         with pytest.raises(ValueError):
             await af.write(b"should fail")
@@ -103,12 +103,22 @@ class TestSpooledTemporaryFile:
         assert stf.closed
 
     async def test_exact_boundary_no_rollover(self) -> None:
-        async with SpooledTemporaryFile(max_size=10) as stf:
-            await stf.write(b"0123456789")
-            assert not stf._rolled
+        rollover_called = False
 
-            await stf.write(b"x")
-            assert stf._rolled
+        async def fake_rollover() -> None:
+            nonlocal rollover_called
+            rollover_called = True
+            await original_rollover()
+
+        async with SpooledTemporaryFile(max_size=10) as stf:
+            original_rollover = stf.rollover
+            with patch.object(stf, "rollover", fake_rollover):
+                await stf.write(b"0123456789")
+                assert not rollover_called
+
+                more = b"x"
+                await stf.write(more)
+                assert rollover_called
 
 
 class TestTemporaryDirectory:
@@ -168,14 +178,14 @@ async def test_mkstemp(
 
     if text:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(content)  # type: ignore[arg-type]
+            f.write(content)
         with open(path, encoding="utf-8") as f:
             read_content = f.read()
     else:
         with os.fdopen(fd, "wb") as f:
-            f.write(content)  # type: ignore[arg-type]
+            f.write(content)
         with open(os.fsdecode(path), "rb") as f:
-            assert f.read() == content
+            read_content = f.read()
 
     assert read_content == content
 

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -102,24 +102,13 @@ class TestSpooledTemporaryFile:
 
         assert stf.closed
 
-    async def test_exact_boundary_no_rollover(self) -> None:
-        rollover_called = False
+async def test_exact_boundary_no_rollover(self) -> None:
+    async with SpooledTemporaryFile(max_size=10) as stf:
+        await stf.write(b"0123456789")
+        assert not stf._rolled
 
-        async def fake_rollover() -> None:
-            nonlocal rollover_called
-            rollover_called = True
-            await original_rollover()
-
-        async with SpooledTemporaryFile(max_size=10) as stf:
-            original_rollover = stf.rollover
-            with patch.object(stf, "rollover", fake_rollover):
-                await stf.write(b"0123456789")
-                assert not rollover_called
-
-                more = b"x"
-                await stf.write(more)
-                assert rollover_called
-
+        await stf.write(b"x")
+        assert stf._rolled
 
 class TestTemporaryDirectory:
     async def test_context_manager(self) -> None:

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -102,6 +102,7 @@ class TestSpooledTemporaryFile:
 
         assert stf.closed
 
+
 async def test_exact_boundary_no_rollover(self) -> None:
     async with SpooledTemporaryFile(max_size=10) as stf:
         await stf.write(b"0123456789")
@@ -109,6 +110,7 @@ async def test_exact_boundary_no_rollover(self) -> None:
 
         await stf.write(b"x")
         assert stf._rolled
+
 
 class TestTemporaryDirectory:
     async def test_context_manager(self) -> None:

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -103,13 +103,13 @@ class TestSpooledTemporaryFile:
         assert stf.closed
 
 
-async def test_exact_boundary_no_rollover(self) -> None:
-    async with SpooledTemporaryFile(max_size=10) as stf:
-        await stf.write(b"0123456789")
-        assert not stf._rolled
+    async def test_exact_boundary_no_rollover(self) -> None:
+        async with SpooledTemporaryFile(max_size=10) as stf:
+            await stf.write(b"0123456789")
+            assert not stf._rolled
 
-        await stf.write(b"x")
-        assert stf._rolled
+            await stf.write(b"x")
+            assert stf._rolled
 
 
 class TestTemporaryDirectory:


### PR DESCRIPTION
## Changes

- Change `_check` condition from `< self._max_size` to `<= self._max_size` so that rollover only occurs when size > max_size  
- Add `test_exact_boundary_no_rollover` to verify no rollover at the exact boundary and rollover on overflow

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch  
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new features)  
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`)
