### PR TITLE
Skip done tasks in asyncio _deliver_cancellation

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -25,6 +25,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed cancellation exception escaping a cancel scope when triggered via
   ``check_cancelled()`` in a worker thread
   (`#1113 <https://github.com/agronholm/anyio/issues/1113>`_)
+- Fixed 100% CPU spin in the asyncio backend when a completed task remained in
+  ``CancelScope._tasks`` and ``_deliver_cancellation`` retried indefinitely
+  (`#1111 <https://github.com/agronholm/anyio/issues/1111>`_; PR by @SAY-5)
 - Fixed ``TaskGroup`` raising ``AttributeError`` instead of a clear error when entered
   more than once
   (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @bahtya)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -583,6 +583,9 @@ class CancelScope(BaseCancelScope):
         should_retry = False
         current = current_task()
         for task in self._tasks:
+            if task.done():
+                continue
+
             should_retry = True
             if task._must_cancel:  # type: ignore[attr-defined]
                 continue

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -256,6 +256,37 @@ async def test_start_native_child_cancelled() -> None:
 
 
 @pytest.mark.parametrize("anyio_backend", asyncio_params)
+async def test_deliver_cancellation_skips_done_tasks() -> None:
+    """Regression test for #1111.
+
+    ``_deliver_cancellation`` must not retry indefinitely when a completed task
+    remains in ``CancelScope._tasks``. asyncio's ``Task.cancel()`` is a no-op
+    for done tasks, so without a ``task.done()`` check the scope reschedules
+    itself forever and spins the event loop at 100% CPU.
+    """
+    from anyio._backends._asyncio import CancelScope as AsyncioCancelScope
+
+    async def noop() -> None:
+        return None
+
+    done_task = asyncio.create_task(noop())
+    await done_task
+    assert done_task.done()
+
+    scope = AsyncioCancelScope.__new__(AsyncioCancelScope)
+    scope._tasks = {done_task}
+    scope._cancel_called = True
+    scope._cancel_reason = None
+    scope._host_task = None
+    scope._child_scopes = set()
+    scope._cancelled_caught = False
+    scope._pending_uncancellations = None
+
+    should_retry = scope._deliver_cancellation(scope)
+    assert should_retry is False
+
+
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_propagate_native_cancellation_from_taskgroup() -> None:
     async def taskfunc() -> None:
         async with create_task_group() as tg:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Changes

Fixes #1111.

A completed task left in ``CancelScope._tasks`` caused ``_deliver_cancellation`` to spin at 100% CPU: ``Task.cancel()`` is a no-op for done tasks, so ``_must_cancel`` never flipped and the scope rescheduled itself forever. Skipping ``task.done()`` tasks at the top of the loop matches the proposal in the issue and breaks the spin.

## Checklist

- [x] You've added tests (in ``tests/``) which would fail without your patch
- [x] You've added a new changelog entry (in ``docs/versionhistory.rst``).