### PR TITLE
fix: validate max_bytes in ByteReceiveStream.receive() implementations

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1020,6 +1020,9 @@ class StreamReaderWrapper(abc.ByteReceiveStream):
     _stream: asyncio.StreamReader
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         data = await self._stream.read(max_bytes)
         if data:
             return data
@@ -1253,6 +1256,9 @@ class SocketStream(abc.SocketStream):
         return self._transport.get_extra_info("socket")
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         with self._receive_guard:
             if (
                 not self._protocol.read_event.is_set()
@@ -1377,6 +1383,9 @@ class UNIXSocketStream(_RawSocketMixin, abc.UNIXSocketStream):
             self._raw_socket.shutdown(socket.SHUT_WR)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         loop = get_running_loop()
         await AsyncIOBackend.checkpoint()
         with self._receive_guard:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -228,6 +228,9 @@ class ReceiveStreamWrapper(abc.ByteReceiveStream):
     _stream: trio.abc.ReceiveStream
 
     async def receive(self, max_bytes: int | None = None) -> bytes:
+        if max_bytes is not None and max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         try:
             data = await self._stream.receive_some(max_bytes)
         except trio.ClosedResourceError as exc:
@@ -383,6 +386,9 @@ class SocketStream(_TrioSocketMixin, abc.SocketStream):
         self._send_guard = ResourceGuard("writing to")
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         with self._receive_guard:
             try:
                 data = await self._trio_socket.recv(max_bytes)

--- a/src/anyio/abc/_streams.py
+++ b/src/anyio/abc/_streams.py
@@ -140,9 +140,10 @@ class ByteReceiveStream(AsyncResource, TypedAttributeProvider):
         .. note:: Implementers of this interface should not return an empty
             :class:`bytes` object, and users should ignore them.
 
-        :param max_bytes: maximum number of bytes to receive
+        :param max_bytes: maximum number of bytes to receive (must be >= 1)
         :return: the received bytes
         :raises ~anyio.EndOfStream: if this stream has been closed from the other end
+        :raises ValueError: if ``max_bytes`` is less than 1
         """
 
 

--- a/src/anyio/streams/buffered.py
+++ b/src/anyio/streams/buffered.py
@@ -65,6 +65,9 @@ class BufferedByteReceiveStream(ByteReceiveStream):
         self._buffer.extend(data)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         if self._closed:
             raise ClosedResourceError
 

--- a/src/anyio/streams/file.py
+++ b/src/anyio/streams/file.py
@@ -79,6 +79,9 @@ class FileReadStream(_BaseFileStream, ByteReceiveStream):
         return cls(cast(BinaryIO, file))
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         try:
             data = await to_thread.run_sync(self._file.read, max_bytes)
         except ValueError:

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -236,6 +236,9 @@ class TLSStream(ByteStream):
         await self.transport_stream.aclose()
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         data = await self._call_sslobject_method(self._ssl_object.read, max_bytes)
         if not data:
             raise EndOfStream

--- a/tests/streams/test_buffered.py
+++ b/tests/streams/test_buffered.py
@@ -17,6 +17,21 @@ from anyio.streams.buffered import (
 from anyio.streams.stapled import StapledObjectStream
 
 
+@pytest.mark.parametrize("max_bytes", [0, -1])
+async def test_receive_max_bytes_validation(max_bytes: int) -> None:
+    """receive() raises ValueError when max_bytes < 1.
+
+    Regression test for https://github.com/agronholm/anyio/issues/1081
+    """
+    send_stream, receive_stream = create_memory_object_stream[bytes](1)
+    buffered_stream = BufferedByteReceiveStream(receive_stream)
+    with pytest.raises(ValueError, match="max_bytes"):
+        await buffered_stream.receive(max_bytes)
+
+    send_stream.close()
+    receive_stream.close()
+
+
 async def test_receive_exactly() -> None:
     send_stream, receive_stream = create_memory_object_stream[bytes](2)
     buffered_stream = BufferedByteReceiveStream(receive_stream)

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -37,6 +37,18 @@ class TestFileReadStream:
             async with FileReadStream(file) as stream:
                 await self._run_filestream_test(stream)
 
+    @pytest.mark.parametrize("max_bytes", [0, -1])
+    async def test_receive_max_bytes_validation(
+        self, file_path: Path, max_bytes: int
+    ) -> None:
+        """receive() raises ValueError when max_bytes < 1.
+
+        Regression test for https://github.com/agronholm/anyio/issues/1081
+        """
+        async with await FileReadStream.from_path(file_path) as stream:
+            with pytest.raises(ValueError, match="max_bytes"):
+                await stream.receive(max_bytes)
+
     async def test_read_after_close(self, file_path: Path) -> None:
         async with await FileReadStream.from_path(file_path) as stream:
             pass

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -268,6 +268,21 @@ class TestTCPStream:
             assert stream.extra(SocketAttribute.remote_address) == server_addr
             assert stream.extra(SocketAttribute.remote_port) == server_addr[1]
 
+    @pytest.mark.parametrize("max_bytes", [0, -1])
+    async def test_receive_max_bytes_validation(
+        self,
+        server_sock: socket.socket,
+        server_addr: tuple[str, int],
+        max_bytes: int,
+    ) -> None:
+        """receive() raises ValueError when max_bytes < 1.
+
+        Regression test for https://github.com/agronholm/anyio/issues/1081
+        """
+        async with await connect_tcp(*server_addr) as stream:
+            with pytest.raises(ValueError, match="max_bytes"):
+                await stream.receive(max_bytes)
+
     async def test_send_receive(
         self, server_sock: socket.socket, server_addr: tuple[str, int]
     ) -> None:
@@ -1174,6 +1189,21 @@ class TestUNIXStream:
             pytest.raises(
                 TypedAttributeLookupError, stream.extra, SocketAttribute.remote_port
             )
+
+    @pytest.mark.parametrize("max_bytes", [0, -1])
+    async def test_receive_max_bytes_validation(
+        self,
+        server_sock: socket.socket,
+        socket_path: Path,
+        max_bytes: int,
+    ) -> None:
+        """receive() raises ValueError when max_bytes < 1.
+
+        Regression test for https://github.com/agronholm/anyio/issues/1081
+        """
+        async with await connect_unix(socket_path) as stream:
+            with pytest.raises(ValueError, match="max_bytes"):
+                await stream.receive(max_bytes)
 
     async def test_send_receive(
         self, server_sock: socket.socket, socket_path_or_str: Path | str


### PR DESCRIPTION
## Summary

- Add consistent `ValueError` for `max_bytes < 1` across all concrete `ByteReceiveStream.receive()` implementations (asyncio backend: `StreamReaderWrapper`, `SocketStream`, `UNIXSocketStream`; trio backend: `ReceiveStreamWrapper`, `SocketStream`; `TLSStream`; `FileReadStream`; `BufferedByteReceiveStream`)
- Update the `ByteReceiveStream` ABC docstring to document the `ValueError` contract
- Add regression tests for TCP sockets, UNIX sockets, buffered streams, and file streams

## Motivation

Closes #1081

Previously, passing `max_bytes=0` or negative values to `receive()` had inconsistent behavior across implementations — some returned empty bytes, some hung indefinitely, some raised unrelated errors. This change makes all implementations raise `ValueError("max_bytes must be a positive integer")` consistently.

## Test plan

- [x] `pytest tests/test_sockets.py -k test_receive_max_bytes_validation` — TCP and UNIX socket streams
- [x] `pytest tests/streams/test_buffered.py -k test_receive_max_bytes_validation` — BufferedByteReceiveStream
- [x] `pytest tests/streams/test_file.py -k test_receive_max_bytes_validation` — FileReadStream
- [x] Full test suite passes (771 passed, 759 skipped)
- [x] ruff lint clean

Generated with [Dhiman's Agentic Suite](https://github.com/Dhi13man)