### PR TITLE
Add local_port parameter to connect_tcp

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added the ``local_port`` parameter to :func:`connect_tcp` to allow binding to a
+  specific local port before connecting
+  (`#1067 <https://github.com/agronholm/anyio/issues/1067>`_; PR by @nullwiz)
 - Added support for custom capacity limiters in async path and file I/O
   functions and classes
 - Added the ``create_task()`` task group method for easier asyncio migration

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -66,6 +66,7 @@ async def connect_tcp(
     remote_port: int,
     *,
     local_host: IPAddressType | None = ...,
+    local_port: int = ...,
     ssl_context: ssl.SSLContext | None = ...,
     tls_standard_compatible: bool = ...,
     tls_hostname: str,
@@ -80,6 +81,7 @@ async def connect_tcp(
     remote_port: int,
     *,
     local_host: IPAddressType | None = ...,
+    local_port: int = ...,
     ssl_context: ssl.SSLContext,
     tls_standard_compatible: bool = ...,
     tls_hostname: str | None = ...,
@@ -94,6 +96,7 @@ async def connect_tcp(
     remote_port: int,
     *,
     local_host: IPAddressType | None = ...,
+    local_port: int = ...,
     tls: Literal[True],
     ssl_context: ssl.SSLContext | None = ...,
     tls_standard_compatible: bool = ...,
@@ -109,6 +112,7 @@ async def connect_tcp(
     remote_port: int,
     *,
     local_host: IPAddressType | None = ...,
+    local_port: int = ...,
     tls: Literal[False],
     ssl_context: ssl.SSLContext | None = ...,
     tls_standard_compatible: bool = ...,
@@ -124,6 +128,7 @@ async def connect_tcp(
     remote_port: int,
     *,
     local_host: IPAddressType | None = ...,
+    local_port: int = ...,
     happy_eyeballs_delay: float = ...,
 ) -> SocketStream: ...
 
@@ -133,6 +138,7 @@ async def connect_tcp(
     remote_port: int,
     *,
     local_host: IPAddressType | None = None,
+    local_port: int = 0,
     tls: bool = False,
     ssl_context: ssl.SSLContext | None = None,
     tls_standard_compatible: bool = True,
@@ -156,6 +162,8 @@ async def connect_tcp(
     :param remote_port: port on the target host to connect to
     :param local_host: the interface address or name to bind the socket to before
         connecting
+    :param local_port: the local port to bind to (requires ``local_host`` to also be
+        set)
     :param tls: ``True`` to do a TLS handshake with the connected stream and return a
         :class:`~anyio.streams.tls.TLSStream` instead
     :param ssl_context: the SSL context object to use (if omitted, a default context is
@@ -196,7 +204,7 @@ async def connect_tcp(
     local_address: IPSockAddrType | None = None
     family = socket.AF_UNSPEC
     if local_host:
-        gai_res = await getaddrinfo(str(local_host), None)
+        gai_res = await getaddrinfo(str(local_host), local_port or None)
         family, *_, local_address = gai_res[0]
 
     target_host = str(remote_host)

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -66,7 +66,7 @@ async def connect_tcp(
     remote_port: int,
     *,
     local_host: IPAddressType | None = ...,
-    local_port: int = ...,
+    local_port: int | None = ...,
     ssl_context: ssl.SSLContext | None = ...,
     tls_standard_compatible: bool = ...,
     tls_hostname: str,
@@ -81,7 +81,7 @@ async def connect_tcp(
     remote_port: int,
     *,
     local_host: IPAddressType | None = ...,
-    local_port: int = ...,
+    local_port: int | None = ...,
     ssl_context: ssl.SSLContext,
     tls_standard_compatible: bool = ...,
     tls_hostname: str | None = ...,
@@ -96,7 +96,7 @@ async def connect_tcp(
     remote_port: int,
     *,
     local_host: IPAddressType | None = ...,
-    local_port: int = ...,
+    local_port: int | None = ...,
     tls: Literal[True],
     ssl_context: ssl.SSLContext | None = ...,
     tls_standard_compatible: bool = ...,
@@ -112,7 +112,7 @@ async def connect_tcp(
     remote_port: int,
     *,
     local_host: IPAddressType | None = ...,
-    local_port: int = ...,
+    local_port: int | None = ...,
     tls: Literal[False],
     ssl_context: ssl.SSLContext | None = ...,
     tls_standard_compatible: bool = ...,
@@ -128,7 +128,7 @@ async def connect_tcp(
     remote_port: int,
     *,
     local_host: IPAddressType | None = ...,
-    local_port: int = ...,
+    local_port: int | None = ...,
     happy_eyeballs_delay: float = ...,
 ) -> SocketStream: ...
 
@@ -138,7 +138,7 @@ async def connect_tcp(
     remote_port: int,
     *,
     local_host: IPAddressType | None = None,
-    local_port: int = 0,
+    local_port: int | None = None,
     tls: bool = False,
     ssl_context: ssl.SSLContext | None = None,
     tls_standard_compatible: bool = True,
@@ -204,7 +204,7 @@ async def connect_tcp(
     local_address: IPSockAddrType | None = None
     family = socket.AF_UNSPEC
     if local_host:
-        gai_res = await getaddrinfo(str(local_host), local_port or None)
+        gai_res = await getaddrinfo(str(local_host), local_port)
         family, *_, local_address = gai_res[0]
 
     target_host = str(remote_host)

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -397,6 +397,18 @@ class TestTCPStream:
         server_sock.close()
         assert client_addr[0] == expected_client_addr
 
+    async def test_connect_tcp_with_local_port(
+        self,
+        server_sock: socket.socket,
+        server_addr: tuple[str, int],
+        family: AnyIPAddressFamily,
+    ) -> None:
+        local_addr = "127.0.0.1" if family == AddressFamily.AF_INET else "::1"
+        async with await connect_tcp(
+            *server_addr, local_host=local_addr, local_port=1234
+        ) as stream:
+            assert stream.extra(SocketAttribute.local_port) == 1234
+
     @pytest.mark.skipif(
         sys.implementation.name == "pypy",
         reason=(

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -402,12 +402,13 @@ class TestTCPStream:
         server_sock: socket.socket,
         server_addr: tuple[str, int],
         family: AnyIPAddressFamily,
+        free_tcp_port: int,
     ) -> None:
         local_addr = "127.0.0.1" if family == AddressFamily.AF_INET else "::1"
         async with await connect_tcp(
-            *server_addr, local_host=local_addr, local_port=1234
+            *server_addr, local_host=local_addr, local_port=free_tcp_port
         ) as stream:
-            assert stream.extra(SocketAttribute.local_port) == 1234
+            assert stream.extra(SocketAttribute.local_port) == free_tcp_port
 
     @pytest.mark.skipif(
         sys.implementation.name == "pypy",


### PR DESCRIPTION
## Changes

Fixes #1067
Adds a `local_port` parameter to the high-level `connect_tcp()` function. 

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).


I feel the change is trivial! Ill see if I can contribute to other issues. 

