### PR TITLE
Added class methods for wrapping sockets

### DIFF
--- a/docs/networking.rst
+++ b/docs/networking.rst
@@ -241,6 +241,20 @@ having to pass the path every time you send data to the peer::
 
     run(main)
 
+Wrapping existing sockets as streams or listeners
+-------------------------------------------------
+
+In some cases, you might want to create a socket in third party code and wrap that as an
+AnyIO stream or socket listener. For that, various class methods exists:
+
+* :meth:`.abc.SocketListener.from_socket`
+* :meth:`.abc.SocketStream.from_socket`
+* :meth:`.abc.UNIXSocketStream.from_socket`
+* :meth:`.abc.UDPSocket.from_socket`
+* :meth:`.abc.ConnectedUDPSocket.from_socket`
+* :meth:`.abc.UNIXDatagramSocket.from_socket`
+* :meth:`.abc.ConnectedUNIXDatagramSocket.from_socket`
+
 Abstracting remote connections using Connectables
 -------------------------------------------------
 

--- a/docs/networking.rst
+++ b/docs/networking.rst
@@ -245,7 +245,7 @@ Wrapping existing sockets as streams or listeners
 -------------------------------------------------
 
 In some cases, you might want to create a socket in third party code and wrap that as an
-AnyIO stream or socket listener. For that, various class methods exists:
+AnyIO stream or socket listener. For that, various class methods exist:
 
 * :meth:`.abc.SocketListener.from_socket`
 * :meth:`.abc.SocketStream.from_socket`

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,15 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added various class methods to wrap existing sockets as listeners or socket streams:
+
+  * ``SocketListener.wrap_socket()``
+  * ``SocketStream.wrap_socket()``
+  * ``UNIXSocketStream.wrap_socket()``
+  * ``UDPSocket.wrap_socket()``
+  * ``ConnectedUDPSocket.wrap_socket()``
+  * ``UNIXDatagramSocket.wrap_socket()``
+  * ``ConnectedUNIXDatagramSocket.wrap_socket()``
 - Added a hierarchy of connectable stream classes for transparently connecting to
   various remote or local endpoints for exchanging bytes or objects
 - Added context manager mix-in classes (``anyio.ContextManagerMixin`` and

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,13 +7,13 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added various class methods to wrap existing sockets as listeners or socket streams:
 
-  * ``SocketListener.wrap_socket()``
-  * ``SocketStream.wrap_socket()``
-  * ``UNIXSocketStream.wrap_socket()``
-  * ``UDPSocket.wrap_socket()``
-  * ``ConnectedUDPSocket.wrap_socket()``
-  * ``UNIXDatagramSocket.wrap_socket()``
-  * ``ConnectedUNIXDatagramSocket.wrap_socket()``
+  * ``SocketListener.from_socket()``
+  * ``SocketStream.from_socket()``
+  * ``UNIXSocketStream.from_socket()``
+  * ``UDPSocket.from_socket()``
+  * ``ConnectedUDPSocket.from_socket()``
+  * ``UNIXDatagramSocket.from_socket()``
+  * ``ConnectedUNIXDatagramSocket.from_socket()``
 - Added a hierarchy of connectable stream classes for transparently connecting to
   various remote or local endpoints for exchanging bytes or objects
 - Added context manager mix-in classes (``anyio.ContextManagerMixin`` and

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2855,6 +2855,45 @@ class AsyncIOBackend(AsyncBackend):
                     get_selector().remove_reader(fd)
 
     @classmethod
+    async def wrap_listener_socket(cls, sock: socket.socket) -> SocketListener:
+        return TCPSocketListener(sock)
+
+    @classmethod
+    async def wrap_stream_socket(cls, sock: socket.socket) -> SocketStream:
+        transport, protocol = await get_running_loop().create_connection(
+            StreamProtocol, sock=sock
+        )
+        return SocketStream(transport, protocol)
+
+    @classmethod
+    async def wrap_unix_stream_socket(cls, sock: socket.socket) -> UNIXSocketStream:
+        return UNIXSocketStream(sock)
+
+    @classmethod
+    async def wrap_udp_socket(cls, sock: socket.socket) -> UDPSocket:
+        transport, protocol = await get_running_loop().create_datagram_endpoint(
+            DatagramProtocol, sock=sock
+        )
+        return UDPSocket(transport, protocol)
+
+    @classmethod
+    async def wrap_connected_udp_socket(cls, sock: socket.socket) -> ConnectedUDPSocket:
+        transport, protocol = await get_running_loop().create_datagram_endpoint(
+            DatagramProtocol, sock=sock
+        )
+        return ConnectedUDPSocket(transport, protocol)
+
+    @classmethod
+    async def wrap_unix_datagram_socket(cls, sock: socket.socket) -> UNIXDatagramSocket:
+        return UNIXDatagramSocket(sock)
+
+    @classmethod
+    async def wrap_connected_unix_datagram_socket(
+        cls, sock: socket.socket
+    ) -> ConnectedUNIXDatagramSocket:
+        return ConnectedUNIXDatagramSocket(sock)
+
+    @classmethod
     def current_default_thread_limiter(cls) -> CapacityLimiter:
         try:
             return _default_thread_limiter.get()

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1287,6 +1287,42 @@ class TrioBackend(AsyncBackend):
         notify_closing(obj)
 
     @classmethod
+    async def wrap_listener_socket(cls, sock: socket.socket) -> abc.SocketListener:
+        return TCPSocketListener(sock)
+
+    @classmethod
+    async def wrap_stream_socket(cls, sock: socket.socket) -> SocketStream:
+        trio_sock = trio.socket.from_stdlib_socket(sock)
+        return SocketStream(trio_sock)
+
+    @classmethod
+    async def wrap_unix_stream_socket(cls, sock: socket.socket) -> UNIXSocketStream:
+        trio_sock = trio.socket.from_stdlib_socket(sock)
+        return UNIXSocketStream(trio_sock)
+
+    @classmethod
+    async def wrap_udp_socket(cls, sock: socket.socket) -> UDPSocket:
+        trio_sock = trio.socket.from_stdlib_socket(sock)
+        return UDPSocket(trio_sock)
+
+    @classmethod
+    async def wrap_connected_udp_socket(cls, sock: socket.socket) -> ConnectedUDPSocket:
+        trio_sock = trio.socket.from_stdlib_socket(sock)
+        return ConnectedUDPSocket(trio_sock)
+
+    @classmethod
+    async def wrap_unix_datagram_socket(cls, sock: socket.socket) -> UNIXDatagramSocket:
+        trio_sock = trio.socket.from_stdlib_socket(sock)
+        return UNIXDatagramSocket(trio_sock)
+
+    @classmethod
+    async def wrap_connected_unix_datagram_socket(
+        cls, sock: socket.socket
+    ) -> ConnectedUNIXDatagramSocket:
+        trio_sock = trio.socket.from_stdlib_socket(sock)
+        return ConnectedUNIXDatagramSocket(trio_sock)
+
+    @classmethod
     def current_default_thread_limiter(cls) -> CapacityLimiter:
         try:
             return _capacity_limiter_wrapper.get()

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -350,6 +350,43 @@ class AsyncBackend(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
+    async def wrap_listener_socket(cls, sock: socket) -> SocketListener:
+        pass
+
+    @classmethod
+    @abstractmethod
+    async def wrap_stream_socket(cls, sock: socket) -> SocketStream:
+        pass
+
+    @classmethod
+    @abstractmethod
+    async def wrap_unix_stream_socket(cls, sock: socket) -> UNIXSocketStream:
+        pass
+
+    @classmethod
+    @abstractmethod
+    async def wrap_udp_socket(cls, sock: socket) -> UDPSocket:
+        pass
+
+    @classmethod
+    @abstractmethod
+    async def wrap_connected_udp_socket(cls, sock: socket) -> ConnectedUDPSocket:
+        pass
+
+    @classmethod
+    @abstractmethod
+    async def wrap_unix_datagram_socket(cls, sock: socket) -> UNIXDatagramSocket:
+        pass
+
+    @classmethod
+    @abstractmethod
+    async def wrap_connected_unix_datagram_socket(
+        cls, sock: socket
+    ) -> ConnectedUNIXDatagramSocket:
+        pass
+
+    @classmethod
+    @abstractmethod
     def current_default_thread_limiter(cls) -> CapacityLimiter:
         pass
 

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -61,8 +61,8 @@ def _validate_socket(
         if require_connected:
             try:
                 sock.getpeername()
-            except OSError:
-                raise ValueError("the socket must be connected") from None
+            except OSError as exc:
+                raise ValueError("the socket must be connected") from exc
 
         if require_bound:
             try:

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -58,17 +58,6 @@ def _validate_socket(
         )
 
     try:
-        if addr_family != socket.AF_UNSPEC and sock.family != addr_family:
-            raise ValueError(
-                f"address family mismatch: expected {addr_family.name}, got "
-                f"{sock.family.name}"
-            )
-
-        if sock.type != sock_type:
-            raise ValueError(
-                f"socket type mismatch: expected {sock_type.name}, got {sock.type.name}"
-            )
-
         if require_connected:
             try:
                 sock.getpeername()
@@ -86,6 +75,17 @@ def _validate_socket(
 
             if not bound_addr:
                 raise ValueError("the socket must be bound to a local address")
+
+        if addr_family != socket.AF_UNSPEC and sock.family != addr_family:
+            raise ValueError(
+                f"address family mismatch: expected {addr_family.name}, got "
+                f"{sock.family.name}"
+            )
+
+        if sock.type != sock_type:
+            raise ValueError(
+                f"socket type mismatch: expected {sock_type.name}, got {sock.type.name}"
+            )
     except BaseException:
         # Avoid ResourceWarning from the locally constructed socket object
         if isinstance(sock_or_fd, int):

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import socket
 import sys
 from abc import abstractmethod
@@ -44,7 +45,11 @@ def _validate_socket(
         try:
             sock = socket.socket(fileno=sock_or_fd)
         except OSError as exc:
-            if require_connected:
+            if exc.errno == errno.ENOTSOCK:
+                raise ValueError(
+                    "the file descriptor does not refer to a socket"
+                ) from exc
+            elif require_connected:
                 raise ValueError("the socket must be connected") from exc
             elif require_bound:
                 raise ValueError("the socket must be bound to a local address") from exc

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -43,11 +43,11 @@ def _validate_socket(
     if isinstance(sock_or_fd, int):
         try:
             sock = socket.socket(fileno=sock_or_fd)
-        except OSError:
+        except OSError as exc:
             if require_connected:
-                raise ValueError("the socket must be connected") from None
+                raise ValueError("the socket must be connected") from exc
             elif require_bound:
-                raise ValueError("the socket must be bound to a local address")
+                raise ValueError("the socket must be bound to a local address") from exc
             else:
                 raise
     elif isinstance(sock_or_fd, socket.socket):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -174,12 +174,12 @@ def sock_or_fd_factory(
         sock = socket.socket(family, kind)
 
         if bound or connected:
-            if family == socket.AF_UNIX:
+            if family in (socket.AF_INET, socket.AF_INET6):
+                local_addr = ("localhost", 0)
+            else:
                 local_addr: str | tuple[str, int] = str(
                     tmp_path_factory.mktemp("anyio") / "socket"
                 )
-            else:
-                local_addr = ("localhost", 0)
 
         if bound:
             sock.bind(local_addr)

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -175,11 +175,9 @@ def sock_or_fd_factory(
 
         if bound or connected:
             if family in (socket.AF_INET, socket.AF_INET6):
-                local_addr = ("localhost", 0)
+                local_addr: str | tuple[str, int] = ("localhost", 0)
             else:
-                local_addr: str | tuple[str, int] = str(
-                    tmp_path_factory.mktemp("anyio") / "socket"
-                )
+                local_addr = str(tmp_path_factory.mktemp("anyio") / "socket")
 
         if bound:
             sock.bind(local_addr)

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -652,7 +652,9 @@ class TestTCPStream:
     async def test_from_socket_wrong_socket_type(
         self, sock_or_fd_factory: SockFdFactoryProtocol
     ) -> None:
-        sock_or_fd = sock_or_fd_factory(socket.AF_INET, socket.SocketKind.SOCK_DGRAM)
+        sock_or_fd = sock_or_fd_factory(
+            socket.AF_INET, socket.SocketKind.SOCK_DGRAM, connected=True
+        )
         with pytest.raises(
             ValueError,
             match="socket type mismatch: expected SOCK_STREAM, got SOCK_DGRAM",
@@ -1247,7 +1249,9 @@ class TestUNIXStream:
     async def test_from_socket_wrong_socket_type(
         self, sock_or_fd_factory: SockFdFactoryProtocol
     ) -> None:
-        sock_or_fd = sock_or_fd_factory(socket.AF_UNIX, socket.SOCK_DGRAM)
+        sock_or_fd = sock_or_fd_factory(
+            socket.AF_UNIX, socket.SOCK_DGRAM, connected=True
+        )
         with pytest.raises(
             ValueError,
             match="socket type mismatch: expected SOCK_STREAM, got SOCK_DGRAM",
@@ -1257,7 +1261,9 @@ class TestUNIXStream:
     async def test_from_socket_wrong_address_family(
         self, sock_or_fd_factory: SockFdFactoryProtocol
     ) -> None:
-        sock_or_fd = sock_or_fd_factory(socket.AF_INET, socket.SOCK_STREAM)
+        sock_or_fd = sock_or_fd_factory(
+            socket.AF_INET, socket.SOCK_STREAM, connected=True
+        )
         with pytest.raises(
             ValueError,
             match="address family mismatch: expected AF_UNIX, got AF_INET",

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1541,6 +1541,7 @@ class TestUDPSocket:
         self, family: AnyIPAddressFamily, as_fileno: bool
     ) -> None:
         sock = socket.socket(family, socket.SOCK_DGRAM)
+        sock.bind(("localhost", 0))
         sock_or_fd = sock.detach() if as_fileno else sock
         async with await UDPSocket.from_socket(sock_or_fd) as udp_socket:
             assert isinstance(udp_socket, UDPSocket)

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -647,6 +647,14 @@ class TestTCPStream:
         ):
             await SocketStream.from_socket("foo")  # type: ignore[arg-type]
 
+    async def test_from_socket_pass_file_fd(self, tmp_path: Path) -> None:
+        with pytest.raises(
+            ValueError,
+            match="the file descriptor does not refer to a socket",
+        ):
+            with tmp_path.joinpath("foo").open("wb") as fd:
+                await SocketStream.from_socket(fd.fileno())
+
     async def test_from_socket_wrong_socket_type(
         self, sock_or_fd_factory: SockFdFactoryProtocol
     ) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Allows wrapping existing sockets as AnyIO streams or listeners.

Fixes #845. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [X] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
