### PR TITLE
Fixed child task not cancelling its task group scope when a parent scope is already cancelled

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed a child task failing without cancelling its task group's scope on asyncio
+  when an outer cancel scope was already cancelled
+  (`#787 <https://github.com/agronholm/anyio/issues/787>`_)
 - Dropped support for Python 3.9
 - Fixed ``anyio.Path`` not being compatible with Python 3.15 due to the removal of
   ``pathlib.Path.is_reserved()`` and the addition of ``pathlib.Path.__vfspath__()``

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -835,8 +835,7 @@ class TaskGroup(abc.TaskGroup):
                     if not isinstance(exc, CancelledError):
                         self._exceptions.append(exc)
 
-                    if not self.cancel_scope._effectively_cancelled:
-                        self.cancel_scope.cancel()
+                    self.cancel_scope.cancel()
                 else:
                     task_status_future.set_exception(exc)
             elif task_status_future is not None and not task_status_future.done():

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1308,6 +1308,35 @@ async def test_cancelscope_exit_in_wrong_task() -> None:
     )
 
 
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
+async def test_child_task_cancels_scope_when_parent_scope_cancelled() -> None:
+    """
+    Regression test for #787 (weak case).
+
+    When a child task exits with an unhandled exception, the task group's
+    cancel scope must be cancelled even if an outer scope is already cancelled.
+    Previously the ``_effectively_cancelled`` guard in ``task_done`` prevented
+    this, leaving the host task unaware that a child had failed.
+    """
+
+    async def taskfunc() -> None:
+        raise Exception("child task failed")
+
+    with pytest.raises(BaseExceptionGroup) as exc:
+        with CancelScope() as outer_scope:
+            async with create_task_group() as tg:
+                outer_scope.cancel()
+                tg.start_soon(taskfunc)
+                with CancelScope(shield=True):
+                    await wait_all_tasks_blocked()
+                    await sleep(0.1)
+                tg.cancel_scope.shield = True
+                assert tg.cancel_scope.cancel_called
+
+    assert len(exc.value.exceptions) == 1
+    assert str(exc.value.exceptions[0]) == "child task failed"
+
+
 def test_unhandled_exception_group(caplog: pytest.LogCaptureFixture) -> None:
     def crash() -> NoReturn:
         raise KeyboardInterrupt


### PR DESCRIPTION
## Changes
On the asyncio backend, the `task_done` callback in `TaskGroup._spawn` skipped
calling `cancel()` on the task group's cancel scope when `_effectively_cancelled`
returned `True` (i.e. any ancestor scope was already cancelled). This meant a child
task could finish with an unhandled exception without cancelling the group's scope,
leaving the host task unaware of the failure.
This is the minimal fix suggested by @gschaffner during the review of #774
(https://github.com/agronholm/anyio/pull/774#discussion_r1755340156), which was
deferred at the time.


Fixes #787.


## Checklist
- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).