### PR TITLE
fix: validate max_bytes/nbytes in stream receive methods

### DIFF
--- a/src/anyio/streams/buffered.py
+++ b/src/anyio/streams/buffered.py
@@ -65,6 +65,9 @@ class BufferedByteReceiveStream(ByteReceiveStream):
         self._buffer.extend(data)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         if self._closed:
             raise ClosedResourceError
 
@@ -95,6 +98,9 @@ class BufferedByteReceiveStream(ByteReceiveStream):
             amount of bytes could be read from the stream
 
         """
+        if nbytes < 1:
+            raise ValueError("nbytes must be a positive integer")
+
         while True:
             remaining = nbytes - len(self._buffer)
             if remaining <= 0:
@@ -126,6 +132,9 @@ class BufferedByteReceiveStream(ByteReceiveStream):
             bytes read up to the maximum allowed
 
         """
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         delimiter_size = len(delimiter)
         offset = 0
         while True:

--- a/src/anyio/streams/file.py
+++ b/src/anyio/streams/file.py
@@ -79,6 +79,9 @@ class FileReadStream(_BaseFileStream, ByteReceiveStream):
         return cls(file)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         try:
             data = await to_thread.run_sync(self._file.read, max_bytes)
         except ValueError:

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -236,6 +236,9 @@ class TLSStream(ByteStream):
         await self.transport_stream.aclose()
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         data = await self._call_sslobject_method(self._ssl_object.read, max_bytes)
         if not data:
             raise EndOfStream

--- a/tests/streams/test_buffered.py
+++ b/tests/streams/test_buffered.py
@@ -122,3 +122,41 @@ async def test_feed_data() -> None:
     buffered_stream.feed_data(b"foo")
     assert await buffered_stream.receive_exactly(10) == b"xxxfooabcd"
     await buffered_stream.aclose()
+
+
+@pytest.mark.parametrize("max_bytes", [0, -1, -5])
+async def test_receive_invalid_max_bytes(max_bytes: int) -> None:
+    send_stream, receive_stream = create_memory_object_stream[bytes](2)
+    async with send_stream, BufferedByteReceiveStream(receive_stream) as stream:
+        await send_stream.send(b"data")
+        with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+            await stream.receive(max_bytes)
+
+
+@pytest.mark.parametrize("max_bytes", [0, -1, -5])
+async def test_receive_invalid_max_bytes_with_buffer(max_bytes: int) -> None:
+    send_stream, receive_stream = create_memory_object_stream[bytes](2)
+    async with send_stream, BufferedByteReceiveStream(receive_stream) as stream:
+        await send_stream.send(b"data")
+        await stream.receive_exactly(1)
+        assert stream._buffer
+        with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+            await stream.receive(max_bytes)
+
+
+@pytest.mark.parametrize("nbytes", [0, -1, -5])
+async def test_receive_exactly_invalid_nbytes(nbytes: int) -> None:
+    send_stream, receive_stream = create_memory_object_stream[bytes](2)
+    async with send_stream, BufferedByteReceiveStream(receive_stream) as stream:
+        await send_stream.send(b"data")
+        with pytest.raises(ValueError, match="nbytes must be a positive integer"):
+            await stream.receive_exactly(nbytes)
+
+
+@pytest.mark.parametrize("max_bytes", [0, -1, -5])
+async def test_receive_until_invalid_max_bytes(max_bytes: int) -> None:
+    send_stream, receive_stream = create_memory_object_stream[bytes](2)
+    async with send_stream, BufferedByteReceiveStream(receive_stream) as stream:
+        await send_stream.send(b"data\n")
+        with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+            await stream.receive_until(b"\n", max_bytes)

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -64,6 +64,16 @@ class TestFileReadStream:
             file = stream.extra(FileStreamAttribute.file)
             assert file.fileno() == fileno
 
+    @pytest.mark.parametrize("max_bytes", [0, -1, -5])
+    async def test_receive_invalid_max_bytes(
+        self, file_path: Path, max_bytes: int
+    ) -> None:
+        async with await FileReadStream.from_path(file_path) as stream:
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
+                await stream.receive(max_bytes)
+
 
 class TestFileWriteStream:
     @pytest.fixture


### PR DESCRIPTION
## What?

Add `ValueError` when `max_bytes < 1` or `nbytes < 1` is passed to stream receive methods.

## Why?

Fixes #1081 - Several stream receive methods silently accept zero or negative values for `max_bytes`/`nbytes`, leading to inconsistent behavior across backends:

- `BufferedByteReceiveStream.receive(0)` returns data from the buffer instead of raising
- `BufferedByteReceiveStream.receive(-1)` returns the entire buffer
- `BufferedByteReceiveStream.receive_exactly(0)` returns empty bytes
- `BufferedByteReceiveStream.receive_exactly(-1)` returns empty bytes
- `FileReadStream.receive(0)` raises `EndOfStream` instead of `ValueError`
- `TLSStream.receive(0)` raises `EndOfStream` instead of `ValueError`

This is inconsistent with standard Python I/O conventions where non-positive read sizes should raise `ValueError`.

## How?

Added early `ValueError` guard at the top of each affected method:

| Class | Method | Parameter |
|-------|--------|-----------|
| `BufferedByteReceiveStream` | `receive()` | `max_bytes` |
| `BufferedByteReceiveStream` | `receive_exactly()` | `nbytes` |
| `BufferedByteReceiveStream` | `receive_until()` | `max_bytes` |
| `FileReadStream` | `receive()` | `max_bytes` |
| `TLSStream` | `receive()` | `max_bytes` |

## Tests

Added parametrized tests (`0, -1, -5`) for each affected method in:
- `tests/streams/test_buffered.py`  
- `tests/streams/test_file.py`