### PR TITLE
Fixed the inconsistent exception on sending to a closed TCP stream

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -23,6 +23,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed TCP listener behavior to guarantee the same ephemeral port is used for all
   socket listeners when ``local_port=0``
   (`#857 <https://github.com/agronholm/anyio/issues/857>`_; PR by @11kkw and @agronholm)
+- Fixed inconsistency between Trio and asyncio where a TCP stream that previously
+  raised a ``BrokenResourceError`` on ``send()`` would still raise
+  ``BrokenResourceError`` after the stream was closed on asyncio, but
+  ``ClosedResourceError`` on Trio. They now both raise a ``ClosedResourceError`` in this
+  scenario. (`#671 <https://github.com/agronholm/anyio/issues/671>`_)
 
 **4.10.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1313,8 +1313,8 @@ class SocketStream(abc.SocketStream):
             pass
 
     async def aclose(self) -> None:
+        self._closed = True
         if not self._transport.is_closing():
-            self._closed = True
             try:
                 self._transport.write_eof()
             except OSError:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Makes stream operations on TCP sockets always raise `ClosedResourceError` after the resource has been explicitly closed.

Fixes #671.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
