### PR TITLE
Fixs RunVar name conflicts.

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -39,6 +39,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#926 <https://github.com/agronholm/anyio/issues/926>`_; PR by @hroncok)
 - Fixed ``SyntaxWarning`` on Python 3.14 about ``return`` in ``finally``
   (`#816 <https://github.com/agronholm/anyio/issues/816>`_)
+- Fixed RunVar name conflicts.
+  (`#880 <https://github.com/agronholm/anyio/issues/880>`_; PR by @vimfu)
 
 **4.9.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -39,7 +39,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#926 <https://github.com/agronholm/anyio/issues/926>`_; PR by @hroncok)
 - Fixed ``SyntaxWarning`` on Python 3.14 about ``return`` in ``finally``
   (`#816 <https://github.com/agronholm/anyio/issues/816>`_)
-- Fixed RunVar name conflicts.
+- Fixed RunVar name conflicts. RunVar instances with the same name should not share storage.
   (`#880 <https://github.com/agronholm/anyio/issues/880>`_; PR by @vimfu)
 
 **4.9.0**

--- a/src/anyio/lowlevel.py
+++ b/src/anyio/lowlevel.py
@@ -64,7 +64,7 @@ def current_token() -> object:
     return get_async_backend().current_token()
 
 
-_run_vars: WeakKeyDictionary[Any, dict[str, Any]] = WeakKeyDictionary()
+_run_vars: WeakKeyDictionary[Any, dict[RunVar[Any], Any]] = WeakKeyDictionary()
 _token_wrappers: dict[Any, _TokenWrapper] = {}
 
 
@@ -105,7 +105,7 @@ class RunVar(Generic[T]):
         self._default = default
 
     @property
-    def _current_vars(self) -> dict[RunVar, T]:
+    def _current_vars(self) -> dict[RunVar[T], T]:
         token = current_token()
         try:
             return _run_vars[token]
@@ -136,7 +136,7 @@ class RunVar(Generic[T]):
 
     def set(self, value: T) -> RunvarToken[T]:
         current_vars = self._current_vars
-        token = RunvarToken(self, current_vars.get(self._name, RunVar.NO_VALUE_SET))
+        token = RunvarToken(self, current_vars.get(self, RunVar.NO_VALUE_SET))
         current_vars[self] = value
         return token
 
@@ -149,11 +149,11 @@ class RunVar(Generic[T]):
 
         if token._value is _NoValueSet.NO_VALUE_SET:
             try:
-                del self._current_vars[self._name]
+                del self._current_vars[self]
             except KeyError:
                 pass
         else:
-            self._current_vars[self._name] = token._value
+            self._current_vars[self] = token._value
 
         token._redeemed = True
 

--- a/src/anyio/lowlevel.py
+++ b/src/anyio/lowlevel.py
@@ -105,7 +105,7 @@ class RunVar(Generic[T]):
         self._default = default
 
     @property
-    def _current_vars(self) -> dict[str, T]:
+    def _current_vars(self) -> dict[RunVar, T]:
         token = current_token()
         try:
             return _run_vars[token]

--- a/src/anyio/lowlevel.py
+++ b/src/anyio/lowlevel.py
@@ -123,7 +123,7 @@ class RunVar(Generic[T]):
         self, default: D | Literal[_NoValueSet.NO_VALUE_SET] = NO_VALUE_SET
     ) -> T | D:
         try:
-            return self._current_vars[self._name]
+            return self._current_vars[self]
         except KeyError:
             if default is not RunVar.NO_VALUE_SET:
                 return default
@@ -137,7 +137,7 @@ class RunVar(Generic[T]):
     def set(self, value: T) -> RunvarToken[T]:
         current_vars = self._current_vars
         token = RunvarToken(self, current_vars.get(self._name, RunVar.NO_VALUE_SET))
-        current_vars[self._name] = value
+        current_vars[self] = value
         return token
 
     def reset(self, token: RunvarToken[T]) -> None:

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -126,3 +126,16 @@ class TestRunVar:
         var.reset(token)
         with pytest.raises(ValueError, match="This token has already been used"):
             var.reset(token)
+
+    async def test_runvar_does_not_share_storage_by_name(self) -> None:
+        var1: RunVar[int] = RunVar("var", 1)
+        var2: RunVar[str] = RunVar("var", "a")
+
+        assert var1.get() == 1
+        assert var2.get() == "a"
+
+        var1.set(2)
+        var2.set("b")
+
+        assert var1.get() == 2
+        assert var2.get() == "b"


### PR DESCRIPTION
RunVar instances with the same name should not share storage.

<!-- Thank you for your contribution! -->
## Changes

Fixes #880. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fixed RunVar name conflicts
  (`#880 <https://github.com/agronholm/anyio/issues/880>`_; PR by @vimfu )
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
