### PR TITLE
Skip getnameinfo() on macOS on GitHub Actions runner

### DIFF
--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -2461,6 +2461,9 @@ async def test_getaddrinfo_ipv6_disabled() -> None:
 
 
 async def test_getnameinfo() -> None:
+    if os.getenv("GITHUB_ACTIONS") and platform.system() == "Darwin":
+        pytest.skip("macOS GitHub Actions runner has broken getnameinfo")
+
     expected_result = socket.getnameinfo(("127.0.0.1", 6666), 0)
     result = await getnameinfo(("127.0.0.1", 6666))
     assert result == expected_result


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Skips a test that  malfunctions on macOS on GitHub runners.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
