### PR TITLE
Fix type hints in FileReadStream/FileWriteStream to accept IO[bytes]

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 **UNRELEASED**
 
 - Dropped support for Python 3.9
+- Changed type hints in ``FileReadStream`` and ``FileWriteStream`` from
+  ``BinaryIO`` to ``IO[bytes]`` so they accept ``AsyncFile[bytes].wrapped``
+  and other ``IO[bytes]`` objects without type errors
+  (`#1078 <https://github.com/agronholm/anyio/issues/1078>`_)
 - Fixed ``anyio.Path`` not being compatible with Python 3.15 due to the removal of
   ``pathlib.Path.is_reserved()`` and the addition of ``pathlib.Path.__vfspath__()``
   (`#1061 <https://github.com/agronholm/anyio/issues/1061>`_; PR by @veeceey)

--- a/src/anyio/streams/file.py
+++ b/src/anyio/streams/file.py
@@ -10,7 +10,7 @@ from collections.abc import Callable, Mapping
 from io import SEEK_SET, UnsupportedOperation
 from os import PathLike
 from pathlib import Path
-from typing import Any, BinaryIO, cast
+from typing import IO, Any, cast
 
 from .. import (
     BrokenResourceError,
@@ -25,7 +25,7 @@ from ..abc import ByteReceiveStream, ByteSendStream
 
 class FileStreamAttribute(TypedAttributeSet):
     #: the open file descriptor
-    file: BinaryIO = typed_attribute()
+    file: IO[bytes] = typed_attribute()
     #: the path of the file on the file system, if available (file must be a real file)
     path: Path = typed_attribute()
     #: the file number, if available (file must be a real file or a TTY)
@@ -33,7 +33,7 @@ class FileStreamAttribute(TypedAttributeSet):
 
 
 class _BaseFileStream:
-    def __init__(self, file: BinaryIO):
+    def __init__(self, file: IO[bytes]):
         self._file = file
 
     async def aclose(self) -> None:
@@ -76,7 +76,7 @@ class FileReadStream(_BaseFileStream, ByteReceiveStream):
 
         """
         file = await to_thread.run_sync(Path(path).open, "rb")
-        return cls(cast(BinaryIO, file))
+        return cls(cast(IO[bytes], file))
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
         try:
@@ -143,7 +143,7 @@ class FileWriteStream(_BaseFileStream, ByteSendStream):
         """
         mode = "ab" if append else "wb"
         file = await to_thread.run_sync(Path(path).open, mode)
-        return cls(cast(BinaryIO, file))
+        return cls(cast(IO[bytes], file))
 
     async def send(self, item: bytes) -> None:
         try:


### PR DESCRIPTION
## Description

Changed `BinaryIO` to `IO[bytes]` in `FileStreamAttribute.file` and `_BaseFileStream.__init__` so that `AsyncFile[bytes].wrapped` (which returns `IO[bytes]`) can be passed to `FileReadStream`/`FileWriteStream` without mypy type errors.

## Problem

`BinaryIO` is a subclass/protocol extending `IO[bytes]`, not an equivalent alias. This means while you can use a `BinaryIO` as an `IO[bytes]`, you cannot use a generic `IO[bytes]` as a `BinaryIO` in the eyes of mypy.

Since `AsyncFile[bytes].wrapped` is typed as `IO[bytes]`, code like:

```python
async with await open_file(path, 'rb') as f:
    stream = FileReadStream(f.wrapped)  # mypy error: IO[bytes] is not BinaryIO
```

...fails type checking.

## Fix

Replace `BinaryIO` with `IO[bytes]` throughout `src/anyio/streams/file.py`:
- `FileStreamAttribute.file` type
- `_BaseFileStream.__init__` parameter type

Fixes #1078