### PR TITLE
Widen Path.write_bytes data param to ReadableBuffer

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -18,13 +18,13 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Improved ``anyio.Path`` to preserve subclass types by returning ``Self`` in methods
   that return path objects
   (`#1130 <https://github.com/agronholm/anyio/issues/1130>`_; PR by @EmmanuelNiyonshuti)
+- Changed the parameter type annotation in ``anyio.Path.write_bytes()`` to accept
+  any ``ReadableBuffer``, thus allowing it to accept ``bytearray`` and ``memoryview`` to
+  match :meth:`pathlib.Path.write_bytes`
+  (`#1135 <https://github.com/agronholm/anyio/issues/1135>`_; PR by @SAY-5)
 - Fixed cancellation exception escaping a cancel scope when triggered via
   ``check_cancelled()`` in a worker thread
   (`#1113 <https://github.com/agronholm/anyio/issues/1113>`_)
-- Fixed ``anyio.Path.write_bytes()`` rejecting non-``bytes`` buffer types (e.g.
-  ``bytearray``, ``memoryview``) by widening its ``data`` parameter to
-  ``ReadableBuffer``, matching :meth:`pathlib.Path.write_bytes`
-  (`#1135 <https://github.com/agronholm/anyio/issues/1135>`_; PR by @SAY-5)
 - Fixed ``TaskGroup`` raising ``AttributeError`` instead of a clear error when entered
   more than once
   (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @bahtya)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -21,6 +21,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed cancellation exception escaping a cancel scope when triggered via
   ``check_cancelled()`` in a worker thread
   (`#1113 <https://github.com/agronholm/anyio/issues/1113>`_)
+- Fixed ``anyio.Path.write_bytes()`` rejecting non-``bytes`` buffer types (e.g.
+  ``bytearray``, ``memoryview``) by widening its ``data`` parameter to
+  ``ReadableBuffer``, matching :meth:`pathlib.Path.write_bytes`
+  (`#1135 <https://github.com/agronholm/anyio/issues/1135>`_; PR by @SAY-5)
 - Fixed ``TaskGroup`` raising ``AttributeError`` instead of a clear error when entered
   more than once
   (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @bahtya)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -20,7 +20,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#1130 <https://github.com/agronholm/anyio/issues/1130>`_; PR by @EmmanuelNiyonshuti)
 - Changed the parameter type annotation in ``anyio.Path.write_bytes()`` to accept
   any ``ReadableBuffer``, thus allowing it to accept ``bytearray`` and ``memoryview`` to
-  match :meth:`pathlib.Path.write_bytes`
+  match ``pathlib.Path.write_bytes()``
   (`#1135 <https://github.com/agronholm/anyio/issues/1135>`_; PR by @SAY-5)
 - Fixed cancellation exception escaping a cancel scope when triggered via
   ``check_cancelled()`` in a worker thread

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -935,7 +935,7 @@ class Path:
     def with_segments(self, *pathsegments: str | PathLike[str]) -> Self:
         return type(self)(*pathsegments, limiter=self._limiter)
 
-    async def write_bytes(self, data: bytes) -> int:
+    async def write_bytes(self, data: ReadableBuffer) -> int:
         return await to_thread.run_sync(
             self._path.write_bytes, data, limiter=self._limiter
         )

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -854,18 +854,20 @@ class TestPath:
     def test_with_suffix(self) -> None:
         assert Path("/xyz/foo.txt.gz").with_suffix(".zip").name == "foo.txt.zip"
 
-    async def test_write_bytes(self, tmp_path: pathlib.Path) -> None:
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param(b"bibbitibobbitiboo", id="bytes"),
+            pytest.param(bytearray(b"bibbitibobbitiboo"), id="bytearray"),
+            pytest.param(memoryview(b"bibbitibobbitiboo"), id="memoryview"),
+        ],
+    )
+    async def test_write_bytes(
+        self, tmp_path: pathlib.Path, data: bytes | bytearray | memoryview
+    ) -> None:
         path = tmp_path / "testfile"
-        await Path(path).write_bytes(b"bibbitibobbitiboo")
+        await Path(path).write_bytes(data)
         assert path.read_bytes() == b"bibbitibobbitiboo"
-
-    async def test_write_bytes_buffer(self, tmp_path: pathlib.Path) -> None:
-        path = tmp_path / "testfile"
-        await Path(path).write_bytes(bytearray(b"bibbitibobbitiboo"))
-        assert path.read_bytes() == b"bibbitibobbitiboo"
-
-        await Path(path).write_bytes(memoryview(b"second"))
-        assert path.read_bytes() == b"second"
 
     async def test_write_text(self, tmp_path: pathlib.Path) -> None:
         path = tmp_path / "testfile"

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -859,6 +859,14 @@ class TestPath:
         await Path(path).write_bytes(b"bibbitibobbitiboo")
         assert path.read_bytes() == b"bibbitibobbitiboo"
 
+    async def test_write_bytes_buffer(self, tmp_path: pathlib.Path) -> None:
+        path = tmp_path / "testfile"
+        await Path(path).write_bytes(bytearray(b"bibbitibobbitiboo"))
+        assert path.read_bytes() == b"bibbitibobbitiboo"
+
+        await Path(path).write_bytes(memoryview(b"second"))
+        assert path.read_bytes() == b"second"
+
     async def test_write_text(self, tmp_path: pathlib.Path) -> None:
         path = tmp_path / "testfile"
         await Path(path).write_text("some text åäö", encoding="utf-8")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Changes

Fixes #1135.

Widens the type of the `data` parameter on `anyio.Path.write_bytes()` from `bytes` to `ReadableBuffer`, matching the signature of `pathlib.Path.write_bytes`. mypy v2's `--strict-bytes` (now default) flagged passing `bytearray` / `memoryview` as a type error even though the underlying call accepts any buffer.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).