### PR TITLE
Added support for cancellation reasons

### DIFF
--- a/docs/cancellation.rst
+++ b/docs/cancellation.rst
@@ -200,6 +200,32 @@ cancelled scope::
 
             raise
 
+Specifying the reason for cancellation
+--------------------------------------
+
+To help with debugging, it is possible to specify a reason why you're cancelling a
+cancel scope::
+
+    async def do_something():
+        with CancelScope() as scope:
+            scope.cancel("Testing cancellation")
+            try:
+                await sleep(1)
+            except get_cancelled_exc_class() as exc:
+                print(exc)  # Print the cancellation message
+                raise  # Always re-raise cancellation exceptions!
+
+        raise
+
+While the exact resulting message from the cancellation exception varies by the event
+loop implementation, it will contain at least the following pieces of information:
+
+* The cancellation reason (if one was given)
+* The task name where :meth:`CancelScope.cancel` was called (if cancelled from a task)
+
+.. note:: Calling :meth:`~CancelScope.cancel` on an already cancelled scope will not
+    change the cancel message.
+
 .. _cancel_scope_stack_corruption:
 
 Avoiding cancel scope stack corruption

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added support for cancellation reasons (the ``reason`` parameter to
+  ``CancelScope.cancel()``)
+- Bumped the minimum version of Trio to v0.31.0
 - Added the ability to enter the event loop from foreign (non-worker) threads by
   passing the return value of ``anyio.lowlevel.current_token()`` to
   ``anyio.from_thread.run()`` and ``anyio.from_thread.run_sync()`` as the ``token``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ Changelog = "https://anyio.readthedocs.io/en/stable/versionhistory.html"
 "Issue tracker" = "https://github.com/agronholm/anyio/issues"
 
 [project.optional-dependencies]
-trio = ["trio >= 0.26.1"]
+trio = ["trio >= 0.31.0"]
 
 [project.entry-points]
 pytest11 = {anyio = "anyio.pytest_plugin"}

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -379,7 +379,7 @@ def is_anyio_cancellation(exc: CancelledError) -> bool:
         if (
             exc.args
             and isinstance(exc.args[0], str)
-            and exc.args[0].startswith("Cancelled by cancel scope ")
+            and exc.args[0].startswith("Cancelled via cancel scope ")
         ):
             return True
 
@@ -623,7 +623,10 @@ class CancelScope(BaseCancelScope):
                 self._timeout_handle = None
 
             self._cancel_called = True
-            self._cancel_reason = f"Cancelled by cancel scope {id(self):x}"
+            self._cancel_reason = f"Cancelled via cancel scope {id(self):x}"
+            if task := current_task():
+                self._cancel_reason += f" by {task}"
+
             if reason:
                 self._cancel_reason += f"; reason: {reason}"
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -402,6 +402,7 @@ class CancelScope(BaseCancelScope):
         self._parent_scope: CancelScope | None = None
         self._child_scopes: set[CancelScope] = set()
         self._cancel_called = False
+        self._cancel_reason: str | None = None
         self._cancelled_caught = False
         self._active = False
         self._timeout_handle: asyncio.TimerHandle | None = None
@@ -546,7 +547,7 @@ class CancelScope(BaseCancelScope):
         if self._deadline != math.inf:
             loop = get_running_loop()
             if loop.time() >= self._deadline:
-                self.cancel()
+                self.cancel("deadline exceeded")
             else:
                 self._timeout_handle = loop.call_at(self._deadline, self._timeout)
 
@@ -572,7 +573,7 @@ class CancelScope(BaseCancelScope):
             if task is not current and (task is self._host_task or _task_started(task)):
                 waiter = task._fut_waiter  # type: ignore[attr-defined]
                 if not isinstance(waiter, asyncio.Future) or not waiter.done():
-                    task.cancel(f"Cancelled by cancel scope {id(origin):x}")
+                    task.cancel(origin._cancel_reason)
                     if (
                         task is origin._host_task
                         and origin._pending_uncancellations is not None
@@ -615,13 +616,17 @@ class CancelScope(BaseCancelScope):
 
             scope = scope._parent_scope
 
-    def cancel(self) -> None:
+    def cancel(self, reason: str | None = None) -> None:
         if not self._cancel_called:
             if self._timeout_handle:
                 self._timeout_handle.cancel()
                 self._timeout_handle = None
 
             self._cancel_called = True
+            self._cancel_reason = f"Cancelled by cancel scope {id(self):x}"
+            if reason:
+                self._cancel_reason += f"; reason: {reason}"
+
             if self._host_task is not None:
                 self._deliver_cancellation(self)
 

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -137,8 +137,8 @@ class CancelScope(BaseCancelScope):
     ) -> bool:
         return self.__original.__exit__(exc_type, exc_val, exc_tb)
 
-    def cancel(self) -> None:
-        self.__original.cancel()
+    def cancel(self, reason: str | None = None) -> None:
+        self.__original.cancel(reason)
 
     @property
     def deadline(self) -> float:

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -30,8 +30,13 @@ class CancelScope:
     ) -> CancelScope:
         return get_async_backend().create_cancel_scope(shield=shield, deadline=deadline)
 
-    def cancel(self) -> None:
-        """Cancel this scope immediately."""
+    def cancel(self, reason: str | None = None) -> None:
+        """
+        Cancel this scope immediately.
+
+        :param reason: a message describing the reason for the cancellation
+
+        """
         raise NotImplementedError
 
     @property

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -224,7 +224,7 @@ class BlockingPortal:
         self._event_loop_thread_id = None
         self._stop_event.set()
         if cancel_remaining:
-            self._task_group.cancel_scope.cancel()
+            self._task_group.cancel_scope.cancel("the blocking portal is shutting down")
 
     async def _call_func(
         self,
@@ -238,14 +238,14 @@ class BlockingPortal:
                 None,
                 get_ident(),
             ):
-                self.call(scope.cancel)
+                self.call(scope.cancel, "the future was cancelled")
 
         try:
             retval_or_awaitable = func(*args, **kwargs)
             if isawaitable(retval_or_awaitable):
                 with CancelScope() as scope:
                     if future.cancelled():
-                        scope.cancel()
+                        scope.cancel("the future was cancelled")
                     else:
                         future.add_done_callback(callback)
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -539,7 +539,13 @@ async def test_cancel_scope_cleared() -> None:
 async def test_fail_after(delay: float) -> None:
     with pytest.raises(TimeoutError):
         with fail_after(delay) as scope:
-            await sleep(1)
+            try:
+                await sleep(1)
+            except get_cancelled_exc_class() as exc:
+                assert "deadline" in str(exc)
+                raise
+            else:
+                pytest.fail("sleep() should have raised a cancellation exception")
 
     assert scope.cancel_called
     assert scope.cancelled_caught
@@ -1798,3 +1804,10 @@ async def test_exception_groups_suppresses_exc_context() -> None:
             raise Exception("Error")
 
     assert exc_info.value.__suppress_context__
+
+
+async def test_cancel_reason() -> None:
+    with CancelScope() as scope:
+        scope.cancel("test reason")
+        with pytest.raises(get_cancelled_exc_class(), match="test reason"):
+            await checkpoint()

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1809,5 +1809,10 @@ async def test_exception_groups_suppresses_exc_context() -> None:
 async def test_cancel_reason() -> None:
     with CancelScope() as scope:
         scope.cancel("test reason")
-        with pytest.raises(get_cancelled_exc_class(), match="test reason"):
+        with pytest.raises(get_cancelled_exc_class()) as exc_info:
             await checkpoint()
+
+    task = get_current_task()
+    assert task and task.name
+    exc_info.match("test reason")
+    exc_info.match(task.name)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This adds support for specifying a reason when cancelling a cancel scope.

It also includes the origin task of the cancellation, if one is present.
This also forces a bump of the minimum Trio version as only v0.31.0 supports cancel reasons.

Fixes #939.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [X] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
