### PR TITLE
fix: remove duplicate self arg in hypothesis class method tests

### DIFF
--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -227,6 +227,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
 @pytest.hookimpl(tryfirst=True)
 def pytest_pyfunc_call(pyfuncitem: Any) -> bool | None:
     def run_with_hypothesis(**kwargs: Any) -> None:
+        kwargs.pop("self", None)
         with get_runner(backend_name, backend_options) as runner:
             runner.run_test(original_func, kwargs)
 


### PR DESCRIPTION
Fixes #700

**Problem:**
When a @given-decorated test is a class method, pytest passes self in the keyword arguments to hypothesis inner_test. The anyio pytest plugin then forwards all kwargs (including self) to runner.run_test(), which calls the original inner_test function with them. Since the inner_test for a class method already expects self as its first parameter and receives it from hypothesis calling convention, this results in a TypeError about multiple values for argument self.

**Fix:**
Pop self from kwargs in run_with_hypothesis() before passing to run_test(), matching how the non-hypothesis code path filters arguments via _fixtureinfo.argnames (which also excludes self).