### PR TITLE
add winloop support and keep unix parts in windows off-limits

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -77,8 +77,8 @@ Here is the list of supported options for each backend:
 * options covered in the documentation of :class:`asyncio.Runner`
 * ``use_uvloop`` (``bool``, default=False): Use the faster uvloop_ event loop
   implementation, if available (this is a shorthand for passing
-  ``loop_factory=uvloop.new_event_loop``, and is ignored if ``loop_factory`` is passed
-  a value other than ``None``)
+  ``loop_factory=uvloop.new_event_loop`` or ``loop_factory=winloop.new_event_loop`` if using windows,
+  and is ignored if ``loop_factory`` is passed a value other than ``None``)
 
 **Trio**: options covered in the
 `official documentation

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,12 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+- Added ``winloop`` to anyio so windows users can now set ``use_uvloop`` with pytest
+  or ``anyio.run()`` to run ``winloop`` instead of ``uvloop`` or being left with an ``ModuleNotFoundError``
+- Fixed Mypy Problems by making unix portions off limits when windows is in use.
+
+
 **4.10.0**
 
 - Added the ``feed_data()`` method to the ``BufferedByteReceiveStream`` class, allowing

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Added ``winloop`` to anyio so windows users can now set ``use_uvloop`` with pytest
   or ``anyio.run()`` to run ``winloop`` instead of ``uvloop`` or being left with an ``ModuleNotFoundError``
 - Fixed Mypy Problems by making unix portions off limits when windows is in use.
+  (`#959 <https://github.com/agronholm/anyio/pull/959>`_; PR by @Vizonex)
 
 
 **4.10.0**

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -3,26 +3,11 @@ from __future__ import annotations
 import os
 import pathlib
 import sys
-from collections.abc import (
-    AsyncIterator,
-    Callable,
-    Iterable,
-    Iterator,
-    Sequence,
-)
+from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from functools import partial
 from os import PathLike
-from typing import (
-    IO,
-    TYPE_CHECKING,
-    Any,
-    AnyStr,
-    ClassVar,
-    Final,
-    Generic,
-    overload,
-)
+from typing import IO, TYPE_CHECKING, Any, AnyStr, ClassVar, Final, Generic, overload
 
 from .. import to_thread
 from ..abc import AsyncResource
@@ -484,7 +469,7 @@ class Path:
         return _PathIterator(gen)
 
     async def group(self) -> str:
-        return await to_thread.run_sync(self._path.group, abandon_on_cancel=True)
+        return await to_thread.run_sync(self._path.group, abandon_on_cancel=True)  # type: ignore[attr-defined]
 
     async def hardlink_to(
         self, target: str | bytes | PathLike[str] | PathLike[bytes]
@@ -597,7 +582,7 @@ class Path:
         return AsyncFile(fp)
 
     async def owner(self) -> str:
-        return await to_thread.run_sync(self._path.owner, abandon_on_cancel=True)
+        return await to_thread.run_sync(self._path.owner, abandon_on_cancel=True)  # type: ignore[attr-defined]
 
     async def read_bytes(self) -> bytes:
         return await to_thread.run_sync(self._path.read_bytes)

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -335,7 +335,7 @@ async def create_tcp_listener(
             else:
                 raw_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-            if reuse_port:
+            if reuse_port and sys.platform != "win32":
                 raw_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
 
             # If only IPv6 was requested, disable dual stack operation
@@ -815,7 +815,7 @@ async def setup_unix_local_socket(
     else:
         path_str = None
 
-    raw_socket = socket.socket(socket.AF_UNIX, socktype)
+    raw_socket = socket.socket(getattr(socket, "AF_UNIX"), socktype)
     raw_socket.setblocking(False)
 
     if path_str is not None:

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -6,13 +6,7 @@ import tempfile
 from collections.abc import Iterable
 from io import BytesIO, TextIOWrapper
 from types import TracebackType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AnyStr,
-    Generic,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, AnyStr, Generic, overload
 
 from .. import to_thread
 from .._core._fileio import AsyncFile

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -8,14 +8,7 @@ from contextlib import AbstractContextManager
 from os import PathLike
 from signal import Signals
 from socket import AddressFamily, SocketKind, socket
-from typing import (
-    IO,
-    TYPE_CHECKING,
-    Any,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import IO, TYPE_CHECKING, Any, TypeVar, Union, overload
 
 if sys.version_info >= (3, 11):
     from typing import TypeVarTuple, Unpack

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -218,7 +218,10 @@ class UNIXSocketStream(SocketStream):
 
         """
         sock = _validate_socket(
-            sock_or_fd, socket.SOCK_STREAM, socket.AF_UNIX, require_connected=True
+            sock_or_fd,
+            socket.SOCK_STREAM,
+            getattr(socket, "AF_UNIX"),
+            require_connected=True,
         )
         return await get_async_backend().wrap_unix_stream_socket(sock)
 
@@ -368,7 +371,9 @@ class UNIXDatagramSocket(
         :return: a UNIX datagram socket
 
         """
-        sock = _validate_socket(sock_or_fd, socket.SOCK_DGRAM, socket.AF_UNIX)
+        sock = _validate_socket(
+            sock_or_fd, socket.SOCK_DGRAM, getattr(socket, "AF_UNIX")
+        )
         return await get_async_backend().wrap_unix_datagram_socket(sock)
 
     async def sendto(self, data: bytes, path: str) -> None:
@@ -400,6 +405,9 @@ class ConnectedUNIXDatagramSocket(UnreliableObjectStream[bytes], _SocketProvider
 
         """
         sock = _validate_socket(
-            sock_or_fd, socket.SOCK_DGRAM, socket.AF_UNIX, require_connected=True
+            sock_or_fd,
+            socket.SOCK_DGRAM,
+            getattr(socket, "AF_UNIX"),
+            require_connected=True,
         )
         return await get_async_backend().wrap_connected_unix_datagram_socket(sock)

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -12,13 +12,7 @@ from dataclasses import dataclass, field
 from inspect import isawaitable
 from threading import Lock, Thread, current_thread, get_ident
 from types import TracebackType
-from typing import (
-    Any,
-    Generic,
-    TypeVar,
-    cast,
-    overload,
-)
+from typing import Any, Generic, TypeVar, cast, overload
 
 from ._core import _eventloop
 from ._core._eventloop import get_async_backend, get_cancelled_exc_class, threadlocals

--- a/src/anyio/streams/memory.py
+++ b/src/anyio/streams/memory.py
@@ -6,12 +6,7 @@ from dataclasses import dataclass, field
 from types import TracebackType
 from typing import Generic, NamedTuple, TypeVar
 
-from .. import (
-    BrokenResourceError,
-    ClosedResourceError,
-    EndOfStream,
-    WouldBlock,
-)
+from .. import BrokenResourceError, ClosedResourceError, EndOfStream, WouldBlock
 from .._core._testing import TaskInfo, get_current_task
 from ..abc import Event, ObjectReceiveStream, ObjectSendStream
 from ..lowlevel import checkpoint


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

- Added `winloop` to test suite so that `winloop` can be supported when a windows user passed off a loop_factory or `use_uvloop`.
- mypy kept misbehaving whenever I would go to use `pre-commit`  since I'm using a Windows 10 system 
to program everything with so the only rational solution was to keep Unix Portions of code triggering mypy 
problems off limits because at the end of the day Windows users shouldn't even be allowed access to Unix only code.
After seeing that I had to do this, I definitely feel inspired to write another wrapper library for making certain classes or functions that are OS Related off-limits to an end user or developer in the future.



## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions. 

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
