### PR TITLE
Always restore __main__ in to_process workers (#1027)

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed ``to_process.run_sync`` leaving the worker process without a
+  ``__main__`` module when the parent's ``__main__.__file__`` does not end in
+  ``.py`` / ``.pyc`` (typically a console-script entry point); the worker now
+  always restores some ``__main__`` module so that ``import __main__`` keeps
+  working for libraries such as ``dill``
+  (`#1027 <https://github.com/agronholm/anyio/issues/1027>`_; PR by @jbbqqf)
 - Added the ``local_port`` parameter to :func:`connect_tcp` to allow binding to a
   specific local port before connecting
   (`#1067 <https://github.com/agronholm/anyio/issues/1067>`_; PR by @nullwiz)

--- a/src/anyio/to_process.py
+++ b/src/anyio/to_process.py
@@ -10,6 +10,7 @@ import os
 import pickle
 import subprocess
 import sys
+import types
 from collections import deque
 from collections.abc import Callable
 from importlib.util import module_from_spec, spec_from_file_location
@@ -231,6 +232,13 @@ def process_worker() -> None:
                 main_module_path: str | None
                 sys.path, main_module_path = args
                 del sys.modules["__main__"]
+                # Always restore *some* __main__: pickle.loads, dill, and many
+                # other libraries assume ``import __main__`` works. Without this
+                # fallback, console-script entry points (paths that don't end in
+                # .py / .pyc, where spec_from_file_location returns None)
+                # leave the worker without a __main__ module entirely. See
+                # https://github.com/agronholm/anyio/issues/1027.
+                sys.modules["__main__"] = types.ModuleType("__main__")
                 if main_module_path and os.path.isfile(main_module_path):
                     # Load the parent's main module but as __mp_main__ instead of
                     # __main__ (like multiprocessing does) to avoid infinite recursion

--- a/tests/test_to_process.py
+++ b/tests/test_to_process.py
@@ -128,3 +128,37 @@ async def test_nonexistent_main_module(
     script_path.touch()
     monkeypatch.setattr("__main__.__file__", str(script_path / "__main__.py"))
     await to_process.run_sync(os.getpid)
+
+
+def _import_main() -> str:
+    # Runs in the worker process. dill, pickle and several other libraries
+    # assume "import __main__" works; make the assumption explicit so the
+    # regression has a concrete failure mode (ModuleNotFoundError on master).
+    import __main__
+
+    return type(__main__).__name__
+
+
+async def test_main_module_with_non_py_path(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    Regression test for #1027.
+
+    When AnyIO's worker process is launched from a console-script entry point
+    (so ``__main__.__file__`` is a path *without* a ``.py`` / ``.pyc`` suffix),
+    ``importlib.util.spec_from_file_location`` returns ``None`` and the worker
+    used to drop ``__main__`` from ``sys.modules`` permanently. Subsequent
+    ``import __main__`` calls in user code (dill et al.) then raised
+    ``ModuleNotFoundError``.
+    """
+
+    # Create an existing file with no .py / .pyc suffix - mimics an installed
+    # console-script entry point.
+    script_path = tmp_path / "myapp"
+    script_path.write_text("#!/usr/bin/env python\n")
+    monkeypatch.setattr("__main__.__file__", str(script_path))
+
+    # On master this raises BrokenWorkerProcess (ModuleNotFoundError: '__main__')
+    # in the worker; with the fix, __main__ is restored and the import works.
+    assert await to_process.run_sync(_import_main) == "module"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Changes

Fixes #1027.

When `to_process.run_sync` initialises a worker, it tries to mirror the parent's `__main__` as `__mp_main__` so user-pickled callables can resolve back to it. The worker first does `del sys.modules["__main__"]`, then loads the parent's module via `importlib.util.spec_from_file_location(..., parent_main_path)`.

`spec_from_file_location` returns `None` when the path's suffix isn't recognised by any registered file finder (in practice, anything that isn't `.py` / `.pyc`). That's the common case for **installed console-script entry points** (`pip install` writes a tiny launcher with no suffix). The worker silently skipped the `if spec and spec.loader:` block and ended up with no `__main__` module at all, breaking later `import __main__` calls in user code (`dill._dill` does this on import; `pickle` does it during unpickling of `__main__`-defined classes).

The fix always assigns a fresh `types.ModuleType("__main__")` as the fallback before attempting to load the real one. The fast path that swaps in the loaded module on success is preserved, so behaviour for `.py` invocations is unchanged.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

### Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
git clone https://github.com/agronholm/anyio.git /tmp/anyio-1027 && cd /tmp/anyio-1027
python -m venv .venv && . .venv/bin/activate
pip install -e . pytest pytest-timeout pytest-mock psutil hypothesis trustme blockbuster trio

# --- BEFORE (master): the new regression test fails ---
git checkout origin/master
git fetch https://github.com/jbbqqf/anyio.git fix/1027-to-process-main-spec
git checkout FETCH_HEAD -- tests/test_to_process.py
pytest -q tests/test_to_process.py::test_main_module_with_non_py_path
# Expected: FAILED on every backend with
#   "ModuleNotFoundError: No module named '__main__'"
# raised inside the worker process.

# --- AFTER (this PR): same command, same test, passes ---
git checkout FETCH_HEAD
pytest -q tests/test_to_process.py::test_main_module_with_non_py_path
# Expected: 4 passed
```

The only difference between the two runs is the checked-out tree.

### Risk / blast radius

Strictly additive: when the existing fast path succeeds (path ends in `.py` / `.pyc` and the module loads), `sys.modules["__main__"]` is replaced just like before. The fallback only kicks in for the previously-broken path. Existing `tests/test_to_process.py` (40 tests, including `test_nonexistent_main_module` from #696) still passes.

---

*PR drafted with assistance from Claude (Anthropic). The change was reviewed manually against anyio's source and verified locally with the project's own test suite.*
