### PR TITLE
Improve missing backend error

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -9,7 +9,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   functions and classes
 
 **4.13.0**
-
+- Improved the error message when a known backend is not installed to suggest the install command
+  (`<https://github.com/agronholm/anyio/pull/1115>`_; PR by @EmmanuelNiyonshuti)
 - Dropped support for Python 3.9
 - Added a ``ttl`` parameter to the ``anyio.functools.lru_cache`` wrapper
   (`#1073 <https://github.com/agronholm/anyio/pull/1073>`_; PR by @Graeme22)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,11 +7,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added support for custom capacity limiters in async path and file I/O
   functions and classes
+- Improved the error message when a known backend is not installed to suggest the install command
+  (`#1115 <https://github.com/agronholm/anyio/pull/1115>`_; PR by @EmmanuelNiyonshuti)
 
 **4.13.0**
 
-- Improved the error message when a known backend is not installed to suggest the install command
-  (`#1115 <https://github.com/agronholm/anyio/pull/1115>`_; PR by @EmmanuelNiyonshuti)
 - Dropped support for Python 3.9
 - Added a ``ttl`` parameter to the ``anyio.functools.lru_cache`` wrapper
   (`#1073 <https://github.com/agronholm/anyio/pull/1073>`_; PR by @Graeme22)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -9,8 +9,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   functions and classes
 
 **4.13.0**
+
 - Improved the error message when a known backend is not installed to suggest the install command
-  (`<https://github.com/agronholm/anyio/pull/1115>`_; PR by @EmmanuelNiyonshuti)
+  (`#1115 <https://github.com/agronholm/anyio/pull/1115>`_; PR by @EmmanuelNiyonshuti)
 - Dropped support for Python 3.9
 - Added a ``ttl`` parameter to the ``anyio.functools.lru_cache`` wrapper
   (`#1073 <https://github.com/agronholm/anyio/pull/1073>`_; PR by @Graeme22)

--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -66,7 +66,7 @@ def run(
     except ImportError as exc:
         if backend in BACKENDS:
             raise LookupError(
-                f"backend '{backend}' is not available. "
+                f"Backend {backend!r} is not available. "
                 f"Install it with: pip install anyio[{backend}]"
             ) from exc
 

--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -69,6 +69,7 @@ def run(
                 f"backend '{backend}' is not available. "
                 f"Install it with: pip install anyio[{backend}]"
             ) from exc
+
         raise LookupError(f"No such backend: {backend}") from exc
 
     token = None

--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -64,6 +64,11 @@ def run(
     try:
         async_backend = get_async_backend(backend)
     except ImportError as exc:
+        if backend in BACKENDS:
+            raise LookupError(
+                f"backend '{backend}' is not available. "
+                f"Install it with: pip install anyio[{backend}]"
+            ) from exc
         raise LookupError(f"No such backend: {backend}") from exc
 
     token = None

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -51,6 +51,21 @@ def test_run_task() -> None:
     assert result == 3
 
 
+async def main() -> None:
+    pass
+
+
+def test_run_unknown_backend() -> None:
+    with pytest.raises(LookupError, match="No such backend: asncio"):
+        run(main, backend="asncio")
+
+
+def test_run_known_but_uninstalled_backend(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr("anyio._core._eventloop.BACKENDS", ("asyncio", "somebackend"))
+    with pytest.raises(LookupError, match="pip install anyio\\[somebackend\\]"):
+        run(main, backend="somebackend")
+
+
 class TestAsyncioOptions:
     def test_debug(self) -> None:
         async def main() -> bool:

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -55,8 +55,8 @@ def test_run_unknown_backend() -> None:
     async def main() -> None:
         pass
 
-    with pytest.raises(LookupError, match="No such backend: asncio"):
-        run(main, backend="asncio")
+    with pytest.raises(LookupError, match="No such backend: somebackend"):
+        run(main, backend="somebackend")
 
 
 def test_run_known_but_uninstalled_backend(monkeypatch: MonkeyPatch) -> None:

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -51,16 +51,18 @@ def test_run_task() -> None:
     assert result == 3
 
 
-async def main() -> None:
-    pass
-
-
 def test_run_unknown_backend() -> None:
+    async def main() -> None:
+        pass
+
     with pytest.raises(LookupError, match="No such backend: asncio"):
         run(main, backend="asncio")
 
 
 def test_run_known_but_uninstalled_backend(monkeypatch: MonkeyPatch) -> None:
+    async def main() -> None:
+        pass
+
     monkeypatch.setattr("anyio._core._eventloop.BACKENDS", ("asyncio", "somebackend"))
     with pytest.raises(LookupError, match="pip install anyio\\[somebackend\\]"):
         run(main, backend="somebackend")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

Right now when you have a backend like `trio` in `BACKENDS` but it is not installed, the error says:
```
LookupError: No such backend: trio
```

This is a bit confusing because `trio` is a valid backend, it is just not installed.  I changed it to tell the user what to do instead:

```
LookupError: Backend 'trio' is not available. Install it with: pip install anyio[trio]
```

The fix uses the already existing `BACKENDS` constant to check if the backend is known but just not installed, and gives a different message for that case.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
