### PR TITLE
implement tg.start_context

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install dependencies
       run: pip install -e . pyright pytest
     - name: Run pyright
-      run: pyright --verifytypes anyio
+      run: pyright --ignoreexternal --verifytypes anyio
 
   test:
     strategy:

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -30,6 +30,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#926 <https://github.com/agronholm/anyio/issues/926>`_; PR by @hroncok)
 - Fixed ``SyntaxWarning`` on Python 3.14 about ``return`` in ``finally``
   (`#816 <https://github.com/agronholm/anyio/issues/816>`_)
+- Added ``TaskGroup.start_context()`` method as a better typed alternative to
+  ``TaskGroup.start()``. Fixes `#678 <https://github.com/agronholm/anyio/issue/678>`_.
 
 **4.9.0**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,12 @@
 [build-system]
-requires = [
-    "setuptools >= 77",
-    "setuptools_scm >= 6.4"
-]
+requires = ["setuptools >= 77", "setuptools_scm >= 6.4"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "anyio"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 readme = "README.rst"
-authors = [{name = "Alex Grönholm", email = "alex.gronholm@nextday.fi"}]
+authors = [{ name = "Alex Grönholm", email = "alex.gronholm@nextday.fi" }]
 license = "MIT"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -43,7 +40,7 @@ Changelog = "https://anyio.readthedocs.io/en/stable/versionhistory.html"
 trio = ["trio >= 0.26.1"]
 
 [project.entry-points]
-pytest11 = {anyio = "anyio.pytest_plugin"}
+pytest11 = { anyio = "anyio.pytest_plugin" }
 
 [dependency-groups]
 test = [
@@ -61,7 +58,7 @@ test = [
     uvloop >= 0.21; platform_python_implementation == 'CPython' \
     and platform_system != 'Windows' \
     and python_version < '3.14'\
-    """
+    """,
 ]
 doc = [
     "packaging",
@@ -80,18 +77,18 @@ src = ["src"]
 
 [tool.ruff.lint]
 extend-select = [
-    "ASYNC",        # flake8-async
-    "B",            # flake8-bugbear
-    "C4",           # flake8-comprehensions
-    "G",            # flake8-logging-format
-    "I",            # isort
-    "ISC",          # flake8-implicit-str-concat
-    "PERF",         # flake8-performance
-    "PGH",          # pygrep-hooks
-    "RUF100",       # unused noqa (yesqa)
-    "T201",         # print
-    "UP",           # pyupgrade
-    "W",            # pycodestyle warnings
+    "ASYNC",  # flake8-async
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "G",      # flake8-logging-format
+    "I",      # isort
+    "ISC",    # flake8-implicit-str-concat
+    "PERF",   # flake8-performance
+    "PGH",    # pygrep-hooks
+    "RUF100", # unused noqa (yesqa)
+    "T201",   # print
+    "UP",     # pyupgrade
+    "W",      # pycodestyle warnings
 ]
 ignore = ["B009", "PERF203"]
 
@@ -119,9 +116,7 @@ filterwarnings = [
     # Workaround for Python 3.9.7 (see https://bugs.python.org/issue45097)
     "ignore:The loop argument is deprecated since Python 3\\.8, and scheduled for removal in Python 3\\.10\\.:DeprecationWarning:asyncio",
 ]
-markers = [
-    "network: marks tests as requiring Internet access",
-]
+markers = ["network: marks tests as requiring Internet access"]
 
 [tool.codespell]
 ignore-words-list = "asend,daa,hel"
@@ -132,20 +127,34 @@ relative_files = true
 
 [tool.coverage.report]
 show_missing = true
-exclude_also = [
-    "if TYPE_CHECKING:",
-    "@(abc\\.)?abstractmethod",
-]
+exclude_also = ["if TYPE_CHECKING:", "@(abc\\.)?abstractmethod"]
 
 [tool.tox]
-env_list = ["pre-commit", "py39", "py310", "py311", "py312", "py313", "py314", "pypy3"]
+env_list = [
+    "pre-commit",
+    "py39",
+    "py310",
+    "py311",
+    "py312",
+    "py313",
+    "py314",
+    "pypy3",
+]
 skip_missing_interpreters = true
 requires = ["tox >= 4.22"]
 
 [tool.tox.env_run_base]
 depends = ["pre-commit"]
 package = "editable"
-commands = [["coverage", "run", "-m", "pytest", { replace = "posargs", extend = true }]]
+commands = [
+    [
+        "coverage",
+        "run",
+        "-m",
+        "pytest",
+        { replace = "posargs", extend = true },
+    ],
+]
 dependency_groups = ["test"]
 
 [tool.tox.env.pypy3]
@@ -165,3 +174,7 @@ commands = [["pyright", "--verifytypes", "anyio"]]
 depends = []
 dependency_groups = ["doc"]
 commands = [["sphinx-build", "-W", "docs", "build/sphinx"]]
+
+[tool.pyright]
+exclude = [".venv"]
+include = ["src"]

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -6,7 +6,8 @@ import math
 import sys
 import time
 from asyncio import CancelledError
-from collections.abc import AsyncGenerator, Coroutine, Generator
+from collections.abc import AsyncGenerator, AsyncIterator, Coroutine, Generator
+from contextlib import asynccontextmanager
 from typing import Any, NoReturn, cast
 from unittest import mock
 
@@ -1822,3 +1823,19 @@ async def test_exception_groups_suppresses_exc_context() -> None:
             raise Exception("Error")
 
     assert exc_info.value.__suppress_context__
+
+
+async def test_taskgroup_start_context() -> None:
+    """
+    Test that the task group context manager can be used to start a task group.
+
+    This is a regression test for issue #1000.
+    """
+
+    @asynccontextmanager
+    async def task_ctx() -> AsyncIterator[str]:
+        yield "foo"
+
+    async with create_task_group() as tg:
+        result = await tg.start_context(task_ctx())
+        assert result == "foo"

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -6,7 +6,7 @@ import math
 import sys
 import time
 from asyncio import CancelledError
-from collections.abc import AsyncGenerator, AsyncIterator, Coroutine, Generator
+from collections.abc import AsyncGenerator, Coroutine, Generator
 from contextlib import asynccontextmanager
 from typing import Any, NoReturn, cast
 from unittest import mock
@@ -1833,7 +1833,7 @@ async def test_taskgroup_start_context() -> None:
     """
 
     @asynccontextmanager
-    async def task_ctx() -> AsyncIterator[str]:
+    async def task_ctx() -> AsyncGenerator[str, None]:
         yield "foo"
 
     async with create_task_group() as tg:


### PR DESCRIPTION
## Changes

Fixes #678

This is accomplished by adding a `TaskGroup.start_context` method as a better-typed alternative to `TaskGroup.start`. The implementation for `start_context` is essentially:

```python
class TaskGroup:
    async def start_context(self, ctx: AbstractAsyncContextManager[T], *, name=None) -> T:
        async def wrapper(*, task_status):
            async with ctx as ret:
                task_status.started(ret)
        return await self.start(wrapper, ctx, name=name)
```

This also has the additional benefit of not being limited to positional only args since the user gets to construct the context manager however they'd like:

```python
async with create_task_group() as tg:
    value = await tg.start_context(my_context(*a, **kw))
```

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
