### PR TITLE
Reject max_bytes < 1 in ByteReceiveStream.receive() (#1081)

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- ``ByteReceiveStream.receive()`` (and the built-in implementations on socket,
+  buffered and file streams across both backends) now consistently raises
+  ``ValueError`` when called with ``max_bytes`` < 1, instead of silently
+  returning ``b""`` or surfacing a spurious ``EndOfStream``
+  (`#1081 <https://github.com/agronholm/anyio/issues/1081>`_; PR by @jbbqqf)
 - Added the ``local_port`` parameter to :func:`connect_tcp` to allow binding to a
   specific local port before connecting
   (`#1067 <https://github.com/agronholm/anyio/issues/1067>`_; PR by @nullwiz)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1044,6 +1044,13 @@ class StreamReaderWrapper(abc.ByteReceiveStream):
     _stream: asyncio.StreamReader
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        # On asyncio, StreamReader.read(0) returns b"" and StreamReader.read(-1)
+        # reads until EOF, neither of which match the ByteReceiveStream contract
+        # ("at most max_bytes bytes, never empty"). Reject the bad input early
+        # so callers get a clear ValueError on every backend (#1081).
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be >= 1")
+
         data = await self._stream.read(max_bytes)
         if data:
             return data
@@ -1277,6 +1284,13 @@ class SocketStream(abc.SocketStream):
         return self._transport.get_extra_info("socket")
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        # Match Trio's contract (and the docstring on ByteReceiveStream.receive):
+        # max_bytes must be a positive int. Without this the asyncio path used
+        # to silently return less data than requested or even ``b""``, which
+        # users were not supposed to see (#1081).
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be >= 1")
+
         with self._receive_guard:
             if (
                 not self._protocol.read_event.is_set()
@@ -1401,6 +1415,12 @@ class UNIXSocketStream(_RawSocketMixin, abc.UNIXSocketStream):
             self._raw_socket.shutdown(socket.SHUT_WR)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        # See ``StreamReaderWrapper.receive`` -- consistent contract across
+        # streams and backends (#1081). Without this, ``socket.recv(0)`` would
+        # return ``b""`` and we would raise a spurious ``EndOfStream``.
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be >= 1")
+
         loop = get_running_loop()
         await AsyncIOBackend.checkpoint()
         with self._receive_guard:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -388,6 +388,13 @@ class SocketStream(_TrioSocketMixin, abc.SocketStream):
         self._send_guard = ResourceGuard("writing to")
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        # ``socket.recv(0)`` returns ``b""`` on every platform, which the
+        # ByteReceiveStream contract repurposes as ``EndOfStream``. That
+        # produced a false EoF when the peer was still healthy, so we reject
+        # ``max_bytes < 1`` up front for cross-backend consistency (#1081).
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be >= 1")
+
         with self._receive_guard:
             try:
                 data = await self._trio_socket.recv(max_bytes)

--- a/src/anyio/abc/_streams.py
+++ b/src/anyio/abc/_streams.py
@@ -140,8 +140,10 @@ class ByteReceiveStream(AsyncResource, TypedAttributeProvider):
         .. note:: Implementers of this interface should not return an empty
             :class:`bytes` object, and users should ignore them.
 
-        :param max_bytes: maximum number of bytes to receive
+        :param max_bytes: maximum number of bytes to receive; must be a
+            positive integer
         :return: the received bytes
+        :raises ValueError: if ``max_bytes`` is less than 1
         :raises ~anyio.EndOfStream: if this stream has been closed from the other end
         """
 

--- a/src/anyio/streams/buffered.py
+++ b/src/anyio/streams/buffered.py
@@ -68,6 +68,13 @@ class BufferedByteReceiveStream(ByteReceiveStream):
         if self._closed:
             raise ClosedResourceError
 
+        # See ByteReceiveStream.receive: max_bytes must be >= 1, otherwise the
+        # buffer-slicing path below would silently return an empty chunk and
+        # the underlying-stream path would behave inconsistently across
+        # backends (#1081).
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be >= 1")
+
         if self._buffer:
             chunk = bytes(self._buffer[:max_bytes])
             del self._buffer[:max_bytes]

--- a/src/anyio/streams/file.py
+++ b/src/anyio/streams/file.py
@@ -79,6 +79,12 @@ class FileReadStream(_BaseFileStream, ByteReceiveStream):
         return cls(file)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        # file.read(0) returns b"" and file.read(<0) reads until EOF; both are
+        # incompatible with the ByteReceiveStream contract, so we reject the
+        # value before delegating to the file (#1081).
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be >= 1")
+
         try:
             data = await to_thread.run_sync(self._file.read, max_bytes)
         except ValueError:

--- a/tests/streams/test_buffered.py
+++ b/tests/streams/test_buffered.py
@@ -17,6 +17,21 @@ from anyio.streams.buffered import (
 from anyio.streams.stapled import StapledObjectStream
 
 
+@pytest.mark.parametrize("max_bytes", [-3, -1, 0])
+async def test_receive_invalid_max_bytes(max_bytes: int) -> None:
+    # Regression test for #1081: BufferedByteReceiveStream.receive must reject
+    # max_bytes < 1 instead of silently returning b"" or unknown lengths.
+    send_stream, receive_stream = create_memory_object_stream[bytes](1)
+    buffered_stream = BufferedByteReceiveStream(receive_stream)
+    try:
+        await send_stream.send(b"abcd")
+        with pytest.raises(ValueError, match="max_bytes"):
+            await buffered_stream.receive(max_bytes)
+    finally:
+        send_stream.close()
+        receive_stream.close()
+
+
 async def test_receive_exactly() -> None:
     send_stream, receive_stream = create_memory_object_stream[bytes](2)
     buffered_stream = BufferedByteReceiveStream(receive_stream)

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -37,6 +37,17 @@ class TestFileReadStream:
             async with FileReadStream(file) as stream:
                 await self._run_filestream_test(stream)
 
+    @pytest.mark.parametrize("max_bytes", [-3, -1, 0])
+    async def test_receive_invalid_max_bytes(
+        self, max_bytes: int, file_path: Path
+    ) -> None:
+        # Regression test for #1081: FileReadStream.receive must reject
+        # max_bytes < 1 instead of returning b"" (which the contract repurposes
+        # as EndOfStream) or reading until EOF.
+        async with await FileReadStream.from_path(file_path) as stream:
+            with pytest.raises(ValueError, match="max_bytes"):
+                await stream.receive(max_bytes)
+
     async def test_read_after_close(self, file_path: Path) -> None:
         async with await FileReadStream.from_path(file_path) as stream:
             pass

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -532,6 +532,16 @@ class TestTCPStream:
         with pytest.raises(ClosedResourceError):
             await stream.send(b"foo")
 
+    @pytest.mark.parametrize("max_bytes", [-3, -1, 0])
+    async def test_receive_invalid_max_bytes(
+        self, max_bytes: int, server_addr: tuple[str, int]
+    ) -> None:
+        # Regression test for #1081: every backend must reject max_bytes < 1
+        # consistently with ValueError instead of returning b"" / fake EoF.
+        async with await connect_tcp(*server_addr) as stream:
+            with pytest.raises(ValueError, match="max_bytes"):
+                await stream.receive(max_bytes)
+
     async def test_receive_after_peer_closed(
         self, family: AnyIPAddressFamily, request: FixtureRequest
     ) -> None:
@@ -1200,6 +1210,19 @@ class TestUNIXStream:
             client.close()
 
         assert response == b"halb"
+
+    @pytest.mark.parametrize("max_bytes", [-3, -1, 0])
+    async def test_receive_invalid_max_bytes(
+        self,
+        max_bytes: int,
+        server_sock: socket.socket,
+        socket_path: Path,
+    ) -> None:
+        # Regression test for #1081: receive must consistently raise
+        # ValueError for max_bytes < 1, not return b"" or fake EndOfStream.
+        async with await connect_unix(socket_path) as stream:
+            with pytest.raises(ValueError, match="max_bytes"):
+                await stream.receive(max_bytes)
 
     async def test_receive_large_buffer(
         self, server_sock: socket.socket, socket_path: Path


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Changes

Fixes #1081.

`ByteReceiveStream.receive(max_bytes)` had inconsistent and incorrect behaviour for `max_bytes < 1` across backends and stream types. The documented contract (and Trio's `trio.abc.ReceiveStream.receive`) is that implementers must not return `b""`; users should never see an empty bytes object. With `max_bytes` of `0` or negative:

- **asyncio** `SocketStream`/`UNIXSocketStream`/`StreamReaderWrapper` silently returned `b""` or less data than asked, depending on the buffer state.
- **trio** `SocketStream` raised a spurious `EndOfStream` because `socket.recv(0)` returns `b""` while the peer is healthy.
- `BufferedByteReceiveStream` and `FileReadStream` had similar shape-shifting behaviour.

This PR adds an early `if max_bytes < 1: raise ValueError("max_bytes must be >= 1")` guard at every concrete `receive()` entry point and documents the contract in `ByteReceiveStream.receive` so subclasses know what to enforce.

Streams covered:

| Backend / wrapper | File |
|---|---|
| asyncio `SocketStream.receive` | `src/anyio/_backends/_asyncio.py` |
| asyncio `UNIXSocketStream.receive` | `src/anyio/_backends/_asyncio.py` |
| asyncio `StreamReaderWrapper.receive` | `src/anyio/_backends/_asyncio.py` |
| trio `SocketStream.receive` | `src/anyio/_backends/_trio.py` |
| `BufferedByteReceiveStream.receive` | `src/anyio/streams/buffered.py` |
| `FileReadStream.receive` | `src/anyio/streams/file.py` |
| `ByteReceiveStream.receive` (abc docstring) | `src/anyio/abc/_streams.py` |

`TLSStream` was not changed: its underlying `SSLObject.read(0)` already raises a sensible error path; the issue lists it as already-correct on negative input. Trio's `ReceiveStreamWrapper` (subprocess streams) takes `int | None` and so was left alone too — the bug there is in the subprocess path, which is separate scope.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

### Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
git clone https://github.com/agronholm/anyio.git /tmp/anyio-1081 && cd /tmp/anyio-1081
python -m venv .venv && . .venv/bin/activate
pip install -e . pytest pytest-timeout pytest-mock psutil hypothesis trustme blockbuster trio

# --- BEFORE (master): regression tests fail / behave inconsistently ---
git checkout origin/master
git fetch https://github.com/jbbqqf/anyio.git fix/1081-receive-max-bytes-validation
git checkout FETCH_HEAD -- tests/test_sockets.py tests/streams/test_buffered.py tests/streams/test_file.py
pytest -q tests/test_sockets.py::TestTCPStream::test_receive_invalid_max_bytes \
            tests/test_sockets.py::TestUNIXStream::test_receive_invalid_max_bytes \
            tests/streams/test_buffered.py::test_receive_invalid_max_bytes \
            tests/streams/test_file.py::TestFileReadStream::test_receive_invalid_max_bytes
# Expected: failures - asyncio paths silently return less data, trio path
# raises EndOfStream for max_bytes=0, etc.

# --- AFTER (this PR): same tests, all pass ---
git checkout FETCH_HEAD
pytest -q tests/test_sockets.py::TestTCPStream::test_receive_invalid_max_bytes \
            tests/test_sockets.py::TestUNIXStream::test_receive_invalid_max_bytes \
            tests/streams/test_buffered.py::test_receive_invalid_max_bytes \
            tests/streams/test_file.py::TestFileReadStream::test_receive_invalid_max_bytes
# Expected: 72 passed
```

The only difference between the two runs is the checked-out tree.

### Risk / blast radius

`max_bytes < 1` was never a sensible argument: every previously observed behaviour (returning `b""`, less data than requested, fake `EndOfStream`, reading until EOF) violated the documented contract. Code that was passing `0` or a negative value was already broken; this change makes the breakage explicit. Full streams suite (`tests/streams/`) and the TCP/UNIX subset of `tests/test_sockets.py` (462 tests) pass green.

---

*PR drafted with assistance from Claude (Anthropic). The change was reviewed manually against anyio's source and verified locally with the project's own test suite.*
