### PR TITLE
Fix test resumption after KeyboardInterrupt in asyncio backend

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,9 +5,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Fixed test resumption after ``KeyboardInterrupt`` in async generator fixtures on the
-  asyncio backend
-  (`#1060 <https://github.com/agronholm/anyio/issues/1060>`_; PR by @EmmanuelNiyonshuti)
 - Added the ``local_port`` parameter to :func:`connect_tcp` to allow binding to a
   specific local port before connecting
   (`#1067 <https://github.com/agronholm/anyio/issues/1067>`_; PR by @nullwiz)
@@ -29,6 +26,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @bahtya)
 - Fixed lost type information when passing arguments to ``lru_cache``
   (`#1104 <https://github.com/agronholm/anyio/pull/1104>`_; PR by @Graeme22)
+- Fixed test resumption after ``KeyboardInterrupt`` in async generator fixtures on the
+  asyncio backend
+  (`#1060 <https://github.com/agronholm/anyio/issues/1060>`_; PR by @EmmanuelNiyonshuti)
 
 **4.13.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed test resumption after ``KeyboardInterrupt`` in async generator fixtures on the
+  asyncio backend
+  (`#1060 <https://github.com/agronholm/anyio/issues/1060>`_; PR by @EmmanuelNiyonshuti)
 - Added the ``local_port`` parameter to :func:`connect_tcp` to allow binding to a
   specific local port before connecting
   (`#1067 <https://github.com/agronholm/anyio/issues/1067>`_; PR by @nullwiz)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2321,7 +2321,6 @@ class TestRunner(abc.TestRunner):
             )
         except Exception as exc:
             self._exceptions.append(exc)
-
         except BaseException:
             # A BaseException (e.g. KeyboardInterrupt, SystemExit) interrupted the event loop before
             # the test completed. Cancel _runner_task so it does not resume when the event

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2321,7 +2321,20 @@ class TestRunner(abc.TestRunner):
             )
         except Exception as exc:
             self._exceptions.append(exc)
-
+        except BaseException:
+            # A BaseException (e.g. KeyboardInterrupt) interrupted the event loop before
+            # the test completed. Cancel _runner_task so it does not resume when the event
+            # loop is re-entered during async generator fixture teardown.
+            if self._runner_task is not None and not self._runner_task.done():
+                self._runner_task.cancel()
+                try:
+                    self.get_loop().run_until_complete(self._runner_task)
+                except BaseException:
+                    pass
+                finally:
+                    self._runner_task = None
+                    self._send_stream.close()
+            raise
         self._raise_async_exceptions()
 
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2321,8 +2321,9 @@ class TestRunner(abc.TestRunner):
             )
         except Exception as exc:
             self._exceptions.append(exc)
+
         except BaseException:
-            # A BaseException (e.g. KeyboardInterrupt) interrupted the event loop before
+            # A BaseException (e.g. KeyboardInterrupt, SystemExit) interrupted the event loop before
             # the test completed. Cancel _runner_task so it does not resume when the event
             # loop is re-entered during async generator fixture teardown.
             if self._runner_task is not None and not self._runner_task.done():
@@ -2334,6 +2335,7 @@ class TestRunner(abc.TestRunner):
                 finally:
                     self._runner_task = None
                     self._send_stream.close()
+
             raise
         self._raise_async_exceptions()
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2327,14 +2327,13 @@ class TestRunner(abc.TestRunner):
             # loop is re-entered during async generator fixture teardown.
             if self._runner_task is not None and not self._runner_task.done():
                 self._runner_task.cancel()
+                self._send_stream.close()
                 try:
                     self.get_loop().run_until_complete(self._runner_task)
-                except BaseException:
+                except CancelledError:
                     pass
                 finally:
                     self._runner_task = None
-                    self._send_stream.close()
-
             raise
         self._raise_async_exceptions()
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -476,6 +476,39 @@ def test_keyboardinterrupt_during_test(
     testdir.runpytest_subprocess(*pytest_args, timeout=3)
 
 
+def test_keyboard_interrupt_does_not_resume_test(testdir: Pytester) -> None:
+    # Regression test for #1060
+    testdir.makepyfile(
+        """
+        import os
+        import signal
+        import anyio
+        import pytest
+        import threading
+
+        @pytest.fixture
+        def anyio_backend():
+            return "asyncio"
+
+        @pytest.fixture
+        async def myfixture():
+            yield
+
+        @pytest.mark.anyio
+        async def test_keyboard_interrupt(myfixture):
+            # using a thread timer, the signal(Ctrl-C) fires after the coroutine has
+            # suspended
+            threading.Timer(0.1, lambda: os.kill(os.getpid(), signal.SIGINT)).start()
+            await anyio.sleep(3600)
+            print("RESUMED_AFTER_INTERRUPT")
+        """
+    )
+
+    result = testdir.runpytest_subprocess(*pytest_args, timeout=5)
+    assert "RESUMED_AFTER_INTERRUPT" not in result.stdout.str()
+    assert "KeyboardInterrupt" in result.stdout.str()
+
+
 def test_async_fixture_in_test_class(testdir: Pytester) -> None:
     # Regression test for #633
     testdir.makepyfile(

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -484,12 +484,10 @@ def test_keyboard_interrupt_does_not_resume_test(testdir: Pytester) -> None:
     # Regression test for #1060
     testdir.makepyfile(
         """
-        import os
-        import signal
         import anyio
         import asyncio
         import pytest
-        import threading
+        import signal
 
         @pytest.fixture
         def anyio_backend():
@@ -502,7 +500,7 @@ def test_keyboard_interrupt_does_not_resume_test(testdir: Pytester) -> None:
         @pytest.mark.anyio
         async def test_keyboard_interrupt(myfixture):
             loop = asyncio.get_running_loop()
-            loop.call_later(0.1, signal.raise_signal, signal.SIGINT)
+            loop.call_soon(signal.raise_signal, signal.SIGINT)
             await anyio.sleep(3600)
             print("RESUMED_AFTER_INTERRUPT")
         """

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -487,6 +487,7 @@ def test_keyboard_interrupt_does_not_resume_test(testdir: Pytester) -> None:
         import os
         import signal
         import anyio
+        import asyncio
         import pytest
         import threading
 
@@ -500,15 +501,15 @@ def test_keyboard_interrupt_does_not_resume_test(testdir: Pytester) -> None:
 
         @pytest.mark.anyio
         async def test_keyboard_interrupt(myfixture):
-            # using a thread timer, the signal(Ctrl-C) fires after the coroutine has
-            # suspended
-            threading.Timer(0.1, lambda: os.kill(os.getpid(), signal.SIGINT)).start()
+            loop = asyncio.get_running_loop()
+            loop.call_later(0.1, signal.raise_signal, signal.SIGINT)
             await anyio.sleep(3600)
             print("RESUMED_AFTER_INTERRUPT")
         """
     )
 
     result = testdir.runpytest_subprocess(*pytest_args, timeout=5)
+    assert result.ret == 2
     assert "RESUMED_AFTER_INTERRUPT" not in result.stdout.str()
     assert "KeyboardInterrupt" in result.stdout.str()
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -477,9 +477,6 @@ def test_keyboardinterrupt_during_test(
     testdir.runpytest_subprocess(*pytest_args, timeout=3)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32", reason="SIGINT behavior differs on Windows"
-)
 def test_keyboard_interrupt_does_not_resume_test(testdir: Pytester) -> None:
     # Regression test for #1060
     testdir.makepyfile(

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -480,10 +480,11 @@ def test_keyboard_interrupt_does_not_resume_test(testdir: Pytester) -> None:
     # Regression test for #1060
     testdir.makepyfile(
         """
-        import anyio
         import asyncio
-        import pytest
         import signal
+
+        import anyio
+        import pytest
 
         @pytest.fixture
         def anyio_backend():

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import socket
+import sys
 from collections.abc import Sequence
 
 import pytest
@@ -476,6 +477,9 @@ def test_keyboardinterrupt_during_test(
     testdir.runpytest_subprocess(*pytest_args, timeout=3)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="SIGINT behavior differs on Windows"
+)
 def test_keyboard_interrupt_does_not_resume_test(testdir: Pytester) -> None:
     # Regression test for #1060
     testdir.makepyfile(

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -505,8 +505,8 @@ def test_keyboard_interrupt_does_not_resume_test(testdir: Pytester) -> None:
 
     result = testdir.runpytest_subprocess(*pytest_args, timeout=5)
     assert result.ret == 2
-    assert "RESUMED_AFTER_INTERRUPT" not in result.stdout.str()
-    assert "KeyboardInterrupt" in result.stdout.str()
+    result.stdout.no_fnmatch_line("*RESUMED_AFTER_INTERRUPT*")
+    result.stdout.fnmatch_lines(["*KeyboardInterrupt*"])
 
 
 def test_async_fixture_in_test_class(testdir: Pytester) -> None:

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import socket
-import sys
 from collections.abc import Sequence
 
 import pytest


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1060

<!-- Please give a short brief about these changes. -->
when an **async test** using an **async generator fixture**  is interrupted with **Ctrl-C** on the
**asyncio backend**, the test resumes and runs to completion **during fixture teardown** instead
of being interrupted. This happens because `run_test()` only caught `Exception`, leaving
`_runner_task` alive mid-test. when `run_asyncgen_fixture()` re-enters the event loop
for teardown, the runner task picks up where it left off in the test.

Fixed by adding an `except BaseException` handler in `run_test()` that cancels
`_runner_task` before teardown runs, ensuring a fresh runner task is created for fixture
cleanup.

This was first attempted in #1103 by @infraAnchor. The fix in `run_test()` is the same approach, I verified it and adapted
the test, which in the original PR was firing the signal before the coroutine suspended and wasn't actually catching the regression.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
