### PR TITLE
Set `None` as the default type argument for `TaskStatus`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,10 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Set ``None`` as the default type argument for ``anyio.abc.TaskStatus``
+
 **4.10.0**
 
 - Added the ``feed_data()`` method to the ``BufferedByteReceiveStream`` class, allowing

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -4,7 +4,12 @@ import sys
 from abc import ABCMeta, abstractmethod
 from collections.abc import Awaitable, Callable
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Protocol, overload
+
+if sys.version_info >= (3, 13):
+    from typing import TypeVar
+else:
+    from typing_extensions import TypeVar
 
 if sys.version_info >= (3, 11):
     from typing import TypeVarTuple, Unpack
@@ -15,7 +20,7 @@ if TYPE_CHECKING:
     from .._core._tasks import CancelScope
 
 T_Retval = TypeVar("T_Retval")
-T_contra = TypeVar("T_contra", contravariant=True)
+T_contra = TypeVar("T_contra", contravariant=True, default=None)
 PosArgsT = TypeVarTuple("PosArgsT")
 
 

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -65,7 +65,7 @@ def test_main_task_name(
 async def test_non_main_task_name(
     name_input: bytes | str | None, expected: str
 ) -> None:
-    async def non_main(*, task_status: TaskStatus) -> None:
+    async def non_main(*, task_status: TaskStatus[str | None]) -> None:
         task_status.started(anyio.get_current_task().name)
 
     async with anyio.create_task_group() as tg:

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -537,7 +537,7 @@ class TestBlockingPortal:
     def test_start_with_value(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        async def taskfunc(*, task_status: TaskStatus) -> None:
+        async def taskfunc(*, task_status: TaskStatus[str]) -> None:
             task_status.started("foo")
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
@@ -558,7 +558,7 @@ class TestBlockingPortal:
     def test_start_crash_after_started_call(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        async def taskfunc(*, task_status: TaskStatus) -> NoReturn:
+        async def taskfunc(*, task_status: TaskStatus[int]) -> NoReturn:
             task_status.started(2)
             raise Exception("foo")
 
@@ -581,7 +581,7 @@ class TestBlockingPortal:
     def test_start_with_name(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:
-        async def taskfunc(*, task_status: TaskStatus) -> None:
+        async def taskfunc(*, task_status: TaskStatus[str | None]) -> None:
             task_status.started(get_current_task().name)
 
         with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -141,7 +141,7 @@ async def test_no_called_started_twice() -> None:
 
 
 async def test_start_with_value() -> None:
-    async def taskfunc(*, task_status: TaskStatus) -> None:
+    async def taskfunc(*, task_status: TaskStatus[str]) -> None:
         task_status.started("foo")
 
     async with create_task_group() as tg:
@@ -161,7 +161,7 @@ async def test_start_crash_before_started_call() -> None:
 
 
 async def test_start_crash_after_started_call() -> None:
-    async def taskfunc(*, task_status: TaskStatus) -> NoReturn:
+    async def taskfunc(*, task_status: TaskStatus[int]) -> NoReturn:
         task_status.started(2)
         raise Exception("foo")
 
@@ -306,7 +306,7 @@ async def test_cancel_with_nested_task_groups() -> None:
 
 
 async def test_start_exception_delivery(anyio_backend_name: str) -> None:
-    def task_fn(*, task_status: TaskStatus = TASK_STATUS_IGNORED) -> None:
+    def task_fn(*, task_status: TaskStatus[str] = TASK_STATUS_IGNORED) -> None:
         task_status.started("hello")
 
     if anyio_backend_name == "trio":


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This makes `None` the default type argument for the `TaskStatus` class, forcing users to specify an explicit type argument unless they plan to call `task_status.started()` without arguments.

This will likely break static type checks in existing projects, but nothing at run-time.
<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
