### PR TITLE
Widen file stream IO annotations

### DIFF
--- a/src/anyio/streams/file.py
+++ b/src/anyio/streams/file.py
@@ -10,7 +10,7 @@ from collections.abc import Callable, Mapping
 from io import SEEK_SET, UnsupportedOperation
 from os import PathLike
 from pathlib import Path
-from typing import Any, BinaryIO, cast
+from typing import IO, Any
 
 from .. import (
     BrokenResourceError,
@@ -25,7 +25,7 @@ from ..abc import ByteReceiveStream, ByteSendStream
 
 class FileStreamAttribute(TypedAttributeSet):
     #: the open file descriptor
-    file: BinaryIO = typed_attribute()
+    file: IO[bytes] = typed_attribute()
     #: the path of the file on the file system, if available (file must be a real file)
     path: Path = typed_attribute()
     #: the file number, if available (file must be a real file or a TTY)
@@ -33,7 +33,7 @@ class FileStreamAttribute(TypedAttributeSet):
 
 
 class _BaseFileStream:
-    def __init__(self, file: BinaryIO):
+    def __init__(self, file: IO[bytes]):
         self._file = file
 
     async def aclose(self) -> None:
@@ -76,7 +76,7 @@ class FileReadStream(_BaseFileStream, ByteReceiveStream):
 
         """
         file = await to_thread.run_sync(Path(path).open, "rb")
-        return cls(cast(BinaryIO, file))
+        return cls(file)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
         try:
@@ -143,7 +143,7 @@ class FileWriteStream(_BaseFileStream, ByteSendStream):
         """
         mode = "ab" if append else "wb"
         file = await to_thread.run_sync(Path(path).open, mode)
-        return cls(cast(BinaryIO, file))
+        return cls(file)
 
     async def send(self, item: bytes) -> None:
         try:


### PR DESCRIPTION
## Summary
- widen file stream constructor and attribute annotations from `BinaryIO` to `IO[bytes]`
- remove unnecessary casts when opening files from paths
- align `FileReadStream` and `FileWriteStream` with `AsyncFile[bytes].wrapped`

Fixes #1078.

## Validation
- `.venv/bin/pytest tests/streams/test_file.py`
- `.venv/bin/mypy src/anyio/streams/file.py`
- `.venv/bin/mypy /tmp/reproducer.py` with the issue reproducer adapted to import `FileReadStream` directly