### PR TITLE
fix: asyncio TestRunner resuming test after KeyboardInterrupt with async fixture

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added support for custom capacity limiters in async path and file I/O
   functions and classes
+- Fixed asyncio ``TestRunner.run_test()`` leaving the runner task alive when a
+  ``KeyboardInterrupt`` interrupts the event loop, which caused the test to
+  incorrectly resume during async fixture teardown
+  (`#1060 <https://github.com/agronholm/anyio/issues/1060>`_)
 
 **4.13.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2318,6 +2318,21 @@ class TestRunner(abc.TestRunner):
             )
         except Exception as exc:
             self._exceptions.append(exc)
+        except BaseException:
+            # A BaseException (e.g. KeyboardInterrupt) interrupted the event loop
+            # before the test completed. The runner task is still alive and mid-test;
+            # cancel it so it does not resume when the event loop is re-entered for
+            # async fixture teardown.
+            if self._runner_task is not None and not self._runner_task.done():
+                self._runner_task.cancel()
+                try:
+                    self.get_loop().run_until_complete(self._runner_task)
+                except BaseException:
+                    pass
+                finally:
+                    self._runner_task = None
+                    self._send_stream.close()
+            raise
 
         self._raise_async_exceptions()
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -476,6 +476,43 @@ def test_keyboardinterrupt_during_test(
     testdir.runpytest_subprocess(*pytest_args, timeout=3)
 
 
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+def test_asyncio_no_test_resumption_after_keyboard_interrupt(
+    testdir: Pytester, anyio_backend_name: str
+) -> None:
+    """Regression test for #1060: a KeyboardInterrupt (e.g. Ctrl-C) that interrupts
+    the asyncio event loop mid-test must not allow the test to resume when the loop is
+    re-entered for async fixture teardown."""
+    testdir.makepyfile(
+        """
+        import os
+        import signal
+        import anyio
+        import pytest
+
+        @pytest.fixture
+        def anyio_backend():
+            return "asyncio"
+
+        @pytest.fixture
+        async def myfixture():
+            yield
+
+        @pytest.mark.anyio
+        async def test_keyboard_interrupt(myfixture):
+            # Schedule a real SIGINT so that the signal fires when control returns to
+            # the event loop, interrupting run_until_complete externally (same as Ctrl-C).
+            os.kill(os.getpid(), signal.SIGINT)
+            await anyio.sleep(3600)
+            # If the test is wrongly resumed after the interrupt, this line would run.
+            print("RESUMED_AFTER_INTERRUPT")
+        """
+    )
+
+    result = testdir.runpytest_subprocess(*pytest_args, timeout=5)
+    assert "RESUMED_AFTER_INTERRUPT" not in result.stdout.str()
+
+
 def test_async_fixture_in_test_class(testdir: Pytester) -> None:
     # Regression test for #633
     testdir.makepyfile(


### PR DESCRIPTION
Fixes #1060.

## Root cause

When Ctrl-C fires, Python raises `KeyboardInterrupt` in the main thread during `loop._run_once()`, which causes `run_until_complete()` to exit **without completing the asyncio task**. The runner task (`_runner_task`) is left alive, still mid-test.

When pytest then tears down async fixtures, `run_asyncgen_fixture()` calls `run_until_complete()` again. The event loop resumes, the runner task continues from where it left off in the test (e.g. after `await anyio.sleep()`), runs the rest of the test body, and only then executes the fixture teardown.

The existing `run_test()` only caught `Exception`, not `BaseException`, so `KeyboardInterrupt` was never handled.

## Fix

Added an `except BaseException` handler in `run_test()` that:
1. Cancels `_runner_task` if it is still alive
2. Runs the loop until the task is done (so the cancellation is processed)
3. Resets `_runner_task = None` and closes the send stream
4. Re-raises the original exception

This ensures the next call to `_call_in_runner_task()` (from fixture teardown) creates a fresh runner task instead of reusing the interrupted one.

## Test

Added `test_asyncio_no_test_resumption_after_keyboard_interrupt` which uses `os.kill(os.getpid(), signal.SIGINT)` followed by `await anyio.sleep(3600)` to simulate a real external SIGINT. The test asserts that code after the sleep (which would indicate the test was resumed) is never reached.