### PR TITLE
fix: raise ValueError when receive() is called with max_bytes < 1

### DIFF
--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1044,6 +1044,9 @@ class StreamReaderWrapper(abc.ByteReceiveStream):
     _stream: asyncio.StreamReader
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         data = await self._stream.read(max_bytes)
         if data:
             return data
@@ -1277,6 +1280,9 @@ class SocketStream(abc.SocketStream):
         return self._transport.get_extra_info("socket")
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         with self._receive_guard:
             if (
                 not self._protocol.read_event.is_set()
@@ -1401,6 +1407,9 @@ class UNIXSocketStream(_RawSocketMixin, abc.UNIXSocketStream):
             self._raw_socket.shutdown(socket.SHUT_WR)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         loop = get_running_loop()
         await AsyncIOBackend.checkpoint()
         with self._receive_guard:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -388,6 +388,9 @@ class SocketStream(_TrioSocketMixin, abc.SocketStream):
         self._send_guard = ResourceGuard("writing to")
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         with self._receive_guard:
             try:
                 data = await self._trio_socket.recv(max_bytes)

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -531,7 +531,9 @@ class TestTCPStream:
         self, server_addr: tuple[str, int], max_bytes: int
     ) -> None:
         async with await connect_tcp(*server_addr) as stream:
-            with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
                 await stream.receive(max_bytes)
 
     async def test_send_after_close(self, server_addr: tuple[str, int]) -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -526,6 +526,14 @@ class TestTCPStream:
         with pytest.raises(ClosedResourceError):
             await stream.receive()
 
+    @pytest.mark.parametrize("max_bytes", [0, -1])
+    async def test_receive_invalid_max_bytes(
+        self, server_addr: tuple[str, int], max_bytes: int
+    ) -> None:
+        async with await connect_tcp(*server_addr) as stream:
+            with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+                await stream.receive(max_bytes)
+
     async def test_send_after_close(self, server_addr: tuple[str, int]) -> None:
         stream = await connect_tcp(*server_addr)
         await stream.aclose()


### PR DESCRIPTION
## Problem

Calling \eceive(max_bytes=0)\ or \eceive(max_bytes=-1)\ silently passes 0 or a negative value to the underlying OS recv() call. On most platforms this raises an obscure OSError or returns empty bytes — neither is as informative as a ValueError.

The anyio docs state max_bytes must be a positive integer, but this contract is not enforced at runtime.

## Fix

Add an explicit guard at the top of every receive() implementation across both backends:
- StreamReaderWrapper.receive() (asyncio)
- SocketStream.receive() (asyncio)  
- UNIXSocketStream.receive() (asyncio)
- SocketStream.receive() (trio)

## Test

Added test_receive_invalid_max_bytes parametrized with 0 and -1 in tests/test_sockets.py.