### PR TITLE
Allowed passing keyword arguments to subprocesses

### DIFF
--- a/docs/subprocesses.rst
+++ b/docs/subprocesses.rst
@@ -98,7 +98,6 @@ in this case a new subprocess will always be created, as it would not be possibl
 to reuse a worker process created with different keyword arguments::
 
   import os
-  import time
   from functools import partial
 
   from anyio import create_task_group, run, to_process, to_thread

--- a/docs/subprocesses.rst
+++ b/docs/subprocesses.rst
@@ -118,7 +118,6 @@ to reuse a worker process created with different keyword arguments::
           data = await to_thread.run_sync(os.read, receiver1, 1024)
       print(data)  # b'Hello, World!'
 
-
   # This check is important when the application uses to_process.run_sync()
   if __name__ == '__main__':
       run(main)

--- a/docs/subprocesses.rst
+++ b/docs/subprocesses.rst
@@ -95,7 +95,8 @@ This is done by using :func:`.to_process.run_sync`::
 
 You can pass keyword arguments directly to :class:`subprocess.Popen`, but note that
 in this case a new subprocess will always be created, as it would not be possible
-to reuse a worker process created with different keyword arguments::
+to reuse a worker process created with different keyword arguments. For instance,
+the following example works (on Linux) because ``close_fds=False`` is passed::
 
   import os
   from functools import partial

--- a/docs/subprocesses.rst
+++ b/docs/subprocesses.rst
@@ -93,10 +93,11 @@ This is done by using :func:`.to_process.run_sync`::
     if __name__ == '__main__':
         run(main)
 
-You can pass keyword arguments directly to :class:`subprocess.Popen`, but note that
-in this case a new subprocess will always be created, as it would not be possible
-to reuse a worker process created with different keyword arguments. For instance,
-the following example works (on Linux) because ``close_fds=False`` is passed::
+Any keyword argument to :func:`.to_process.run_sync` (other than ``cancellable`` and
+``limiter``) will be passed to :class:`subprocess.Popen`, but note that in this case
+a new subprocess will always be created, as it would not be possible to reuse a worker
+process created with different keyword arguments. For instance, the following example
+works (on Linux) because ``close_fds=False`` is passed::
 
   import os
   from functools import partial

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 **UNRELEASED**
 
 - Dropped support for Python 3.9
+- Allowed passing keyword arguments to subprocesses
+  (`#993 <https://github.com/agronholm/anyio/pull/993>`_; PR by @davidbrochart)
 - Fixed ``anyio.Path`` not being compatible with Python 3.15 due to the removal of
   ``pathlib.Path.is_reserved()`` and the addition of ``pathlib.Path.__vfspath__()``
   (`#1061 <https://github.com/agronholm/anyio/issues/1061>`_; PR by @veeceey)
@@ -30,8 +32,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#1001 <https://github.com/agronholm/anyio/pull/1001>`_)
 - Added support for ``uvloop=True`` on Windows via the winloop_ implementation
   (`#960 <https://github.com/agronholm/anyio/pull/960>`_; PR by @Vizonex)
-- Allowed passing keyword arguments to subprocesses
-  (`#993 <https://github.com/agronholm/anyio/pull/993>`_; PR by @davidbrochart)
 - Added support for use as a context manager to ``anyio.lowlevel.RunVar``
   (`#1003 <https://github.com/agronholm/anyio/pull/1003>`_)
 - Added ``__all__`` declarations to public submodules (``anyio.lowlevel`` etc.)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -9,6 +9,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Set ``None`` as the default type argument for ``anyio.abc.TaskStatus``
 - Added support for ``uvloop=True`` on Windows via the winloop_ implementation
   (`#960 <https://github.com/agronholm/anyio/pull/960>`_; PR by @Vizonex)
+- Allowed passing keyword arguments to subprocesses
+  (`#993 <https://github.com/agronholm/anyio/pull/993>`_; PR by @davidbrochart)
 
 .. _winloop: https://github.com/Vizonex/Winloop
 

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -37,6 +37,7 @@ async def run_process(
     group: str | int | None = None,
     extra_groups: Iterable[str | int] | None = None,
     umask: int = -1,
+    **kwargs: Any,
 ) -> CompletedProcess[bytes]:
     """
     Run an external command in a subprocess and wait until it completes.
@@ -72,6 +73,7 @@ async def run_process(
         POSIX only)
     :param umask: if not negative, this umask is applied in the child process before
         running the given command (Python >= 3.9, POSIX only)
+    :param kwargs: keyword arguments passed to :class:`subprocess.Popen`
     :return: an object representing the completed process
     :raises ~subprocess.CalledProcessError: if ``check`` is ``True`` and the process
         exits with a nonzero return code
@@ -103,6 +105,7 @@ async def run_process(
         group=group,
         extra_groups=extra_groups,
         umask=umask,
+        **kwargs,
     ) as process:
         stream_contents: list[bytes | None] = [None, None]
         async with create_task_group() as tg:
@@ -141,6 +144,7 @@ async def open_process(
     group: str | int | None = None,
     extra_groups: Iterable[str | int] | None = None,
     umask: int = -1,
+    **kwargs: Any,
 ) -> Process:
     """
     Start an external command in a subprocess.
@@ -171,10 +175,10 @@ async def open_process(
     :param extra_groups: supplementary groups to set in the subprocess (POSIX only)
     :param umask: if not negative, this umask is applied in the child process before
         running the given command (POSIX only)
+    :param kwargs: keyword arguments passed to :class:`subprocess.Popen`
     :return: an asynchronous process object
 
     """
-    kwargs: dict[str, Any] = {}
     if user is not None:
         kwargs["user"] = user
 

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -37,7 +37,7 @@ async def run_process(
     group: str | int | None = None,
     extra_groups: Iterable[str | int] | None = None,
     umask: int = -1,
-    **kwargs: Any,
+    popen_args: dict[str, Any] | None = None,
 ) -> CompletedProcess[bytes]:
     """
     Run an external command in a subprocess and wait until it completes.
@@ -73,7 +73,7 @@ async def run_process(
         POSIX only)
     :param umask: if not negative, this umask is applied in the child process before
         running the given command (Python >= 3.9, POSIX only)
-    :param kwargs: keyword arguments passed to :class:`subprocess.Popen`
+    :param popen_args: arguments passed to :class:`subprocess.Popen`
     :return: an object representing the completed process
     :raises ~subprocess.CalledProcessError: if ``check`` is ``True`` and the process
         exits with a nonzero return code
@@ -105,7 +105,7 @@ async def run_process(
         group=group,
         extra_groups=extra_groups,
         umask=umask,
-        **kwargs,
+        popen_args=popen_args,
     ) as process:
         stream_contents: list[bytes | None] = [None, None]
         async with create_task_group() as tg:
@@ -144,7 +144,7 @@ async def open_process(
     group: str | int | None = None,
     extra_groups: Iterable[str | int] | None = None,
     umask: int = -1,
-    **kwargs: Any,
+    popen_args: dict[str, Any] | None = None,
 ) -> Process:
     """
     Start an external command in a subprocess.
@@ -175,10 +175,14 @@ async def open_process(
     :param extra_groups: supplementary groups to set in the subprocess (POSIX only)
     :param umask: if not negative, this umask is applied in the child process before
         running the given command (POSIX only)
-    :param kwargs: keyword arguments passed to :class:`subprocess.Popen`
+    :param popen_args: arguments passed to :class:`subprocess.Popen`
     :return: an asynchronous process object
 
     """
+    kwargs: dict[str, Any] = {}
+    if popen_args is not None:
+        kwargs.update(popen_args)
+
     if user is not None:
         kwargs["user"] = user
 

--- a/src/anyio/to_process.py
+++ b/src/anyio/to_process.py
@@ -7,7 +7,7 @@ import sys
 from collections import deque
 from collections.abc import Callable
 from importlib.util import module_from_spec, spec_from_file_location
-from typing import TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from ._core._eventloop import current_time, get_async_backend, get_cancelled_exc_class
 from ._core._exceptions import BrokenWorkerProcess
@@ -40,6 +40,7 @@ async def run_sync(  # type: ignore[return]
     *args: Unpack[PosArgsT],
     cancellable: bool = False,
     limiter: CapacityLimiter | None = None,
+    **kwargs: Any,
 ) -> T_Retval:
     """
     Call the given function with the given arguments in a worker process.
@@ -54,11 +55,19 @@ async def run_sync(  # type: ignore[return]
         running
     :param limiter: capacity limiter to use to limit the total amount of processes
         running (if omitted, the default limiter is used)
+    :param kwargs: keyword arguments passed to :class:`subprocess.Popen`. If any,
+        a new subprocess will always be created instead of using a process pool
+        (and potentially reusing a worker process).
     :return: an awaitable that yields the return value of the function.
 
     """
 
-    async def send_raw_command(pickled_cmd: bytes) -> object:
+    async def send_raw_command(
+        pickled_cmd: bytes,
+        process: Process,
+        stdin: ByteSendStream,
+        buffered: BufferedByteReceiveStream,
+    ) -> object:
         try:
             await stdin.send(pickled_cmd)
             response = await buffered.receive_until(b"\n", 50)
@@ -90,6 +99,41 @@ async def run_sync(  # type: ignore[return]
         else:
             return retval
 
+    async def _open_process(
+        **kwargs: Any,
+    ) -> tuple[Process, ByteSendStream, BufferedByteReceiveStream]:
+        command = [sys.executable, "-u", "-m", __name__]
+        process = await open_process(
+            command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, **kwargs
+        )
+        try:
+            stdin = cast(ByteSendStream, process.stdin)
+            buffered = BufferedByteReceiveStream(
+                cast(ByteReceiveStream, process.stdout)
+            )
+            with fail_after(20):
+                message = await buffered.receive(6)
+
+            if message != b"READY\n":
+                raise BrokenWorkerProcess(
+                    f"Worker process returned unexpected response: {message!r}"
+                )
+
+            main_module_path = getattr(sys.modules["__main__"], "__file__", None)
+            pickled = pickle.dumps(
+                ("init", sys.path, main_module_path),
+                protocol=pickle.HIGHEST_PROTOCOL,
+            )
+            await send_raw_command(pickled, process, stdin, buffered)
+        except (BrokenWorkerProcess, get_cancelled_exc_class()):
+            raise
+        except BaseException as exc:
+            process.kill()
+            raise BrokenWorkerProcess(
+                "Error during worker process initialization"
+            ) from exc
+        return process, stdin, buffered
+
     # First pickle the request before trying to reserve a worker process
     await checkpoint_if_cancelled()
     request = pickle.dumps(("run", func, args), protocol=pickle.HIGHEST_PROTOCOL)
@@ -105,78 +149,59 @@ async def run_sync(  # type: ignore[return]
         _process_pool_idle_workers.set(idle_workers)
         get_async_backend().setup_process_pool_exit_at_shutdown(workers)
 
-    async with limiter or current_default_process_limiter():
-        # Pop processes from the pool (starting from the most recently used) until we
-        # find one that hasn't exited yet
-        process: Process
-        while idle_workers:
-            process, idle_since = idle_workers.pop()
-            if process.returncode is None:
-                stdin = cast(ByteSendStream, process.stdin)
-                buffered = BufferedByteReceiveStream(
-                    cast(ByteReceiveStream, process.stdout)
-                )
-
-                # Prune any other workers that have been idle for WORKER_MAX_IDLE_TIME
-                # seconds or longer
-                now = current_time()
-                killed_processes: list[Process] = []
-                while idle_workers:
-                    if now - idle_workers[0][1] < WORKER_MAX_IDLE_TIME:
-                        break
-
-                    process_to_kill, idle_since = idle_workers.popleft()
-                    process_to_kill.kill()
-                    workers.remove(process_to_kill)
-                    killed_processes.append(process_to_kill)
-
-                with CancelScope(shield=True):
-                    for killed_process in killed_processes:
-                        await killed_process.aclose()
-
-                break
-
-            workers.remove(process)
-        else:
-            command = [sys.executable, "-u", "-m", __name__]
-            process = await open_process(
-                command, stdin=subprocess.PIPE, stdout=subprocess.PIPE
-            )
-            try:
-                stdin = cast(ByteSendStream, process.stdin)
-                buffered = BufferedByteReceiveStream(
-                    cast(ByteReceiveStream, process.stdout)
-                )
-                with fail_after(20):
-                    message = await buffered.receive(6)
-
-                if message != b"READY\n":
-                    raise BrokenWorkerProcess(
-                        f"Worker process returned unexpected response: {message!r}"
+    if kwargs:
+        process, stdin, buffered = await _open_process(**kwargs)
+    else:
+        async with limiter or current_default_process_limiter():
+            # Pop processes from the pool (starting from the most recently used) until we
+            # find one that hasn't exited yet
+            while idle_workers:
+                process, idle_since = idle_workers.pop()
+                if process.returncode is None:
+                    stdin = cast(ByteSendStream, process.stdin)
+                    buffered = BufferedByteReceiveStream(
+                        cast(ByteReceiveStream, process.stdout)
                     )
 
-                main_module_path = getattr(sys.modules["__main__"], "__file__", None)
-                pickled = pickle.dumps(
-                    ("init", sys.path, main_module_path),
-                    protocol=pickle.HIGHEST_PROTOCOL,
-                )
-                await send_raw_command(pickled)
-            except (BrokenWorkerProcess, get_cancelled_exc_class()):
-                raise
-            except BaseException as exc:
-                process.kill()
-                raise BrokenWorkerProcess(
-                    "Error during worker process initialization"
-                ) from exc
+                    # Prune any other workers that have been idle for WORKER_MAX_IDLE_TIME
+                    # seconds or longer
+                    now = current_time()
+                    killed_processes: list[Process] = []
+                    while idle_workers:
+                        if now - idle_workers[0][1] < WORKER_MAX_IDLE_TIME:
+                            break
 
-            workers.add(process)
+                        process_to_kill, idle_since = idle_workers.popleft()
+                        process_to_kill.kill()
+                        workers.remove(process_to_kill)
+                        killed_processes.append(process_to_kill)
 
-        with CancelScope(shield=not cancellable):
-            try:
-                return cast(T_Retval, await send_raw_command(request))
-            finally:
-                if process in workers:
-                    idle_workers.append((process, current_time()))
+                    with CancelScope(shield=True):
+                        for killed_process in killed_processes:
+                            await killed_process.aclose()
+
+                    break
+
+                workers.remove(process)
+            else:
+                process, stdin, buffered = await _open_process()
+                workers.add(process)
+
+    with CancelScope(shield=not cancellable):
+        try:
+            return cast(
+                T_Retval, await send_raw_command(request, process, stdin, buffered)
+            )
+        finally:
+            if kwargs:
+                try:
+                    process.kill()
+                    with CancelScope(shield=True):
+                        await process.aclose()
+                except ProcessLookupError:
+                    pass
+            elif process in workers:
+                idle_workers.append((process, current_time()))
 
 
 def current_default_process_limiter() -> CapacityLimiter:

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -59,8 +59,12 @@ async def test_run_sync_with_kwargs() -> None:
 
     receiver0, sender0 = os.pipe()
     receiver1, sender1 = os.pipe()
-    os.set_inheritable(receiver0, True)
-    os.set_inheritable(sender1, True)
+    if sys.platform == "win32":
+        os.set_handle_inheritable(receiver0, True)
+        os.set_handle_inheritable(sender1, True)
+    else:
+        os.set_inheritable(receiver0, True)
+        os.set_inheritable(sender1, True)
 
     with fail_after(4):
         async with create_task_group() as tg:

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -31,6 +31,7 @@ async def test_run_sync_in_process_pool() -> None:
     assert worker_pid != os.getpid()
     assert await to_process.run_sync(os.getpid) == worker_pid
 
+
 async def test_run_sync_not_in_process_pool() -> None:
     """
     Test that the function runs in a different process, and not the same process in both
@@ -60,7 +61,16 @@ async def test_run_sync_with_kwargs() -> None:
 
     with fail_after(4):
         async with create_task_group() as tg:
-            tg.start_soon(partial(to_process.run_sync, process_func, receiver0, sender1, close_fds=False, cancellable=True))
+            tg.start_soon(
+                partial(
+                    to_process.run_sync,
+                    process_func,
+                    receiver0,
+                    sender1,
+                    close_fds=False,
+                    cancellable=True,
+                )
+            )
             os.write(sender0, b"Hello")
             data = await to_thread.run_sync(os.read, receiver1, 1024)
 

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -38,9 +38,12 @@ async def test_run_sync_not_in_process_pool() -> None:
     calls.
 
     """
-    worker_pid = await to_process.run_sync(os.getpid, close_fds=False)
+    worker_pid = await to_process.run_sync(os.getpid, popen_args={"close_fds": False})
     assert worker_pid != os.getpid()
-    assert await to_process.run_sync(os.getpid, close_fds=False) != worker_pid
+    assert (
+        await to_process.run_sync(os.getpid, popen_args={"close_fds": False})
+        != worker_pid
+    )
 
 
 def process_func(receiver: int) -> bytes:
@@ -54,9 +57,9 @@ def process_func(receiver: int) -> bytes:
     return data + b", World!"
 
 
-async def test_run_sync_with_kwargs(event_loop_implementation_name: str) -> None:
+async def test_run_sync_with_popen_args(event_loop_implementation_name: str) -> None:
     """
-    Test that keyword arguments are passed to the process.
+    Test that arguments are passed to Popen.
 
     """
     if platform.system() == "Darwin" and event_loop_implementation_name == "uvloop":
@@ -79,8 +82,8 @@ async def test_run_sync_with_kwargs(event_loop_implementation_name: str) -> None
             data = await to_process.run_sync(
                 process_func,
                 receiver,
-                close_fds=False,
                 cancellable=True,
+                popen_args={"close_fds": False},
             )
 
         assert data == b"Hello, World!"

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -54,6 +54,7 @@ def process_func(receiver: int, sender: int) -> None:
     sys.platform == "win32",
     reason="The test hangs on Windows",
 )
+@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
 async def test_run_sync_with_kwargs() -> None:
     """
     Test that keyword arguments are passed to the process.

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -53,7 +53,6 @@ def process_func(receiver: int) -> bytes:
     return data + b", World!"
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
 async def test_run_sync_with_kwargs() -> None:
     """
     Test that keyword arguments are passed to the process.

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -15,7 +15,6 @@ from anyio import (
     create_task_group,
     fail_after,
     to_process,
-    to_thread,
     wait_all_tasks_blocked,
 )
 from anyio.abc import Process

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -31,6 +31,17 @@ async def test_run_sync_in_process_pool() -> None:
     assert await to_process.run_sync(os.getpid) == worker_pid
 
 
+async def test_run_sync_with_kwargs() -> None:
+    """
+    Test that the function runs in a different process, and not the same process in both
+    calls.
+
+    """
+    worker_pid = await to_process.run_sync(os.getpid, close_fds=False)
+    assert worker_pid != os.getpid()
+    assert await to_process.run_sync(os.getpid, close_fds=False) != worker_pid
+
+
 async def test_identical_sys_path() -> None:
     """Test that partial() can be used to pass keyword arguments."""
     assert await to_process.run_sync(eval, "sys.path") == sys.path

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -43,7 +43,7 @@ async def test_run_sync_not_in_process_pool() -> None:
     assert await to_process.run_sync(os.getpid, close_fds=False) != worker_pid
 
 
-def process_func(receiver, sender):
+def process_func(receiver: int, sender: int) -> None:
     data = os.read(receiver, 1024)
     os.write(sender, data + b", World!")
 

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import platform
 import os
+import platform
 import sys
 import time
 from functools import partial

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -54,7 +54,7 @@ def process_func(receiver: int) -> bytes:
     return data + b", World!"
 
 
-async def test_run_sync_with_kwargs(event_loop_implementation_name) -> None:
+async def test_run_sync_with_kwargs(event_loop_implementation_name: str) -> None:
     """
     Test that keyword arguments are passed to the process.
 

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -50,6 +50,10 @@ def process_func(receiver: int, sender: int) -> None:
     os.close(sender)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="The test hangs on Windows",
+)
 @pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
 async def test_run_sync_with_kwargs() -> None:
     """
@@ -59,12 +63,8 @@ async def test_run_sync_with_kwargs() -> None:
 
     receiver0, sender0 = os.pipe()
     receiver1, sender1 = os.pipe()
-    if sys.platform == "win32":
-        os.set_handle_inheritable(receiver0, True)
-        os.set_handle_inheritable(sender1, True)
-    else:
-        os.set_inheritable(receiver0, True)
-        os.set_inheritable(sender1, True)
+    os.set_inheritable(receiver0, True)
+    os.set_inheritable(sender1, True)
 
     with fail_after(4):
         async with create_task_group() as tg:

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -66,7 +66,7 @@ async def test_run_sync_with_kwargs() -> None:
         from msvcrt import get_osfhandle
 
         receiver = get_osfhandle(receiver_fd)
-        os.set_handle_inheritable(receiver)
+        os.set_handle_inheritable(receiver, True)
     else:
         receiver = receiver_fd
         os.set_inheritable(receiver, True)

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -46,6 +46,8 @@ async def test_run_sync_not_in_process_pool() -> None:
 def process_func(receiver: int, sender: int) -> None:
     data = os.read(receiver, 1024)
     os.write(sender, data + b", World!")
+    os.close(receiver)
+    os.close(sender)
 
 
 @pytest.mark.skipif(
@@ -79,6 +81,8 @@ async def test_run_sync_with_kwargs() -> None:
             data = await to_thread.run_sync(os.read, receiver1, 1024)
 
     assert data == b"Hello, World!"
+    os.close(sender0)
+    os.close(receiver1)
 
 
 async def test_identical_sys_path() -> None:

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import platform
 import os
 import sys
 import time
@@ -53,11 +54,13 @@ def process_func(receiver: int) -> bytes:
     return data + b", World!"
 
 
-async def test_run_sync_with_kwargs() -> None:
+async def test_run_sync_with_kwargs(event_loop_implementation_name) -> None:
     """
     Test that keyword arguments are passed to the process.
 
     """
+    if platform.system() == "Darwin" and event_loop_implementation_name == "uvloop":
+        pytest.skip("The test fails on macOS with uvloop (Bad file descriptor)")
 
     receiver_fd, sender_fd = os.pipe()
 

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -50,10 +50,6 @@ def process_func(receiver: int, sender: int) -> None:
     os.close(sender)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="The test hangs on Windows",
-)
 @pytest.mark.parametrize("anyio_backend", ["asyncio", "trio"])
 async def test_run_sync_with_kwargs() -> None:
     """

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -52,7 +52,6 @@ def process_func(receiver: int, sender: int) -> None:
     sys.platform == "win32",
     reason="The test hangs on Windows",
 )
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_run_sync_with_kwargs() -> None:
     """
     Test that keyword arguments are passed to the process.

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -48,6 +48,7 @@ def process_func(receiver: int, sender: int) -> None:
     os.write(sender, data + b", World!")
 
 
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_run_sync_with_kwargs() -> None:
     """
     Test that keyword arguments are passed to the process.

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -48,6 +48,10 @@ def process_func(receiver: int, sender: int) -> None:
     os.write(sender, data + b", World!")
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="The test hangs on Windows",
+)
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_run_sync_with_kwargs() -> None:
     """


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

This PR makes it possible to pass keyword arguments to [Popen](https://docs.python.org/3/library/subprocess.html#popen-constructor), through `run_process`, `open_process` or `to_process.run_sync`. In the later case, a new subprocess is always created, since it wouldn't be possible to reuse a worker process created with different keyword arguments.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
