### PR TITLE
Fixed SocketListener.from_socket() for AF_UNIX listening sockets

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -29,6 +29,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed test resumption after ``KeyboardInterrupt`` in async generator fixtures on the
   asyncio backend
   (`#1060 <https://github.com/agronholm/anyio/issues/1060>`_; PR by @EmmanuelNiyonshuti)
+- Fixed ``SocketListener.from_socket()`` returning a TCP listener for ``AF_UNIX``
+  listening sockets, causing ``accept()`` to fail with ``ENOTSUP``
+  (`#1132 <https://github.com/agronholm/anyio/issues/1132>`_; PR by @kudato)
 
 **4.13.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2928,7 +2928,7 @@ class AsyncIOBackend(AsyncBackend):
 
     @classmethod
     async def wrap_listener_socket(cls, sock: socket.socket) -> SocketListener:
-        if sock.family == socket.AF_UNIX:
+        if hasattr(socket, "AF_UNIX") and sock.family == socket.AF_UNIX:
             return UNIXSocketListener(sock)
 
         return TCPSocketListener(sock)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2928,6 +2928,9 @@ class AsyncIOBackend(AsyncBackend):
 
     @classmethod
     async def wrap_listener_socket(cls, sock: socket.socket) -> SocketListener:
+        if sock.family == socket.AF_UNIX:
+            return UNIXSocketListener(sock)
+
         return TCPSocketListener(sock)
 
     @classmethod

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1261,7 +1261,7 @@ class TrioBackend(AsyncBackend):
 
     @classmethod
     async def wrap_listener_socket(cls, sock: socket.socket) -> abc.SocketListener:
-        if sock.family == socket.AF_UNIX:
+        if hasattr(socket, "AF_UNIX") and sock.family == socket.AF_UNIX:
             return UNIXSocketListener(sock)
 
         return TCPSocketListener(sock)

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1261,6 +1261,9 @@ class TrioBackend(AsyncBackend):
 
     @classmethod
     async def wrap_listener_socket(cls, sock: socket.socket) -> abc.SocketListener:
+        if sock.family == socket.AF_UNIX:
+            return UNIXSocketListener(sock)
+
         return TCPSocketListener(sock)
 
     @classmethod

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1639,14 +1639,11 @@ class TestUNIXListener:
 
             local_address = listener.extra(SocketAttribute.local_address)
             assert isinstance(local_address, str)
-            client = socket.socket(socket.AF_UNIX)
-            client.settimeout(1)
-            client.connect(local_address)
-            try:
+            with socket.socket(socket.AF_UNIX) as client:
+                client.settimeout(1)
+                client.connect(local_address)
                 async with await listener.accept() as stream:
                     assert stream.extra(SocketAttribute.family) == socket.AF_UNIX
-            finally:
-                client.close()
 
 
 async def test_multi_listener(tmp_path_factory: TempPathFactory) -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1635,8 +1635,18 @@ class TestUNIXListener:
     async def test_from_socket(self, sock_or_fd_factory: SockFdFactoryProtocol) -> None:
         sock_or_fd = sock_or_fd_factory(socket.AF_UNIX, socket.SOCK_STREAM, bound=True)
         async with await SocketListener.from_socket(sock_or_fd) as listener:
-            assert isinstance(listener, SocketListener)
             assert listener.extra(SocketAttribute.family) == socket.AF_UNIX
+
+            local_address = listener.extra(SocketAttribute.local_address)
+            assert isinstance(local_address, str)
+            client = socket.socket(socket.AF_UNIX)
+            client.settimeout(1)
+            client.connect(local_address)
+            try:
+                async with await listener.accept() as stream:
+                    assert stream.extra(SocketAttribute.family) == socket.AF_UNIX
+            finally:
+                client.close()
 
 
 async def test_multi_listener(tmp_path_factory: TempPathFactory) -> None:


### PR DESCRIPTION
## Changes

Fixes #1132.

`SocketListener.from_socket()` unconditionally constructed a `TCPSocketListener`
in both backends, so wrapping an `AF_UNIX` listening socket failed on the first
`accept()` call with `ENOTSUP` from `setsockopt(IPPROTO_TCP, TCP_NODELAY)`. This
dispatches on `sock.family` in `wrap_listener_socket()` and returns
`UNIXSocketListener` for `AF_UNIX` sockets — the same class that
`create_unix_listener()` already uses.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`) — bug fix only, behavior aligns with existing docs
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
