### PR TITLE
tweak to_thread docs about abandon_on_cancel

### DIFF
--- a/docs/threads.rst
+++ b/docs/threads.rst
@@ -25,7 +25,7 @@ To run a (synchronous) callable in a worker thread::
     run(main)
 
 By default, tasks are shielded from cancellation while they are waiting for a worker
-thread to finish. You can pass the ``cancellable=True`` parameter to allow such tasks to
+thread to finish. You can pass the ``abandon_on_cancel=True`` parameter to allow such tasks to
 be cancelled. Note, however, that the thread will still continue running – only its
 outcome will be ignored.
 

--- a/src/anyio/to_thread.py
+++ b/src/anyio/to_thread.py
@@ -32,9 +32,9 @@ async def run_sync(
     """
     Call the given function with the given arguments in a worker thread.
 
-    If the ``cancellable`` option is enabled and the task waiting for its completion is
-    cancelled, the thread will still run its course but its return value (or any raised
-    exception) will be ignored.
+    If the ``abandon_on_cancel`` option is enabled and the task waiting for its
+    completion is cancelled, the thread will still run its course but its
+    return value (or any raised exception) will be ignored.
 
     :param func: a callable
     :param args: positional arguments for the callable


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #. <!-- Provide issue number if exists --> Minor docs change so no issue

The docs for https://anyio.readthedocs.io/en/stable/api.html#anyio.to_thread.run_sync mentions the deprecated alias "cancellable" in the verbiage section, it should probably be re-worded to describe abandon_on_cancel