### PR TITLE
Added the condition.wait_for() method

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -12,6 +12,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   keyword argument
 - Added pytest option (``anyio_mode = "auto"``) to make the pytest plugin automatically
   handle all async tests
+- Added the ``anyio.Condition.wait_for()`` method for feature parity with asyncio
 - Set ``None`` as the default type argument for ``anyio.abc.TaskStatus``
 
 **4.10.0**

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 import math
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass
 from types import TracebackType
+from typing import TypeVar
 
 from sniffio import AsyncLibraryNotFoundError
 
-from ..lowlevel import checkpoint
+from ..lowlevel import checkpoint_if_cancelled
 from ._eventloop import get_async_backend
 from ._exceptions import BusyResourceError
 from ._tasks import CancelScope
 from ._testing import TaskInfo, get_current_task
+
+T = TypeVar("T")
 
 
 @dataclass(frozen=True)
@@ -323,7 +327,7 @@ class Condition:
 
     async def wait(self) -> None:
         """Wait for a notification."""
-        await checkpoint()
+        await checkpoint_if_cancelled()
         event = Event()
         self._waiters.append(event)
         self.release()
@@ -337,6 +341,22 @@ class Condition:
         finally:
             with CancelScope(shield=True):
                 await self.acquire()
+
+    async def wait_for(self, predicate: Callable[[], T]) -> T:
+        """
+        Wait until a predicate becomes true.
+
+        :param predicate: a callable that returns a truthy value when the condition is
+            met
+        :return: the result of the predicate
+
+        .. versionadded:: 4.11.0
+
+        """
+        while not (result := predicate()):
+            await self.wait()
+
+        return result
 
     def statistics(self) -> ConditionStatistics:
         """

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -328,6 +328,7 @@ class Condition:
     async def wait(self) -> None:
         """Wait for a notification."""
         await checkpoint_if_cancelled()
+        self._check_acquired()
         event = Event()
         self._waiters.append(event)
         self.release()

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -399,6 +399,13 @@ class TestCondition:
         assert task_started
         assert not notified
 
+    async def test_wait_no_lock(self) -> None:
+        condition = Condition()
+        with pytest.raises(
+            RuntimeError, match="The current task is not holding the underlying lock"
+        ):
+            await condition.wait()
+
     async def test_statistics(self) -> None:
         async def waiter() -> None:
             async with condition:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This adds the `wait_for()` method to `Condition`, same as the one on [asyncio](https://docs.python.org/3.14/library/asyncio-sync.html#asyncio.Condition.wait_for).

It also makes minute improvements to the performance and error messages in `Condition`.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [X] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
