### PR TITLE
Fix type hints: accept IO[bytes] instead of BinaryIO in file streams

### DIFF
--- a/src/anyio/streams/file.py
+++ b/src/anyio/streams/file.py
@@ -10,7 +10,7 @@ from collections.abc import Callable, Mapping
 from io import SEEK_SET, UnsupportedOperation
 from os import PathLike
 from pathlib import Path
-from typing import Any, BinaryIO, cast
+from typing import IO, Any, BinaryIO, cast
 
 from .. import (
     BrokenResourceError,
@@ -25,7 +25,7 @@ from ..abc import ByteReceiveStream, ByteSendStream
 
 class FileStreamAttribute(TypedAttributeSet):
     #: the open file descriptor
-    file: BinaryIO = typed_attribute()
+    file: IO[bytes] = typed_attribute()
     #: the path of the file on the file system, if available (file must be a real file)
     path: Path = typed_attribute()
     #: the file number, if available (file must be a real file or a TTY)
@@ -33,7 +33,7 @@ class FileStreamAttribute(TypedAttributeSet):
 
 
 class _BaseFileStream:
-    def __init__(self, file: BinaryIO):
+    def __init__(self, file: IO[bytes]):
         self._file = file
 
     async def aclose(self) -> None:


### PR DESCRIPTION
## Problem

`AsyncFile.wrapped` returns `IO[bytes]`, but `_BaseFileStream.__init__` and `FileStreamAttribute.file` were typed as `BinaryIO`. Since `BinaryIO` is a subclass of `IO[bytes]` (not an alias), type checkers like mypy reject passing `IO[bytes]` where `BinaryIO` is expected:

```
error: Argument 1 to "FileReadStream" has incompatible type "IO[bytes]"; expected "BinaryIO"  [arg-type]
```

## Fix

Changes `_BaseFileStream.__init__` parameter type and `FileStreamAttribute.file` type from `BinaryIO` to `IO[bytes]`. The `from_path` class methods still return `BinaryIO` since they create actual binary file objects via `Path.open("rb")`/`Path.open("wb")`.

The operations used on the file object (`read`, `write`, `close`, `seek`, `tell`, `fileno`) are all part of `IO[bytes]`, so this widening is safe and correct.

Fixes #1078