### PR TITLE
fix: prevent TaskGroup re-entry with clear RuntimeError

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,7 +10,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Fixed ``TaskGroup`` raising ``AttributeError`` instead of a clear error when entered
   more than once
-  (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @bahtya)
+  (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @Bahtya)
 
 **4.13.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added support for custom capacity limiters in async path and file I/O
   functions and classes
+- Fixed ``TaskGroup`` raising ``AttributeError`` instead of a clear error
+  when entered more than once
+  (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_;
+  PR by @bahtya)
 
 **4.13.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added support for custom capacity limiters in async path and file I/O
   functions and classes
+
 - Fixed ``TaskGroup`` raising ``AttributeError`` instead of a clear error when entered
   more than once
   (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @bahtya)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,10 +7,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added support for custom capacity limiters in async path and file I/O
   functions and classes
-- Fixed ``TaskGroup`` raising ``AttributeError`` instead of a clear error
-  when entered more than once
-  (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_;
-  PR by @bahtya)
+- Fixed ``TaskGroup`` raising ``AttributeError`` instead of a clear error when entered
+  more than once
+  (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @bahtya)
 
 **4.13.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,7 +10,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Fixed ``TaskGroup`` raising ``AttributeError`` instead of a clear error when entered
   more than once
-  (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @Bahtya)
+  (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @bahtya)
 
 **4.13.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -12,7 +12,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed cancellation exception escaping a cancel scope when triggered via
   ``check_cancelled()`` in a worker thread
   (`#1113 <https://github.com/agronholm/anyio/issues/1113>`_)
-
 - Fixed ``TaskGroup`` raising ``AttributeError`` instead of a clear error when entered
   more than once
   (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @bahtya)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -747,6 +747,7 @@ class TaskGroup(abc.TaskGroup):
     async def __aenter__(self) -> TaskGroup:
         if self._entered:
             raise RuntimeError("TaskGroup cannot be entered more than once")
+            raise RuntimeError("TaskGroup cannot be entered more than once")
 
         self._entered = True
         self.cancel_scope.__enter__()

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -747,6 +747,7 @@ class TaskGroup(abc.TaskGroup):
     async def __aenter__(self) -> TaskGroup:
         if self._entered:
             raise RuntimeError("TaskGroup cannot be entered more than once")
+
         self._entered = True
         self.cancel_scope.__enter__()
         self._active = True

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -738,7 +738,6 @@ else:
 class TaskGroup(abc.TaskGroup):
     def __init__(self) -> None:
         self.cancel_scope: CancelScope = CancelScope()
-        self._active = False
         self._entered = False
         self._exceptions: list[BaseException] = []
         self._tasks: set[asyncio.Task] = set()
@@ -751,7 +750,6 @@ class TaskGroup(abc.TaskGroup):
         self._entered = True
 
         self.cancel_scope.__enter__()
-        self._active = True
         return self
 
     async def __aexit__(
@@ -796,7 +794,6 @@ class TaskGroup(abc.TaskGroup):
                     # anyway
                     await AsyncIOBackend.cancel_shielded_checkpoint()
 
-                self._active = False
                 if self._exceptions:
                     # The exception that got us here should already have been
                     # added to self._exceptions so it's ok to break exception
@@ -871,7 +868,7 @@ class TaskGroup(abc.TaskGroup):
                     RuntimeError("Child exited without calling task_status.started()")
                 )
 
-        if not self._active:
+        if not self._entered or not self.cancel_scope._active:
             raise RuntimeError(
                 "This task group is not active; no new tasks can be started."
             )

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -749,9 +749,9 @@ class TaskGroup(abc.TaskGroup):
             raise RuntimeError("TaskGroup cannot be entered more than once")
 
         self._entered = True
+
         self.cancel_scope.__enter__()
         self._active = True
-        self._exceptions = []
         return self
 
     async def __aexit__(

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -744,8 +744,11 @@ class TaskGroup(abc.TaskGroup):
         self._on_completed_fut: asyncio.Future[None] | None = None
 
     async def __aenter__(self) -> TaskGroup:
+        if self._active:
+            raise RuntimeError("TaskGroup cannot be entered more than once")
         self.cancel_scope.__enter__()
         self._active = True
+        self._exceptions = []
         return self
 
     async def __aexit__(

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -739,13 +739,15 @@ class TaskGroup(abc.TaskGroup):
     def __init__(self) -> None:
         self.cancel_scope: CancelScope = CancelScope()
         self._active = False
+        self._entered = False
         self._exceptions: list[BaseException] = []
         self._tasks: set[asyncio.Task] = set()
         self._on_completed_fut: asyncio.Future[None] | None = None
 
     async def __aenter__(self) -> TaskGroup:
-        if self._active:
+        if self._entered:
             raise RuntimeError("TaskGroup cannot be entered more than once")
+        self._entered = True
         self.cancel_scope.__enter__()
         self._active = True
         self._exceptions = []

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -747,7 +747,6 @@ class TaskGroup(abc.TaskGroup):
     async def __aenter__(self) -> TaskGroup:
         if self._entered:
             raise RuntimeError("TaskGroup cannot be entered more than once")
-            raise RuntimeError("TaskGroup cannot be entered more than once")
 
         self._entered = True
         self.cancel_scope.__enter__()

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -165,6 +165,8 @@ class CancelScope(BaseCancelScope):
 
 
 class TaskGroup(abc.TaskGroup):
+    _active = False
+
     def __init__(self) -> None:
         self._entered = False
         self._nursery_manager = trio.open_nursery(strict_exception_groups=True)
@@ -175,6 +177,7 @@ class TaskGroup(abc.TaskGroup):
             raise RuntimeError("TaskGroup cannot be entered more than once")
 
         self._entered = True
+        self._active = True
         self._nursery = await self._nursery_manager.__aenter__()
         self.cancel_scope = CancelScope(self._nursery.cancel_scope)
         return self
@@ -194,6 +197,7 @@ class TaskGroup(abc.TaskGroup):
 
             raise
         finally:
+            self._active = False
             del exc_val, exc_tb
 
     def start_soon(
@@ -202,16 +206,20 @@ class TaskGroup(abc.TaskGroup):
         *args: Unpack[PosArgsT],
         name: object = None,
     ) -> None:
-        if not self._entered:
-            raise RuntimeError("This task group has not been entered yet.")
+        if not self._active:
+            raise RuntimeError(
+                "This task group is not active; no new tasks can be started."
+            )
 
         self._nursery.start_soon(func, *args, name=name)
 
     async def start(
         self, func: Callable[..., Awaitable[Any]], *args: object, name: object = None
     ) -> Any:
-        if not self._entered:
-            raise RuntimeError("This task group has not been entered yet.")
+        if not self._active:
+            raise RuntimeError(
+                "This task group is not active; no new tasks can be started."
+            )
 
         return await self._nursery.start(func, *args, name=name)
 

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -167,10 +167,14 @@ class CancelScope(BaseCancelScope):
 class TaskGroup(abc.TaskGroup):
     def __init__(self) -> None:
         self._active = False
+        self._entered = False
         self._nursery_manager = trio.open_nursery(strict_exception_groups=True)
         self.cancel_scope = None  # type: ignore[assignment]
 
     async def __aenter__(self) -> TaskGroup:
+        if self._entered:
+            raise RuntimeError("TaskGroup cannot be entered more than once")
+        self._entered = True
         self._active = True
         self._nursery = await self._nursery_manager.__aenter__()
         self.cancel_scope = CancelScope(self._nursery.cancel_scope)

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -197,8 +197,8 @@ class TaskGroup(abc.TaskGroup):
 
             raise
         finally:
-            self._active = False
             del exc_val, exc_tb
+            self._active = False
 
     def start_soon(
         self,

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -166,7 +166,6 @@ class CancelScope(BaseCancelScope):
 
 class TaskGroup(abc.TaskGroup):
     def __init__(self) -> None:
-        self._active = False
         self._entered = False
         self._nursery_manager = trio.open_nursery(strict_exception_groups=True)
         self.cancel_scope = None  # type: ignore[assignment]
@@ -176,7 +175,6 @@ class TaskGroup(abc.TaskGroup):
             raise RuntimeError("TaskGroup cannot be entered more than once")
 
         self._entered = True
-        self._active = True
         self._nursery = await self._nursery_manager.__aenter__()
         self.cancel_scope = CancelScope(self._nursery.cancel_scope)
         return self
@@ -197,7 +195,6 @@ class TaskGroup(abc.TaskGroup):
             raise
         finally:
             del exc_val, exc_tb
-            self._active = False
 
     def start_soon(
         self,
@@ -205,9 +202,9 @@ class TaskGroup(abc.TaskGroup):
         *args: Unpack[PosArgsT],
         name: object = None,
     ) -> None:
-        if not self._active:
+        if not self._entered:
             raise RuntimeError(
-                "This task group is not active; no new tasks can be started."
+                "This task group has not been entered yet."
             )
 
         self._nursery.start_soon(func, *args, name=name)
@@ -215,9 +212,9 @@ class TaskGroup(abc.TaskGroup):
     async def start(
         self, func: Callable[..., Awaitable[Any]], *args: object, name: object = None
     ) -> Any:
-        if not self._active:
+        if not self._entered:
             raise RuntimeError(
-                "This task group is not active; no new tasks can be started."
+                "This task group has not been entered yet."
             )
 
         return await self._nursery.start(func, *args, name=name)

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -174,6 +174,7 @@ class TaskGroup(abc.TaskGroup):
     async def __aenter__(self) -> TaskGroup:
         if self._entered:
             raise RuntimeError("TaskGroup cannot be entered more than once")
+
         self._entered = True
         self._active = True
         self._nursery = await self._nursery_manager.__aenter__()

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -203,9 +203,7 @@ class TaskGroup(abc.TaskGroup):
         name: object = None,
     ) -> None:
         if not self._entered:
-            raise RuntimeError(
-                "This task group has not been entered yet."
-            )
+            raise RuntimeError("This task group has not been entered yet.")
 
         self._nursery.start_soon(func, *args, name=name)
 
@@ -213,9 +211,7 @@ class TaskGroup(abc.TaskGroup):
         self, func: Callable[..., Awaitable[Any]], *args: object, name: object = None
     ) -> Any:
         if not self._entered:
-            raise RuntimeError(
-                "This task group has not been entered yet."
-            )
+            raise RuntimeError("This task group has not been entered yet.")
 
         return await self._nursery.start(func, *args, name=name)
 

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -165,10 +165,9 @@ class CancelScope(BaseCancelScope):
 
 
 class TaskGroup(abc.TaskGroup):
-    _active = False
-
     def __init__(self) -> None:
         self._entered = False
+        self._active = False
         self._nursery_manager = trio.open_nursery(strict_exception_groups=True)
         self.cancel_scope = None  # type: ignore[assignment]
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1627,7 +1627,9 @@ async def test_taskgroup_reentry() -> None:
     async with tg:
         pass
 
-    with pytest.raises(RuntimeError, match="TaskGroup cannot be entered more than once"):
+    with pytest.raises(
+        RuntimeError, match="TaskGroup cannot be entered more than once"
+    ):
         async with tg:
             pass
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1620,9 +1620,6 @@ class TestUncancel:
 
 async def test_taskgroup_reentry() -> None:
     """Test that entering a TaskGroup more than once raises RuntimeError."""
-    async with create_task_group():
-        pass
-
     tg = create_task_group()
     async with tg:
         pass

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1618,6 +1618,20 @@ class TestUncancel:
         assert not task.cancelling()
 
 
+async def test_taskgroup_reentry() -> None:
+    """Test that entering a TaskGroup more than once raises RuntimeError."""
+    async with create_task_group():
+        pass
+
+    tg = create_task_group()
+    async with tg:
+        pass
+
+    with pytest.raises(RuntimeError, match="TaskGroup cannot be entered more than once"):
+        async with tg:
+            pass
+
+
 async def test_cancel_before_entering_task_group() -> None:
     with CancelScope() as scope:
         scope.cancel()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Changes

Fixes #1109

TaskGroup re-entry raises confusing `AttributeError` instead of a clear error. Added a guard in `__aenter__` that raises `RuntimeError("TaskGroup cannot be entered more than once")` if the group is already active. Also reinitializes `_exceptions` for safety.

## Checklist

- [x] Added tests (in `tests/`) which would fail without your patch
- [ ] Updated the documentation (in `docs/`) — no behavior change for users, just better error message
- [x] Added a new changelog entry (in `docs/versionhistory.rst`)