### PR TITLE
fix TaskError typo in TaskHandle.return_value docstring

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -4,6 +4,7 @@ Version history
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
+
 - Fixed incorrect exception name in ``TaskHandle.return_value`` docstring
   (``TaskError`` to ``TaskFailed``)
   (`#1117 <https://github.com/agronholm/anyio/pull/1117>`_; PR by @EmmanuelNiyonshuti)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -4,7 +4,9 @@ Version history
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
-
+- Fixed incorrect exception name in ``TaskHandle.return_value`` docstring
+  (``TaskError`` to ``TaskFailed``)
+  (`#1117 <https://github.com/agronholm/anyio/pull/1117>`_; PR by @EmmanuelNiyonshuti)
 - Added support for custom capacity limiters in async path and file I/O
   functions and classes
 - Added the ``create_task()`` task group method for easier asyncio migration

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,9 +5,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Fixed incorrect exception name in ``TaskHandle.return_value`` docstring
-  (``TaskError`` to ``TaskFailed``)
-  (`#1117 <https://github.com/agronholm/anyio/pull/1117>`_; PR by @EmmanuelNiyonshuti)
 - Added support for custom capacity limiters in async path and file I/O
   functions and classes
 - Added the ``create_task()`` task group method for easier asyncio migration

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -344,7 +344,7 @@ class TaskHandle(Generic[T_co]):
 
         :raises TaskNotFinished: if the task has not finished yet
         :raises TaskCancelled: if the task was cancelled
-        :raises TaskError: if the task raised an exception
+        :raises TaskFailed: if the task raised an exception
 
         """
         match self.status:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

`TaskHandle.return_value` raises three exceptions `TaskNotFinished`, `TaskCancelled` and `TaskFailed` but the docstrings names `TaskFailed` as `TaskError`.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
