### PR TITLE
Use eager_start=False on Python 3.14+ instead of __code__ hacks

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -23,6 +23,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @bahtya)
 - Fixed lost type information when passing arguments to ``lru_cache``
   (`#1104 <https://github.com/agronholm/anyio/pull/1104>`_; PR by @Graeme22)
+- Used ``eager_start=False`` on Python 3.14+ in the asyncio backend instead of
+  inspecting the task factory's ``__code__`` and ``__closure__``
+  (`#1125 <https://github.com/agronholm/anyio/issues/1125>`_; PR by @graingert)
 
 **4.13.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -729,10 +729,32 @@ class _AsyncioTaskStatus(abc.TaskStatus):
         _task_states[task].parent_id = self._parent_id
 
 
-if sys.version_info >= (3, 12):
-    _eager_task_factory_code: CodeType | None = asyncio.eager_task_factory.__code__
+if sys.version_info >= (3, 14):
+    _eager_task_factory_code: CodeType | None = None
+
+    def _create_task(*, coro: Coroutine[Any, Any, Any], name: str) -> asyncio.Task:
+        return create_task(coro, name=name, eager_start=False)
+
+elif sys.version_info >= (3, 12):
+    _eager_task_factory_code = asyncio.eager_task_factory.__code__
+
+    def _create_task(*, coro: Coroutine[Any, Any, Any], name: str) -> asyncio.Task:
+        loop = asyncio.get_running_loop()
+        if (
+            (factory := loop.get_task_factory())
+            and getattr(factory, "__code__", None) is _eager_task_factory_code
+            and (closure := getattr(factory, "__closure__", None))
+        ):
+            custom_task_constructor = closure[0].cell_contents
+            return custom_task_constructor(coro, loop=loop, name=name)
+        else:
+            return create_task(coro, name=name)
+
 else:
     _eager_task_factory_code = None
+
+    def _create_task(*, coro: Coroutine[Any, Any, Any], name: str) -> asyncio.Task:
+        return create_task(coro, name=name)
 
 
 class TaskGroup(abc.TaskGroup):
@@ -891,16 +913,7 @@ class TaskGroup(abc.TaskGroup):
             )
 
         name = get_callable_name(func) if name is None else str(name)
-        loop = asyncio.get_running_loop()
-        if (
-            (factory := loop.get_task_factory())
-            and getattr(factory, "__code__", None) is _eager_task_factory_code
-            and (closure := getattr(factory, "__closure__", None))
-        ):
-            custom_task_constructor = closure[0].cell_contents
-            task = custom_task_constructor(coro, loop=loop, name=name)
-        else:
-            task = create_task(coro, name=name)
+        task = _create_task(coro=coro, name=name)
 
         # Make the spawned task inherit the task group's cancel scope
         _task_states[task] = TaskState(


### PR DESCRIPTION
On Python 3.14+, `asyncio.create_task()` accepts `eager_start=False` directly, avoiding the need to inspect the task factory's `__code__` and `__closure__`.

<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1125

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
