### PR TITLE
fix: typo in BrokenWorkerIntepreter

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -226,7 +226,7 @@ Exceptions
 ----------
 
 .. autoexception:: anyio.BrokenResourceError
-.. autoexception:: anyio.BrokenWorkerIntepreter
+.. autoexception:: anyio.BrokenWorkerInterpreter
 .. autoexception:: anyio.BrokenWorkerProcess
 .. autoexception:: anyio.BusyResourceError
 .. autoexception:: anyio.ClosedResourceError

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -43,6 +43,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#880 <https://github.com/agronholm/anyio/issues/880>`_; PR by @vimfu)
 - Renamed the ``BrokenWorkerIntepreter`` exception to ``BrokenWorkerInterpreter``.
   The old name is available as a deprecated alias.
+  (`#938 <https://github.com/agronholm/anyio/pull/938>`_; PR by @ayussh-verma)
 
 **4.9.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -19,7 +19,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Added context manager mix-in classes (``anyio.ContextManagerMixin`` and
   ``anyio.AsyncContextManagerMixin``) to help write classes that embed other context
   managers, particularly cancel scopes or task groups
-  (`#905 <https://github.com/agronholm/anyio/pull/905>`_; PR by by @agronholm and
+  (`#905 <https://github.com/agronholm/anyio/pull/905>`_; PR by @agronholm and
   @tapetersen)
 - Added the ability to specify the thread name in ``start_blocking_portal()``
   (`#818 <https://github.com/agronholm/anyio/issues/818>`_; PR by @davidbrochart)
@@ -41,6 +41,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#816 <https://github.com/agronholm/anyio/issues/816>`_)
 - Fixed RunVar name conflicts. RunVar instances with the same name should not share storage.
   (`#880 <https://github.com/agronholm/anyio/issues/880>`_; PR by @vimfu)
+- Renamed the ``BrokenWorkerIntepreter`` exception to ``BrokenWorkerInterpreter``.
+  The old name is available as an alias.
 
 **4.9.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -42,7 +42,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed RunVar name conflicts. RunVar instances with the same name should not share storage.
   (`#880 <https://github.com/agronholm/anyio/issues/880>`_; PR by @vimfu)
 - Renamed the ``BrokenWorkerIntepreter`` exception to ``BrokenWorkerInterpreter``.
-  The old name is available as an alias.
+  The old name is available as a deprecated alias.
 
 **4.9.0**
 

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -89,6 +89,18 @@ for __value in list(locals().values()):
     if getattr(__value, "__module__", "").startswith("anyio."):
         __value.__module__ = __name__
 
-del __value
 
-BrokenWorkerIntepreter = BrokenWorkerInterpreter
+def __getattr__(attr: str):  # type: ignore[no-untyped-def]
+    """Support deprecated aliases."""
+    if attr == "BrokenWorkerIntepreter":
+        replaced_class_name = BrokenWorkerInterpreter.__name__
+        import warnings  # A lazy import here cuts the overall import time
+
+        warnings.warn(
+            f"The 'BrokenWorkerIntepreter' alias is deprecated, use {replaced_class_name!r} instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return BrokenWorkerInterpreter
+
+    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -96,11 +96,10 @@ del __value
 def __getattr__(attr: str) -> type[BrokenWorkerInterpreter]:
     """Support deprecated aliases."""
     if attr == "BrokenWorkerIntepreter":
-        replaced_class_name = BrokenWorkerInterpreter.__name__
         import warnings
 
         warnings.warn(
-            f"The 'BrokenWorkerIntepreter' alias is deprecated, use {replaced_class_name!r} instead.",
+            "The 'BrokenWorkerIntepreter' alias is deprecated, use 'BrokenWorkerInterpreter' instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -90,11 +90,14 @@ for __value in list(locals().values()):
         __value.__module__ = __name__
 
 
-def __getattr__(attr: str):  # type: ignore[no-untyped-def]
+del __value
+
+
+def __getattr__(attr: str) -> type[BrokenWorkerInterpreter]:
     """Support deprecated aliases."""
     if attr == "BrokenWorkerIntepreter":
         replaced_class_name = BrokenWorkerInterpreter.__name__
-        import warnings  # A lazy import here cuts the overall import time
+        import warnings
 
         warnings.warn(
             f"The 'BrokenWorkerIntepreter' alias is deprecated, use {replaced_class_name!r} instead.",

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -10,7 +10,7 @@ from ._core._eventloop import sleep as sleep
 from ._core._eventloop import sleep_forever as sleep_forever
 from ._core._eventloop import sleep_until as sleep_until
 from ._core._exceptions import BrokenResourceError as BrokenResourceError
-from ._core._exceptions import BrokenWorkerIntepreter as BrokenWorkerIntepreter
+from ._core._exceptions import BrokenWorkerInterpreter as BrokenWorkerInterpreter
 from ._core._exceptions import BrokenWorkerProcess as BrokenWorkerProcess
 from ._core._exceptions import BusyResourceError as BusyResourceError
 from ._core._exceptions import ClosedResourceError as ClosedResourceError
@@ -90,3 +90,5 @@ for __value in list(locals().values()):
         __value.__module__ = __name__
 
 del __value
+
+BrokenWorkerIntepreter = BrokenWorkerInterpreter

--- a/src/anyio/_core/_exceptions.py
+++ b/src/anyio/_core/_exceptions.py
@@ -23,7 +23,7 @@ class BrokenWorkerProcess(Exception):
     """
 
 
-class BrokenWorkerIntepreter(Exception):
+class BrokenWorkerInterpreter(Exception):
     """
     Raised by :meth:`~anyio.to_interpreter.run_sync` if an unexpected exception is
     raised in the subinterpreter.

--- a/src/anyio/to_interpreter.py
+++ b/src/anyio/to_interpreter.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 from typing import Any, Final, TypeVar
 
 from . import current_time, to_thread
-from ._core._exceptions import BrokenWorkerIntepreter
+from ._core._exceptions import BrokenWorkerInterpreter
 from ._core._synchronization import CapacityLimiter
 from .lowlevel import RunVar
 
@@ -116,7 +116,7 @@ class Worker:
         res: Any
         is_exception: bool
         if exc_info := interpreters.exec(self._interpreter_id, self._run_func):
-            raise BrokenWorkerIntepreter(exc_info)
+            raise BrokenWorkerInterpreter(exc_info)
 
         (res, is_exception), fmt = queues.get(self._queue_id)[:2]
         if fmt == FMT_PICKLED:
@@ -170,7 +170,7 @@ async def run_sync(
     :param limiter: capacity limiter to use to limit the total amount of subinterpreters
         running (if omitted, the default limiter is used)
     :return: the result of the call
-    :raises BrokenWorkerIntepreter: if there's an internal error in a subinterpreter
+    :raises BrokenWorkerInterpreter: if there's an internal error in a subinterpreter
 
     """
     if sys.version_info <= (3, 13):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -7,4 +7,5 @@ import anyio
 
 def test_broken_worker_interpreter_deprecation() -> None:
     with pytest.warns(DeprecationWarning):
-        assert anyio.BrokenWorkerIntepreter is anyio.BrokenWorkerInterpreter
+        DeprecatedClass = anyio.BrokenWorkerIntepreter
+    assert DeprecatedClass is anyio.BrokenWorkerInterpreter

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import pytest
+
+import anyio
+
+
+def test_broken_worker_interpreter_deprecation() -> None:
+    with pytest.warns(DeprecationWarning):
+        assert anyio.BrokenWorkerIntepreter is anyio.BrokenWorkerInterpreter


### PR DESCRIPTION
## Changes

Renames BrokenWorkerIntepreter to BrokenWorkerInterpreter;

## Checklist

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
