### PR TITLE
Revert "Fixed getaddrinfo tests failing (#911)"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,16 +91,6 @@ jobs:
         cache-dependency-path: pyproject.toml
     - name: Install the project and its dependencies
       run: pip install --group test -e .
-    - name: Patch /etc/hosts
-      if: runner.os != 'Windows'
-      run: |
-        echo "1.2.3.4 xn--fa-hia.de" | sudo tee -a /etc/hosts
-        echo "5.6.7.8 fass.de" | sudo tee -a /etc/hosts
-    - name: Patch C:\Windows\System32\drivers\etc\hosts
-      if: runner.os == 'Windows'
-      run: |
-        Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "1.2.3.4 xn--fa-hia.de"
-        Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "5.6.7.8 fass.de"
     - name: Test with pytest
       run: coverage run -m pytest -v
       timeout-minutes: 5


### PR DESCRIPTION
This reverts commit 62c42cc50d748937ae65dd288254fd04c190e61e.

Conflicts:
	.github/workflows/test.yml

Relates-to commit da0a792c17b840027030289a2566cf5910880d42.

## Changes

Potential resolution for discussion question/topic opened at: https://github.com/agronholm/anyio/pull/911?notification_referrer_id=NT_kwDOA0mODLQxNTg3MDExMjAyNzo1NTE1MjE0MA#issuecomment-3160518149

This changeset removes some customizations applied during GitHub Actions CI that modify the domain name resolution process for two sample hostnames used during some recently-removed `getaddrinfo`-related unit tests.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] ~~You've added tests (in `tests/`) added which would fail without your patch~~
- [ ] ~~You've updated the documentation (in `docs/`, in case of behavior changes or new
features)~~
- [ ] ~~You've added a new changelog entry (in `docs/versionhistory.rst`)~~.

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.