### PR TITLE
Validate max_bytes >= 1 in ByteReceiveStream.receive() implementations

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added support for custom capacity limiters in async path and file I/O
   functions and classes
+- Fixed ``ByteReceiveStream.receive()`` accepting ``max_bytes < 1`` with
+  inconsistent behavior across backends and stream types. All implementations
+  now raise ``ValueError`` when ``max_bytes < 1``. Also fixed ``receive_exactly()``
+  and ``receive_until()`` on ``BufferedByteReceiveStream``
+  (`#1081 <https://github.com/agronholm/anyio/issues/1081>`_; PR by @joaquinhuigomez)
 
 **4.13.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1041,6 +1041,9 @@ class StreamReaderWrapper(abc.ByteReceiveStream):
     _stream: asyncio.StreamReader
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         data = await self._stream.read(max_bytes)
         if data:
             return data
@@ -1274,6 +1277,9 @@ class SocketStream(abc.SocketStream):
         return self._transport.get_extra_info("socket")
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         with self._receive_guard:
             if (
                 not self._protocol.read_event.is_set()
@@ -1398,6 +1404,9 @@ class UNIXSocketStream(_RawSocketMixin, abc.UNIXSocketStream):
             self._raw_socket.shutdown(socket.SHUT_WR)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         loop = get_running_loop()
         await AsyncIOBackend.checkpoint()
         with self._receive_guard:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -228,6 +228,9 @@ class ReceiveStreamWrapper(abc.ByteReceiveStream):
     _stream: trio.abc.ReceiveStream
 
     async def receive(self, max_bytes: int | None = None) -> bytes:
+        if max_bytes is not None and max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         try:
             data = await self._stream.receive_some(max_bytes)
         except trio.ClosedResourceError as exc:
@@ -383,6 +386,9 @@ class SocketStream(_TrioSocketMixin, abc.SocketStream):
         self._send_guard = ResourceGuard("writing to")
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         with self._receive_guard:
             try:
                 data = await self._trio_socket.recv(max_bytes)

--- a/src/anyio/abc/_streams.py
+++ b/src/anyio/abc/_streams.py
@@ -140,9 +140,10 @@ class ByteReceiveStream(AsyncResource, TypedAttributeProvider):
         .. note:: Implementers of this interface should not return an empty
             :class:`bytes` object, and users should ignore them.
 
-        :param max_bytes: maximum number of bytes to receive
+        :param max_bytes: maximum number of bytes to receive (must be >= 1)
         :return: the received bytes
         :raises ~anyio.EndOfStream: if this stream has been closed from the other end
+        :raises ValueError: if ``max_bytes`` is less than 1
         """
 
 

--- a/src/anyio/streams/buffered.py
+++ b/src/anyio/streams/buffered.py
@@ -65,6 +65,9 @@ class BufferedByteReceiveStream(ByteReceiveStream):
         self._buffer.extend(data)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         if self._closed:
             raise ClosedResourceError
 
@@ -95,6 +98,9 @@ class BufferedByteReceiveStream(ByteReceiveStream):
             amount of bytes could be read from the stream
 
         """
+        if nbytes < 1:
+            raise ValueError("nbytes must be a positive integer")
+
         while True:
             remaining = nbytes - len(self._buffer)
             if remaining <= 0:
@@ -126,6 +132,9 @@ class BufferedByteReceiveStream(ByteReceiveStream):
             bytes read up to the maximum allowed
 
         """
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         delimiter_size = len(delimiter)
         offset = 0
         while True:

--- a/src/anyio/streams/file.py
+++ b/src/anyio/streams/file.py
@@ -79,6 +79,9 @@ class FileReadStream(_BaseFileStream, ByteReceiveStream):
         return cls(file)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         try:
             data = await to_thread.run_sync(self._file.read, max_bytes)
         except ValueError:

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -236,6 +236,9 @@ class TLSStream(ByteStream):
         await self.transport_stream.aclose()
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         data = await self._call_sslobject_method(self._ssl_object.read, max_bytes)
         if not data:
             raise EndOfStream

--- a/tests/streams/test_buffered.py
+++ b/tests/streams/test_buffered.py
@@ -148,9 +148,7 @@ class TestMaxBytesValidation:
             BufferedByteReceiveStream(receive_stream) as buffered_stream,
         ):
             await send_stream.send(b"blah")
-            with pytest.raises(
-                ValueError, match="nbytes must be a positive integer"
-            ):
+            with pytest.raises(ValueError, match="nbytes must be a positive integer"):
                 await buffered_stream.receive_exactly(nbytes)
 
     @pytest.mark.parametrize("max_bytes", [0, -1, -5])

--- a/tests/streams/test_buffered.py
+++ b/tests/streams/test_buffered.py
@@ -109,6 +109,64 @@ async def test_buffered_connectable() -> None:
         assert await stream.receive_exactly(2) == b"cd"
 
 
+class TestMaxBytesValidation:
+    @pytest.mark.parametrize("max_bytes", [0, -1, -5])
+    async def test_receive_max_bytes_validation(self, max_bytes: int) -> None:
+        send_stream, receive_stream = create_memory_object_stream[bytes](2)
+        async with (
+            send_stream,
+            BufferedByteReceiveStream(receive_stream) as buffered_stream,
+        ):
+            await send_stream.send(b"blah")
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
+                await buffered_stream.receive(max_bytes)
+
+    @pytest.mark.parametrize("max_bytes", [0, -1, -5])
+    async def test_receive_max_bytes_validation_with_buffer(
+        self, max_bytes: int
+    ) -> None:
+        send_stream, receive_stream = create_memory_object_stream[bytes](2)
+        async with (
+            send_stream,
+            BufferedByteReceiveStream(receive_stream) as buffered_stream,
+        ):
+            await send_stream.send(b"ablah")
+            await buffered_stream.receive_exactly(1)
+            assert buffered_stream._buffer
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
+                await buffered_stream.receive(max_bytes)
+
+    @pytest.mark.parametrize("nbytes", [0, -1, -5])
+    async def test_receive_exactly_nbytes_validation(self, nbytes: int) -> None:
+        send_stream, receive_stream = create_memory_object_stream[bytes](2)
+        async with (
+            send_stream,
+            BufferedByteReceiveStream(receive_stream) as buffered_stream,
+        ):
+            await send_stream.send(b"blah")
+            with pytest.raises(
+                ValueError, match="nbytes must be a positive integer"
+            ):
+                await buffered_stream.receive_exactly(nbytes)
+
+    @pytest.mark.parametrize("max_bytes", [0, -1, -5])
+    async def test_receive_until_max_bytes_validation(self, max_bytes: int) -> None:
+        send_stream, receive_stream = create_memory_object_stream[bytes](2)
+        async with (
+            send_stream,
+            BufferedByteReceiveStream(receive_stream) as buffered_stream,
+        ):
+            await send_stream.send(b"blah\n")
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
+                await buffered_stream.receive_until(b"\n", max_bytes)
+
+
 async def test_feed_data() -> None:
     send_stream, receive_stream = create_memory_object_stream[bytes](1)
     buffered_stream = BufferedByteStream(

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -64,6 +64,14 @@ class TestFileReadStream:
             file = stream.extra(FileStreamAttribute.file)
             assert file.fileno() == fileno
 
+    @pytest.mark.parametrize("max_bytes", [0, -1, -5])
+    async def test_receive_max_bytes_validation(
+        self, max_bytes: int, file_path: Path
+    ) -> None:
+        async with await FileReadStream.from_path(file_path) as stream:
+            with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+                await stream.receive(max_bytes)
+
 
 class TestFileWriteStream:
     @pytest.fixture

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -69,7 +69,9 @@ class TestFileReadStream:
         self, max_bytes: int, file_path: Path
     ) -> None:
         async with await FileReadStream.from_path(file_path) as stream:
-            with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
                 await stream.receive(max_bytes)
 
 

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -32,6 +32,38 @@ from anyio.streams.tls import TLSAttribute, TLSConnectable, TLSListener, TLSStre
 
 
 class TestTLSStream:
+    @pytest.mark.parametrize("max_bytes", [0, -1, -5])
+    async def test_receive_max_bytes_validation(
+        self,
+        max_bytes: int,
+        server_context: ssl.SSLContext,
+        client_context: ssl.SSLContext,
+    ) -> None:
+        def serve_sync() -> None:
+            conn, addr = server_sock.accept()
+            conn.settimeout(1)
+            conn.send(b"blah")
+            conn.close()
+
+        server_sock = server_context.wrap_socket(
+            socket.socket(), server_side=True, suppress_ragged_eofs=False
+        )
+        server_sock.settimeout(1)
+        server_sock.bind(("127.0.0.1", 0))
+        server_sock.listen()
+        server_thread = Thread(target=serve_sync)
+        server_thread.start()
+
+        async with await connect_tcp(*server_sock.getsockname()) as stream:
+            wrapper = await TLSStream.wrap(
+                stream, hostname="localhost", ssl_context=client_context
+            )
+            with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+                await wrapper.receive(max_bytes)
+
+        server_thread.join()
+        server_sock.close()
+
     async def test_send_receive(
         self, server_context: ssl.SSLContext, client_context: ssl.SSLContext
     ) -> None:

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -58,7 +58,9 @@ class TestTLSStream:
             wrapper = await TLSStream.wrap(
                 stream, hostname="localhost", ssl_context=client_context
             )
-            with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
                 await wrapper.receive(max_bytes)
 
         server_thread.join()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -703,6 +703,17 @@ class TestTCPStream:
             )
             assert not caplog_text
 
+    @pytest.mark.parametrize("max_bytes", [0, -1, -5])
+    async def test_receive_max_bytes_validation(
+        self,
+        max_bytes: int,
+        server_sock: socket.socket,
+        server_addr: tuple[str, int],
+    ) -> None:
+        async with await connect_tcp(*server_addr) as stream:
+            with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+                await stream.receive(max_bytes)
+
     async def test_from_socket(
         self, family: AnyIPAddressFamily, sock_or_fd_factory: SockFdFactoryProtocol
     ) -> None:
@@ -1455,6 +1466,17 @@ class TestUNIXStream:
 
             async with await connect_unix(actual_path):
                 pass
+
+    @pytest.mark.parametrize("max_bytes", [0, -1, -5])
+    async def test_receive_max_bytes_validation(
+        self,
+        max_bytes: int,
+        server_sock: socket.socket,
+        socket_path_or_str: Path | str,
+    ) -> None:
+        async with await connect_unix(socket_path_or_str) as stream:
+            with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+                await stream.receive(max_bytes)
 
     async def test_from_socket(
         self, socket_path: Path, sock_or_fd_factory: SockFdFactoryProtocol

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -711,7 +711,9 @@ class TestTCPStream:
         server_addr: tuple[str, int],
     ) -> None:
         async with await connect_tcp(*server_addr) as stream:
-            with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
                 await stream.receive(max_bytes)
 
     async def test_from_socket(
@@ -1475,7 +1477,9 @@ class TestUNIXStream:
         socket_path_or_str: Path | str,
     ) -> None:
         async with await connect_unix(socket_path_or_str) as stream:
-            with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
                 await stream.receive(max_bytes)
 
     async def test_from_socket(

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -374,6 +374,16 @@ async def test_close_early() -> None:
         pass
 
 
+@pytest.mark.parametrize("max_bytes", [0, -1, -5])
+async def test_receive_max_bytes_validation(max_bytes: int) -> None:
+    async with await open_process(
+        [sys.executable, "-c", "import sys; print('blah', end='')"]
+    ) as process:
+        assert process.stdout is not None
+        with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+            await process.stdout.receive(max_bytes)
+
+
 async def test_close_while_reading() -> None:
     code = dedent("""\
     import time


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1081.

Add `if max_bytes < 1: raise ValueError` guards across all `ByteReceiveStream.receive()` implementations and `BufferedByteReceiveStream` helper methods (`receive_exactly`, `receive_until`). This makes behavior consistent between asyncio and trio backends, and across all stream types.

Affected implementations:
- **asyncio backend**: `SocketStream.receive`, `StreamReaderWrapper.receive` (subprocess), `UNIXSocketStream.receive`
- **trio backend**: `ReceiveStreamWrapper.receive` (subprocess), `SocketStream.receive`
- **Streams**: `TLSStream.receive`, `FileReadStream.receive`, `BufferedByteReceiveStream.receive` / `receive_exactly` / `receive_until`
- **ABC**: Updated `ByteReceiveStream.receive` docstring to document the `ValueError` contract

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.