### PR TITLE
Avoid ScopeMismatch when overriding anyio_backend fixture

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -65,7 +65,7 @@ this name which runs everything on all supported backends.
 If you change the backends/options for the entire project, then put something like this
 in your top level ``conftest.py``::
 
-    @pytest.fixture
+    @pytest.fixture(scope="module")
     def anyio_backend():
         return 'asyncio'
 


### PR DESCRIPTION
It took me a while to figure out how to get around the ScopeMismatch, when overriding the anyio_backend fixture from default (asyncio + trio) to just asyncio.
