### PR TITLE
Fix ValueError not raised when receive() is called with max_bytes < 1

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1044,6 +1044,9 @@ class StreamReaderWrapper(abc.ByteReceiveStream):
     _stream: asyncio.StreamReader
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         data = await self._stream.read(max_bytes)
         if data:
             return data
@@ -1277,6 +1280,9 @@ class SocketStream(abc.SocketStream):
         return self._transport.get_extra_info("socket")
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         with self._receive_guard:
             if (
                 not self._protocol.read_event.is_set()
@@ -1401,6 +1407,9 @@ class UNIXSocketStream(_RawSocketMixin, abc.UNIXSocketStream):
             self._raw_socket.shutdown(socket.SHUT_WR)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         loop = get_running_loop()
         await AsyncIOBackend.checkpoint()
         with self._receive_guard:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -388,6 +388,9 @@ class SocketStream(_TrioSocketMixin, abc.SocketStream):
         self._send_guard = ResourceGuard("writing to")
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         with self._receive_guard:
             try:
                 data = await self._trio_socket.recv(max_bytes)

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -531,7 +531,9 @@ class TestTCPStream:
         self, server_addr: tuple[str, int], max_bytes: int
     ) -> None:
         async with await connect_tcp(*server_addr) as stream:
-            with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
                 await stream.receive(max_bytes)
 
     async def test_send_after_close(self, server_addr: tuple[str, int]) -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -526,6 +526,14 @@ class TestTCPStream:
         with pytest.raises(ClosedResourceError):
             await stream.receive()
 
+    @pytest.mark.parametrize("max_bytes", [0, -1])
+    async def test_receive_invalid_max_bytes(
+        self, server_addr: tuple[str, int], max_bytes: int
+    ) -> None:
+        async with await connect_tcp(*server_addr) as stream:
+            with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+                await stream.receive(max_bytes)
+
     async def test_send_after_close(self, server_addr: tuple[str, int]) -> None:
         stream = await connect_tcp(*server_addr)
         await stream.aclose()


### PR DESCRIPTION
## Summary

Fixes #1081

`SocketStream.receive()` and related stream types did not raise `ValueError` when called with `max_bytes=0` or `max_bytes<0`, causing silent data corruption or false `EndOfStream` errors depending on the backend.

## Root cause

None of the affected `receive()` implementations validated `max_bytes` before use. The exact failure mode varied by stream type and backend:

| Stream | Backend | `max_bytes < 0` | `max_bytes == 0` |
|--------|---------|-----------------|------------------|
| `SocketStream` | asyncio | returned wrong data (bad negative slice) | returned `b""` (silent empty read) |
| `UNIXSocketStream` | asyncio | `ValueError` via CPython ✓ | false `EndOfStream` |
| `StreamReaderWrapper` (subprocess) | asyncio | read until EOF | false `EndOfStream` |
| `SocketStream` / `UNIXSocketStream` | trio | `ValueError` via CPython ✓ | false `EndOfStream` |

## Fix

Add an explicit `if max_bytes < 1: raise ValueError("max_bytes must be a positive integer")` guard at the top of each affected `receive()` method. This is consistent with how [Trio's own `ReceiveStream` ABC validates this parameter](https://github.com/python-trio/trio/blob/v0.33.0/src/trio/_abc.py#L447-L448).

## Changes

- `src/anyio/_backends/_asyncio.py`: guard added to `StreamReaderWrapper.receive()`, `SocketStream.receive()`, and `UNIXSocketStream.receive()`
- `src/anyio/_backends/_trio.py`: guard added to `SocketStream.receive()` (also covers `UNIXSocketStream` which inherits it)
- `tests/test_sockets.py`: parametrised test `test_receive_invalid_max_bytes` added to `TestTCPStream`, exercising `max_bytes=0` and `max_bytes=-1` on both backends
