### PR TITLE
Added auto mode for the pytest plugin

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -11,12 +11,27 @@ Creating asynchronous tests
 ---------------------------
 
 Pytest does not natively support running asynchronous test functions, so they have to be
-marked for the AnyIO pytest plugin to pick them up. This can be done in one of two ways:
+marked for the AnyIO pytest plugin to pick them up. This can be done in one of three
+ways:
 
+#. Setting the ``anyio_mode = "auto"`` option in the pytest configuration
 #. Using the ``pytest.mark.anyio`` marker
 #. Using the ``anyio_backend`` fixture, either directly or via another fixture
 
-The simplest way is thus the following::
+The simplest way is thus the following:
+
+.. code-block:: toml
+
+    [tool.pytest.ini_options]
+    anyio_mode = "auto"
+
+.. note:: This does not work if ``pytest-asyncio`` is installed and configured to use
+    its own ``auto`` mode, as it will conflict with the AnyIO plugin. To prevent this
+    from happening, you can remove the ``asyncio_mode`` option from your pytest
+    configuration, thus making ``pytest-asyncio`` use its default strict mode.
+
+In case your AnyIO tests need to coexist with other async test plugins, the next best
+option is to use the ``pytest.mark.anyio`` marker::
 
     import pytest
 
@@ -26,6 +41,8 @@ The simplest way is thus the following::
 
     async def test_something():
         ...
+
+.. note:: The marker only affects asynchronous test functions.
 
 Marking modules, classes or functions with this marker has the same effect as applying
 the ``pytest.mark.usefixtures('anyio_backend')`` on them.

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added pytest option (``anyio_mode = "auto"``) to make the pytest plugin automatically
+  handle all async tests
 - Set ``None`` as the default type argument for ``anyio.abc.TaskStatus``
 
 **4.10.0**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ disallow_untyped_decorators = false
 [tool.pytest.ini_options]
 addopts = "-rsfE --tb=short --strict-config --strict-markers -p anyio -p pytest_mock -p no:asyncio -p no:trio"
 testpaths = ["tests"]
+anyio_mode = "auto"
 xfail_strict = true
 filterwarnings = [
     "error",

--- a/tests/streams/test_buffered.py
+++ b/tests/streams/test_buffered.py
@@ -16,8 +16,6 @@ from anyio.streams.buffered import (
 )
 from anyio.streams.stapled import StapledObjectStream
 
-pytestmark = pytest.mark.anyio
-
 
 async def test_receive_exactly() -> None:
     send_stream, receive_stream = create_memory_object_stream[bytes](2)

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -10,8 +10,6 @@ from anyio import ClosedResourceError, EndOfStream
 from anyio.abc import ByteReceiveStream
 from anyio.streams.file import FileReadStream, FileStreamAttribute, FileWriteStream
 
-pytestmark = pytest.mark.anyio
-
 
 class TestFileReadStream:
     @pytest.fixture(scope="class")

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -29,8 +29,6 @@ from ..conftest import asyncio_params
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
 
-pytestmark = pytest.mark.anyio
-
 
 def test_invalid_max_buffer() -> None:
     pytest.raises(ValueError, create_memory_object_stream, 1.0).match(

--- a/tests/streams/test_stapled.py
+++ b/tests/streams/test_stapled.py
@@ -16,8 +16,6 @@ from anyio.abc import (
 )
 from anyio.streams.stapled import StapledByteStream, StapledObjectStream
 
-pytestmark = pytest.mark.anyio
-
 
 @dataclass
 class DummyByteReceiveStream(ByteReceiveStream):

--- a/tests/streams/test_text.py
+++ b/tests/streams/test_text.py
@@ -15,8 +15,6 @@ from anyio.streams.text import (
     TextStream,
 )
 
-pytestmark = pytest.mark.anyio
-
 
 async def test_receive() -> None:
     send_stream, receive_stream = create_memory_object_stream[bytes](1)

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -30,8 +30,6 @@ from anyio.abc import (
 from anyio.streams.stapled import StapledObjectStream
 from anyio.streams.tls import TLSAttribute, TLSConnectable, TLSListener, TLSStream
 
-pytestmark = pytest.mark.anyio
-
 
 class TestTLSStream:
     async def test_send_receive(

--- a/tests/test_contextmanagers.py
+++ b/tests/test_contextmanagers.py
@@ -19,8 +19,6 @@ import pytest
 
 from anyio import AsyncContextManagerMixin, ContextManagerMixin
 
-pytestmark = pytest.mark.anyio
-
 
 class DummyContextManager(ContextManagerMixin):
     def __init__(self, handle_exc: bool = False) -> None:

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -22,9 +22,6 @@ from anyio.abc import TaskStatus
 
 from .conftest import asyncio_params
 
-pytestmark = pytest.mark.anyio
-
-
 get_coro = asyncio.Task.get_coro
 
 

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -12,7 +12,6 @@ from pytest import MonkeyPatch
 
 from anyio import run, sleep_forever, sleep_until
 
-pytestmark = pytest.mark.anyio
 fake_current_time = 1620581544.0
 
 

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -12,8 +12,6 @@ from _pytest.tmpdir import TempPathFactory
 
 from anyio import AsyncFile, Path, open_file, wrap_file
 
-pytestmark = pytest.mark.anyio
-
 
 class TestAsyncFile:
     @pytest.fixture(scope="class")

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -38,8 +38,6 @@ from .conftest import asyncio_params
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
 
-pytestmark = pytest.mark.anyio
-
 T_Retval = TypeVar("T_Retval")
 
 

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -12,8 +12,6 @@ from anyio.lowlevel import (
     checkpoint_if_cancelled,
 )
 
-pytestmark = pytest.mark.anyio
-
 
 @pytest.mark.parametrize("cancel", [False, True])
 async def test_checkpoint_if_cancelled(cancel: bool) -> None:

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -14,8 +14,7 @@ pytestmark = [
     pytest.mark.filterwarnings(
         "ignore:The TerminalReporter.writer attribute is deprecated"
         ":pytest.PytestDeprecationWarning:"
-    ),
-    pytest.mark.anyio,
+    )
 ]
 
 pytest_args = "-v", "-p", "anyio", "-p", "no:asyncio", "-p", "no:trio"
@@ -568,6 +567,80 @@ def test_async_fixture_params(testdir: Pytester) -> None:
 
     result = testdir.runpytest(*pytest_args)
     result.assert_outcomes(passed=len(get_all_backends()) * 2)
+
+
+def test_auto_mode(testdir: Pytester) -> None:
+    testdir.makepyprojecttoml(
+        """
+        [tool.pytest.ini_options]
+        anyio_mode = "auto"
+        """
+    )
+    testdir.makepyfile(
+        """
+        import inspect
+        import pytest
+
+        @pytest.fixture
+        async def fixt(request):
+            return 1
+
+        async def test_params(fixt):
+            assert fixt == 1
+        """
+    )
+
+    result = testdir.runpytest(*pytest_args)
+    result.assert_outcomes(passed=len(get_all_backends()))
+
+
+def test_auto_mode_conflict_warning(testdir: Pytester) -> None:
+    testdir.makepyprojecttoml(
+        """
+        [tool.pytest.ini_options]
+        anyio_mode = "auto"
+        asyncio_mode = "auto"
+        asyncio_default_fixture_loop_scope = "function"
+        """
+    )
+    testdir.makeconftest(
+        """
+        import pytest
+
+        class FakeAsyncioPlugin:
+            def pytest_addoption(self, parser, pluginmanager):
+                parser.addini(
+                    "asyncio_mode",
+                    default="strict",
+                    type="string",
+                    help="dummy asyncio plugin"
+                )
+
+        def pytest_addhooks(pluginmanager):
+            if not pluginmanager.has_plugin("asyncio"):
+                pluginmanager.register(FakeAsyncioPlugin(), "asyncio")
+        """
+    )
+    testdir.makepyfile(
+        """
+        import inspect
+        import pytest
+
+        @pytest.fixture
+        async def fixt(request):
+            return 1
+
+        async def test_params(fixt):
+            assert fixt == 1
+        """
+    )
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=len(get_all_backends()))
+    assert (
+        "PytestConfigWarning: AnyIO auto mode has been enabled together with "
+        "pytest-asyncio auto mode. This may cause unexpected behavior."
+    ) in result.stdout.str()
 
 
 class TestFreePortFactory:

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -10,7 +10,6 @@ import pytest
 from anyio import create_task_group, fail_after, open_signal_receiver, to_thread
 
 pytestmark = [
-    pytest.mark.anyio,
     pytest.mark.skipif(
         sys.platform == "win32",
         reason="Signal delivery cannot be tested on Windows",

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -88,8 +88,6 @@ AnyIPAddressFamily = Literal[
     AddressFamily.AF_UNSPEC, AddressFamily.AF_INET, AddressFamily.AF_INET6
 ]
 
-pytestmark = pytest.mark.anyio
-
 # If a socket can bind to ::1, the current environment has IPv6 properly configured
 has_ipv6 = False
 if socket.has_ipv6:

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -21,8 +21,6 @@ from anyio import (
 )
 from anyio.streams.buffered import BufferedByteReceiveStream
 
-pytestmark = pytest.mark.anyio
-
 
 @pytest.mark.parametrize(
     "shell, command",

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -24,8 +24,6 @@ from anyio.lowlevel import checkpoint
 
 from .conftest import asyncio_params
 
-pytestmark = pytest.mark.anyio
-
 
 class TestLock:
     async def test_contextmanager(self) -> None:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -37,8 +37,6 @@ from .conftest import asyncio_params, no_other_refs
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup
 
-pytestmark = pytest.mark.anyio
-
 
 async def async_error(text: str, delay: float = 0.1) -> NoReturn:
     try:

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -20,8 +20,6 @@ from anyio import (
     mkstemp,
 )
 
-pytestmark = pytest.mark.anyio
-
 
 class TestTemporaryFile:
     async def test_temporary_file(self) -> None:

--- a/tests/test_to_interpreter.py
+++ b/tests/test_to_interpreter.py
@@ -10,7 +10,6 @@ from pytest import fixture
 from anyio import to_interpreter
 
 pytestmark = [
-    pytest.mark.anyio,
     pytest.mark.skipif(sys.version_info < (3, 13), reason="requires Python 3.13+"),
 ]
 

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -19,8 +19,6 @@ from anyio import (
 )
 from anyio.abc import Process
 
-pytestmark = pytest.mark.anyio
-
 
 async def test_run_sync_in_process_pool() -> None:
     """

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -27,8 +27,6 @@ from anyio.from_thread import BlockingPortalProvider
 
 from .conftest import asyncio_params, no_other_refs
 
-pytestmark = pytest.mark.anyio
-
 
 async def test_run_in_thread_cancelled() -> None:
     state = 0


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This adds the `anyio_mode` configuration option for the pytest plugin, allowing it to be applied to all async tests by default.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [X] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
