### PR TITLE
Added the BufferedByteReceiveStream.feed_data() method

### DIFF
--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -132,6 +132,9 @@ The above script gives the following output::
     b'hello, w'
     b'orld'
 
+.. tip:: In some cases, you may need to inject data directly into the buffer. You can do
+    that with the :meth:`~.streams.buffered.BufferedByteReceiveStream.feed_data` method.
+
 Text streams
 ------------
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added the ``feed_data()`` method to the ``BufferedByteReceiveStream`` class, allowing
+  users to inject data directly into the buffer
 - Added various class methods to wrap existing sockets as listeners or socket streams:
 
   * ``SocketListener.from_socket()``

--- a/src/anyio/streams/buffered.py
+++ b/src/anyio/streams/buffered.py
@@ -45,7 +45,7 @@ class BufferedByteReceiveStream(ByteReceiveStream):
     def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         return self.receive_stream.extra_attributes
 
-    def feed_data(self, data: Iterable[SupportsIndex]) -> None:
+    def feed_data(self, data: Iterable[SupportsIndex], /) -> None:
         """
         Append data directly into the buffer.
 

--- a/src/anyio/streams/buffered.py
+++ b/src/anyio/streams/buffered.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, SupportsIndex
 
 from .. import ClosedResourceError, DelimiterNotFound, EndOfStream, IncompleteRead
 from ..abc import (
@@ -44,6 +44,19 @@ class BufferedByteReceiveStream(ByteReceiveStream):
     @property
     def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:
         return self.receive_stream.extra_attributes
+
+    def feed_data(self, data: Iterable[SupportsIndex]) -> None:
+        """
+        Append data directly into the buffer.
+
+        Any data in the buffer will be consumed by receive operations before receiving
+        anything from the wrapped stream.
+
+        :param data: the data to append to the buffer (can be bytes or anything else
+            that supports ``__index__()``)
+
+        """
+        self._buffer.extend(data)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
         if self._closed:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Adds a method that allows users to directly feed data into the stream's buffer. This is useful for protocol switching where you need to wrap an existing stream with a buffer, but the sans-io protocol has some trailing data left that needs to be returned from the stream.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [X] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
