### PR TITLE
asyncio: skip done tasks in _deliver_cancellation to prevent CPU spin

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -583,6 +583,9 @@ class CancelScope(BaseCancelScope):
         should_retry = False
         current = current_task()
         for task in self._tasks:
+            if task.done():
+                continue
+
             should_retry = True
             if task._must_cancel:  # type: ignore[attr-defined]
                 continue


### PR DESCRIPTION
`_deliver_cancellation` sets `should_retry=True` for every task in `self._tasks`, including completed tasks. A done task cannot be cancelled, but the retry flag still triggers a `call_soon` callback, which re-iterates, finds the same done task, and schedules again — infinite loop at 100% CPU.

Add a `task.done()` guard at the top of the loop to skip completed tasks entirely.

Fixes #1111