### PR TITLE
Ensure __main__ module is importable in ``to_process`` when not ending in .py

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -29,6 +29,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed test resumption after ``KeyboardInterrupt`` in async generator fixtures on the
   asyncio backend
   (`#1060 <https://github.com/agronholm/anyio/issues/1060>`_; PR by @EmmanuelNiyonshuti)
+- Fixed import of ``__main__`` in ``to_process`` workers when entrypoint script
+  doesn't end in ``.py``, such as when using ``console_script`` entrypoints.
+  (`#1027 <https://github.com/agronholm/anyio/issues/1027>`_; PR by @tapetersen and @worksbyfriday)
+
 
 **4.13.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -31,8 +31,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#1060 <https://github.com/agronholm/anyio/issues/1060>`_; PR by @EmmanuelNiyonshuti)
 - Fixed import of ``__main__`` in ``to_process`` workers when entrypoint script
   doesn't end in ``.py``, such as when using ``console_script`` entrypoints.
-  (`#1027 <https://github.com/agronholm/anyio/issues/1027>`_; PR by @tapetersen and @worksbyfriday)
-
+  (`#1027 <https://github.com/agronholm/anyio/issues/1027>`_; PR by @tapetersen and
+  @worksbyfriday)
 
 **4.13.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -35,8 +35,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#1060 <https://github.com/agronholm/anyio/issues/1060>`_; PR by @EmmanuelNiyonshuti)
 - Fixed import of ``__main__`` in ``to_process`` workers when entrypoint script
   doesn't end in ``.py``, such as when using ``console_script`` entrypoints.
-  (`#1027 <https://github.com/agronholm/anyio/issues/1027>`_; PR by @tapetersen and
-  @worksbyfriday)
+  (`#1027 <https://github.com/agronholm/anyio/issues/1027>`_; PR by @tapetersen)
 - Fixed ``SocketListener.from_socket()`` returning a TCP listener for ``AF_UNIX``
   listening sockets, causing ``accept()`` to fail with ``ENOTSUP``
   (`#1132 <https://github.com/agronholm/anyio/issues/1132>`_; PR by @kudato)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ test = [
 ]
 doc = [
     "packaging >= 14.1",
-    "Sphinx ~= 8.2",
+    "Sphinx ~= 8.2; python_version >= '3.11'",
     "sphinx_rtd_theme >= 2.0.0",
     "sphinx-autodoc-typehints >= 1.2.0",
     "sphinx-tabs >= 3.3.1",

--- a/src/anyio/to_process.py
+++ b/src/anyio/to_process.py
@@ -8,11 +8,12 @@ __all__ = (
 
 import os
 import pickle
+import runpy
 import subprocess
 import sys
 from collections import deque
 from collections.abc import Callable
-from importlib.util import module_from_spec, spec_from_file_location
+from types import ModuleType
 from typing import TypeVar, cast
 
 from ._core._eventloop import current_time, get_async_backend, get_cancelled_exc_class
@@ -235,11 +236,12 @@ def process_worker() -> None:
                     # Load the parent's main module but as __mp_main__ instead of
                     # __main__ (like multiprocessing does) to avoid infinite recursion
                     try:
-                        spec = spec_from_file_location("__mp_main__", main_module_path)
-                        if spec and spec.loader:
-                            main = module_from_spec(spec)
-                            spec.loader.exec_module(main)
-                            sys.modules["__main__"] = main
+                        main = ModuleType("__mp_main__")
+                        main_content = runpy.run_path(
+                            main_module_path, run_name="__mp_main__"
+                        )
+                        main.__dict__.update(main_content)
+                        sys.modules["__main__"] = sys.modules["__mp_main__"] = main
                     except BaseException as exc:
                         exception = exc
         try:

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -132,7 +132,10 @@ async def test_nonexistent_main_module(
 
 def _check_main_importable() -> int:
     """Helper that runs in the worker process to check main was imported correctly"""
-    return sys.modules["__main__"].foo
+    assert sys.modules["__main__"].foo == 3
+
+    # python multiprocessing does it this way and there is probably code dependent on it.
+    assert sys.modules["__main__"] == sys.modules["__mp_main__"]
 
 
 async def test_entrypoint_main_module(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -132,10 +132,11 @@ async def test_nonexistent_main_module(
 
 def _check_main_importable() -> int:
     """Helper that runs in the worker process to check main was imported correctly"""
-    assert sys.modules["__main__"].foo == 3
 
     # python multiprocessing does it this way and there is probably code dependent on it.
     assert sys.modules["__main__"] == sys.modules["__mp_main__"]
+
+    return sys.modules["__main__"].foo
 
 
 async def test_entrypoint_main_module(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -128,3 +128,20 @@ async def test_nonexistent_main_module(
     script_path.touch()
     monkeypatch.setattr("__main__.__file__", str(script_path / "__main__.py"))
     await to_process.run_sync(os.getpid)
+
+
+def _check_main_importable() -> int:
+    """Helper that runs in the worker process to check main was imported correctly"""
+    return sys.modules["__main__"].foo
+
+
+async def test_entrypoint_main_module(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """
+    Test that worker process creation succeeds when __main__.__file__ points to an
+    entry point script (no .py extension). Regression test for #1027.
+    """
+
+    script_path = tmp_path / "my-entrypoint"
+    script_path.write_text("foo=3")
+    monkeypatch.setattr("__main__.__file__", str(script_path))
+    assert await to_process.run_sync(_check_main_importable) == 3


### PR DESCRIPTION
Solves #1027

<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1027

Changes the import of __main__ in ` to_process` from trying to load `__main__` as a module to using `runpy` instead to allow entrypoints not ending in the usual extensions.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```
