### PR TITLE
Fix ModuleNotFoundError for __main__ when run from entry points

### DIFF
--- a/src/anyio/to_process.py
+++ b/src/anyio/to_process.py
@@ -10,6 +10,7 @@ import os
 import pickle
 import subprocess
 import sys
+import types
 from collections import deque
 from collections.abc import Callable
 from importlib.util import module_from_spec, spec_from_file_location
@@ -242,6 +243,13 @@ def process_worker() -> None:
                             sys.modules["__main__"] = main
                     except BaseException as exc:
                         exception = exc
+
+                # Ensure __main__ is always present in sys.modules (entry
+                # point scripts without .py extension cause
+                # spec_from_file_location to return None, leaving __main__
+                # deleted)
+                if "__main__" not in sys.modules:
+                    sys.modules["__main__"] = types.ModuleType("__main__")
         try:
             if exception is not None:
                 status = b"EXCEPTION"

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -135,9 +135,7 @@ def _check_main_importable() -> bool:
     return "__main__" in sys.modules
 
 
-async def test_entrypoint_main_module(
-    monkeypatch: MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_entrypoint_main_module(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """
     Test that worker process creation succeeds when __main__.__file__ points to an
     entry point script (no .py extension). Regression test for #1027.

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -128,3 +128,22 @@ async def test_nonexistent_main_module(
     script_path.touch()
     monkeypatch.setattr("__main__.__file__", str(script_path / "__main__.py"))
     await to_process.run_sync(os.getpid)
+
+
+def _check_main_importable() -> bool:
+    """Helper that runs in the worker process to check __main__ is accessible."""
+    return "__main__" in sys.modules
+
+
+async def test_entrypoint_main_module(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    Test that worker process creation succeeds when __main__.__file__ points to an
+    entry point script (no .py extension). Regression test for #1027.
+    """
+
+    script_path = tmp_path / "my-entrypoint"
+    script_path.write_text("#!/usr/bin/env python3\n")
+    monkeypatch.setattr("__main__.__file__", str(script_path))
+    assert await to_process.run_sync(_check_main_importable) is True


### PR DESCRIPTION
## Summary

Fixes `ModuleNotFoundError: No module named '__main__'` when `to_process.run_sync()` is called from a package entry point (console_scripts).

Fixes #1027

## Root cause

When `__main__.__file__` points to an entry point script without a `.py` extension, `spec_from_file_location` returns `None`. The worker's init code deletes `sys.modules["__main__"]` (line 233) but never restores it, because the spec guard at line 239 skips module loading. Libraries like `dill` that subsequently try `import __main__` get `ModuleNotFoundError`.

## Fix

After the init block, if `"__main__"` is no longer in `sys.modules`, create a placeholder `types.ModuleType("__main__")`. This matches `multiprocessing`'s approach for handling non-importable main modules.

## Test plan

- [x] New test `test_entrypoint_main_module`: sets `__main__.__file__` to a real file without `.py` extension, verifies worker can still access `__main__` via `sys.modules`
- [x] All 30 existing `test_to_process.py` tests pass (10 skipped for uvloop)
