### PR TITLE
Fix SocketListener.from_socket() for AF_UNIX sockets

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed ``SocketListener.from_socket()`` returning a TCP listener (and failing on
+  ``accept()`` with ``ENOTSUP``) when handed an ``AF_UNIX`` listening socket;
+  it now returns a UNIX listener
+  (`#1132 <https://github.com/agronholm/anyio/issues/1132>`_; PR by @jbbqqf)
 - Added the ``local_port`` parameter to :func:`connect_tcp` to allow binding to a
   specific local port before connecting
   (`#1067 <https://github.com/agronholm/anyio/issues/1067>`_; PR by @nullwiz)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2928,6 +2928,12 @@ class AsyncIOBackend(AsyncBackend):
 
     @classmethod
     async def wrap_listener_socket(cls, sock: socket.socket) -> SocketListener:
+        # Dispatch on the underlying socket family: AF_UNIX listeners must use
+        # UNIXSocketListener, otherwise accept() would call setsockopt
+        # IPPROTO_TCP/TCP_NODELAY on the accepted UDS, which raises ENOTSUP.
+        if sock.family == socket.AF_UNIX:
+            return UNIXSocketListener(sock)
+
         return TCPSocketListener(sock)
 
     @classmethod

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2931,7 +2931,9 @@ class AsyncIOBackend(AsyncBackend):
         # Dispatch on the underlying socket family: AF_UNIX listeners must use
         # UNIXSocketListener, otherwise accept() would call setsockopt
         # IPPROTO_TCP/TCP_NODELAY on the accepted UDS, which raises ENOTSUP.
-        if sock.family == socket.AF_UNIX:
+        # ``socket.AF_UNIX`` is unavailable on some platforms (e.g. Windows),
+        # so use getattr() to avoid an AttributeError at import/call time.
+        if sock.family == getattr(socket, "AF_UNIX", None):
             return UNIXSocketListener(sock)
 
         return TCPSocketListener(sock)

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1264,7 +1264,9 @@ class TrioBackend(AsyncBackend):
         # Dispatch on the underlying socket family: AF_UNIX listeners must use
         # UNIXSocketListener, otherwise accept() would call setsockopt
         # IPPROTO_TCP/TCP_NODELAY on the accepted UDS, which raises ENOTSUP.
-        if sock.family == socket.AF_UNIX:
+        # ``socket.AF_UNIX`` is unavailable on some platforms (e.g. Windows),
+        # so use getattr() to avoid an AttributeError at import/call time.
+        if sock.family == getattr(socket, "AF_UNIX", None):
             return UNIXSocketListener(sock)
 
         return TCPSocketListener(sock)

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1261,6 +1261,12 @@ class TrioBackend(AsyncBackend):
 
     @classmethod
     async def wrap_listener_socket(cls, sock: socket.socket) -> abc.SocketListener:
+        # Dispatch on the underlying socket family: AF_UNIX listeners must use
+        # UNIXSocketListener, otherwise accept() would call setsockopt
+        # IPPROTO_TCP/TCP_NODELAY on the accepted UDS, which raises ENOTSUP.
+        if sock.family == socket.AF_UNIX:
+            return UNIXSocketListener(sock)
+
         return TCPSocketListener(sock)
 
     @classmethod

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1638,6 +1638,25 @@ class TestUNIXListener:
             assert isinstance(listener, SocketListener)
             assert listener.extra(SocketAttribute.family) == socket.AF_UNIX
 
+    async def test_from_socket_accept(
+        self, socket_path: Path, sock_or_fd_factory: SockFdFactoryProtocol
+    ) -> None:
+        # Regression test for #1132: SocketListener.from_socket(unix_sock) must
+        # produce a UNIXSocketListener, not a TCPSocketListener. The latter sets
+        # IPPROTO_TCP/TCP_NODELAY on accepted clients, which fails on AF_UNIX.
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.bind(str(socket_path))
+        sock.listen()
+        async with await SocketListener.from_socket(sock) as listener:
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            client.settimeout(1)
+            client.connect(str(socket_path))
+            stream = await listener.accept()
+            client.sendall(b"ping")
+            assert await stream.receive() == b"ping"
+            client.close()
+            await stream.aclose()
+
 
 async def test_multi_listener(tmp_path_factory: TempPathFactory) -> None:
     async def handle(stream: SocketStream) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Changes

Fixes #1132.

`SocketListener.from_socket()` unconditionally returned a `TCPSocketListener` regardless of the underlying socket family. The first `accept()` then failed on `AF_UNIX` listening sockets with `OSError(ENOTSUP)` because `TCPSocketListener.accept()` calls `setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)` on the accepted client, which AF_UNIX sockets do not support.

`wrap_listener_socket()` on both backends now dispatches on `sock.family`:

- `AF_UNIX` -> `UNIXSocketListener`
- otherwise -> `TCPSocketListener` (unchanged)

A new regression test (`TestUNIXListener.test_from_socket_accept`) covers the full bind -> from_socket -> accept -> recv path on AF_UNIX, which is what the original ticket reproducer does.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

### Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
git clone https://github.com/agronholm/anyio.git /tmp/anyio-1132 && cd /tmp/anyio-1132
python -m venv .venv && . .venv/bin/activate
pip install -e . pytest pytest-timeout pytest-mock psutil hypothesis trustme blockbuster trio

# --- BEFORE (master): the new regression test fails ---
git checkout origin/master
git fetch https://github.com/jbbqqf/anyio.git feat/1132-unix-listener-from-socket
git checkout FETCH_HEAD -- tests/test_sockets.py
pytest -q tests/test_sockets.py::TestUNIXListener::test_from_socket_accept
# Expected: FAILED with OSError(ENOTSUP) when accept() runs setsockopt TCP_NODELAY on the AF_UNIX peer

# --- AFTER (this PR): same command, same test, passes ---
git checkout FETCH_HEAD
pytest -q tests/test_sockets.py::TestUNIXListener::test_from_socket_accept
# Expected: 16 passed
```

The only difference between the two runs is the checked-out tree.

### Risk / blast radius

Strictly additive: the previous `return TCPSocketListener(sock)` is preserved as the fallback for non-`AF_UNIX` families. No public API change.

---

*PR drafted with assistance from Claude (Anthropic). The change was reviewed manually against anyio's source and verified locally with the project's own test suite.*
