### PR TITLE
Stop requiring exceptiongroup on Python ≥ 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ pytest11 = {anyio = "anyio.pytest_plugin"}
 test = [
     "blockbuster >= 1.5.23",
     "coverage[toml] >= 7",
-    "exceptiongroup >= 1.2.0",
+    "exceptiongroup >= 1.2.0; python_version < '3.11'",
     "hypothesis >= 4.18.2",
     "psutil >= 5.9",
     "pytest >= 7.0",

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -11,7 +11,6 @@ from typing import Any, NoReturn, cast
 from unittest import mock
 
 import pytest
-from exceptiongroup import catch
 from pytest import FixtureRequest, MonkeyPatch
 
 import anyio
@@ -35,7 +34,7 @@ from anyio.lowlevel import checkpoint
 from .conftest import asyncio_params, no_other_refs
 
 if sys.version_info < (3, 11):
-    from exceptiongroup import BaseExceptionGroup, ExceptionGroup
+    from exceptiongroup import BaseExceptionGroup, ExceptionGroup, catch
 
 
 async def async_error(text: str, delay: float = 0.1) -> NoReturn:
@@ -1555,8 +1554,14 @@ async def test_reraise_cancelled_in_excgroup() -> None:
 
     with CancelScope() as scope:
         scope.cancel()
-        with catch({get_cancelled_exc_class(): handler}):
-            await anyio.sleep_forever()
+        if sys.version_info < (3, 11):
+            with catch({get_cancelled_exc_class(): handler}):
+                await anyio.sleep_forever()
+        else:
+            try:
+                await anyio.sleep_forever()
+            except* get_cancelled_exc_class():
+                raise
 
 
 async def test_cancel_child_task_when_host_is_shielded() -> None:


### PR DESCRIPTION
## Changes

Make exceptiongroup not a test requirement on Python ≥ 3.11.  [In Guix we want to remove exceptiongroup originally because it depends on the inactive flit-scm project](https://codeberg.org/guix/guix/issues/2360), but fewer dependencies is always better

## Checklist

Please let me know if any of the following is applicable, as the patch isn't user-facing.

- [ ] I've added tests (in `tests/`) which would fail without my patch
- [ ] I've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] I've added a new changelog entry (in `docs/versionhistory.rst`).