### PR TITLE
opt-in source tracing of cancel-scopes

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -4,12 +4,12 @@ import array
 import asyncio
 import concurrent.futures
 import contextvars
-import traceback
 import math
 import os
 import socket
 import sys
 import threading
+import traceback
 import weakref
 from asyncio import (
     AbstractEventLoop,
@@ -579,7 +579,9 @@ class CancelScope(BaseCancelScope):
                 waiter = task._fut_waiter  # type: ignore[attr-defined]
                 if not isinstance(waiter, asyncio.Future) or not waiter.done():
                     if origin._source_stack is not None:
-                        task.cancel(f"Cancelled by cancel scope {id(origin):x} at\n{"".join(traceback.format_list(origin._source_stack))}")
+                        task.cancel(
+                            f"Cancelled by cancel scope {id(origin):x} at\n{''.join(traceback.format_list(origin._source_stack))}"
+                        )
                     else:
                         task.cancel(f"Cancelled by cancel scope {id(origin):x}")
                     if (

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import math
 import contextvars
+import math
 from collections.abc import Generator
 from contextlib import contextmanager
 from types import TracebackType
@@ -27,7 +27,9 @@ class CancelScope:
     """
 
     # set to True to capture full stack traces. set to an integer to capture at most that many frames
-    track_source_information = contextvars.ContextVar("track_source_information", default=False)
+    track_source_information = contextvars.ContextVar(
+        "track_source_information", default=False
+    )
 
     def __new__(
         cls, *, deadline: float = math.inf, shield: bool = False

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import contextvars
 from collections.abc import Generator
 from contextlib import contextmanager
 from types import TracebackType
@@ -24,6 +25,9 @@ class CancelScope:
     :param deadline: The time (clock value) when this scope is cancelled automatically
     :param shield: ``True`` to shield the cancel scope from external cancellation
     """
+
+    # set to True to capture full stack traces. set to an integer to capture at most that many frames
+    track_source_information = contextvars.ContextVar("track_source_information", default=False)
 
     def __new__(
         cls, *, deadline: float = math.inf, shield: bool = False


### PR DESCRIPTION
## Changes

Fixes #939

This PR adds a [`ContextVar`](https://docs.python.org/3/library/contextvars.html#contextvars.ContextVar) `CancelScope.track_source_information`, which, when set to `True` or a nonzero integer,
causes `CancelScope`s to retain a trace of the stack at the point of their creation.
Then, when tasks are cancelled, instead of just giving the ID of the originating `CancelScope`,
the `CancelledError` also contains a rendered traceback of the source location.

## Checklist

So far, this is just a sketch/draft to check back with the maintainers. That said, it did help me solving the issue I was debugging.

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

## Bikeshedding
 - `track_source_information` - a good name?
 - `track_source_information` on `CancelScope` or some global scope?
 - Should the stack trace already be formatted at creation to reduce memory footprint?
 - Should we try to somehow discard the closures associated with the stack frames in order to reduce memory footprint?
