### PR TITLE
Fix asyncio lock waiter deadlocks after cancellation

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -82,7 +82,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#1161 <https://github.com/agronholm/anyio/pull/1161>`_; PR by @Zac-HD)
 - Fixed asyncio ``Lock`` and ``Semaphore`` deadlocks caused by cancelled waiters
   left queued during release
-  (`#1145 <https://github.com/agronholm/anyio/pull/1145>`_; PR by @rasmusfaber)
+  (`#1145 <https://github.com/agronholm/anyio/pull/1145>`_; PR by @rasmusfaber,
+   @x42005e1f and @agronholm)
 
 **4.13.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -25,9 +25,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed cancellation exception escaping a cancel scope when triggered via
   ``check_cancelled()`` in a worker thread
   (`#1113 <https://github.com/agronholm/anyio/issues/1113>`_)
-- Fixed asyncio ``Lock`` and ``Semaphore`` deadlocks caused by cancelled waiters
-  left queued during release
-  (`#1145 <https://github.com/agronholm/anyio/pull/1145>`_; PR by @rasmusfaber)
 - Fixed ``TaskGroup`` raising ``AttributeError`` instead of a clear error when entered
   more than once
   (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @bahtya)
@@ -42,6 +39,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``SocketListener.from_socket()`` returning a TCP listener for ``AF_UNIX``
   listening sockets, causing ``accept()`` to fail with ``ENOTSUP``
   (`#1132 <https://github.com/agronholm/anyio/issues/1132>`_; PR by @kudato)
+- Fixed asyncio ``Lock`` and ``Semaphore`` deadlocks caused by cancelled waiters
+  left queued during release
+  (`#1145 <https://github.com/agronholm/anyio/pull/1145>`_; PR by @rasmusfaber)
 
 **4.13.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -83,7 +83,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed asyncio ``Lock`` and ``Semaphore`` deadlocks caused by cancelled waiters
   left queued during release
   (`#1145 <https://github.com/agronholm/anyio/pull/1145>`_; PR by @rasmusfaber,
-   @x42005e1f and @agronholm)
+  @x42005e1f and @agronholm)
 
 **4.13.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -25,6 +25,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed cancellation exception escaping a cancel scope when triggered via
   ``check_cancelled()`` in a worker thread
   (`#1113 <https://github.com/agronholm/anyio/issues/1113>`_)
+- Fixed asyncio ``Lock`` and ``Semaphore`` deadlocks caused by cancelled waiters
+  left queued during release
+  (`#1145 <https://github.com/agronholm/anyio/pull/1145>`_; PR by @rasmusfaber)
 - Fixed ``TaskGroup`` raising ``AttributeError`` instead of a clear error when entered
   more than once
   (`#1109 <https://github.com/agronholm/anyio/issues/1109>`_; PR by @bahtya)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1880,12 +1880,12 @@ class Lock(BaseLock):
         try:
             await fut
         except CancelledError:
-            try:
-                self._waiters.remove(item)
-            except ValueError:
-                pass
-
-            if self._owner_task is task:
+            if fut.cancelled():
+                try:
+                    self._waiters.remove(item)
+                except ValueError:
+                    pass
+            else:
                 self.release()
 
             raise
@@ -1973,11 +1973,13 @@ class Semaphore(BaseSemaphore):
         try:
             await fut
         except CancelledError:
-            try:
-                self._waiters.remove(fut)
-            except ValueError:
-                if not fut.cancelled():
-                    self.release()
+            if fut.cancelled():
+                try:
+                    self._waiters.remove(fut)
+                except ValueError:
+                    pass
+            else:
+                self.release()
 
             raise
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1845,7 +1845,11 @@ class Lock(BaseLock):
         try:
             await fut
         except CancelledError:
-            self._waiters.remove(item)
+            try:
+                self._waiters.remove(item)
+            except ValueError:
+                pass
+
             if self._owner_task is task:
                 self.release()
 
@@ -1871,11 +1875,18 @@ class Lock(BaseLock):
         if self._owner_task != current_task():
             raise RuntimeError("The current task is not holding this lock")
 
-        for task, fut in self._waiters:
-            if not fut.cancelled():
-                self._owner_task = task
-                fut.set_result(None)
-                return
+        # A cancelled waiter that already received ownership removes itself from
+        # _waiters before calling release(); any cancelled waiter still queued here
+        # was cancelled before being woken, so drop it.
+        while self._waiters:
+            task, fut = self._waiters[0]
+            if fut.cancelled():
+                self._waiters.popleft()
+                continue
+
+            self._owner_task = task
+            fut.set_result(None)
+            return
 
         self._owner_task = None
 
@@ -1931,7 +1942,8 @@ class Semaphore(BaseSemaphore):
             try:
                 self._waiters.remove(fut)
             except ValueError:
-                self.release()
+                if not fut.cancelled():
+                    self.release()
 
             raise
 
@@ -1945,11 +1957,15 @@ class Semaphore(BaseSemaphore):
         if self._max_value is not None and self._value == self._max_value:
             raise ValueError("semaphore released too many times")
 
-        for fut in self._waiters:
-            if not fut.cancelled():
-                fut.set_result(None)
-                self._waiters.remove(fut)
-                return
+        while self._waiters:
+            fut = self._waiters[0]
+            if fut.cancelled():
+                self._waiters.popleft()
+                continue
+
+            fut.set_result(None)
+            self._waiters.popleft()
+            return
 
         self._value += 1
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1890,8 +1890,6 @@ class Lock(BaseLock):
 
             raise
 
-        self._waiters.remove(item)
-
     def acquire_nowait(self) -> None:
         task = cast(asyncio.Task, current_task())
         if self._owner_task is None and not self._waiters:
@@ -1914,9 +1912,8 @@ class Lock(BaseLock):
         # _waiters before calling release(); any cancelled waiter still queued here
         # was cancelled before being woken, so drop it.
         while self._waiters:
-            task, fut = self._waiters[0]
+            task, fut = self._waiters.popleft()
             if fut.cancelled():
-                self._waiters.popleft()
                 continue
 
             self._owner_task = task
@@ -1995,13 +1992,11 @@ class Semaphore(BaseSemaphore):
             raise ValueError("semaphore released too many times")
 
         while self._waiters:
-            fut = self._waiters[0]
+            fut = self._waiters.popleft()
             if fut.cancelled():
-                self._waiters.popleft()
                 continue
 
             fut.set_result(None)
-            self._waiters.popleft()
             return
 
         self._value += 1

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -13,6 +13,7 @@ from anyio import (
     Event,
     Lock,
     Semaphore,
+    TaskCancelled,
     WouldBlock,
     create_task_group,
     fail_after,
@@ -213,6 +214,47 @@ class TestLock:
         assert statistics.owner is None
         assert statistics.tasks_waiting == 0
         lock.acquire_nowait()
+
+    async def test_cancelled_head_waiter_does_not_orphan_later_waiter(
+        self,
+    ) -> None:
+        lock = Lock()
+        lock.acquire_nowait()
+        gate = Event()
+        last_task_acquired = False
+
+        async def acquire_after_gate() -> None:
+            nonlocal last_task_acquired
+            await gate.wait()
+            await lock.acquire()
+            try:
+                last_task_acquired = True
+            finally:
+                lock.release()
+
+        async with create_task_group() as tg:
+            task1 = tg.create_task(lock.acquire())
+            task2 = tg.create_task(lock.acquire())
+            last_task = tg.create_task(acquire_after_gate())
+            await wait_all_tasks_blocked()
+            assert lock.statistics().tasks_waiting == 2
+
+            gate.set()
+            task1.cancel()
+            task2.cancel()
+            lock.release()
+            with fail_after(1):
+                await last_task
+
+            with pytest.raises(TaskCancelled):
+                await task1
+
+            with pytest.raises(TaskCancelled):
+                await task2
+
+        assert last_task_acquired
+        assert not lock.locked()
+        assert lock.statistics().tasks_waiting == 0
 
     def test_instantiate_outside_event_loop(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
@@ -660,6 +702,63 @@ class TestSemaphore:
         assert semaphore.value == 1
         assert semaphore.statistics().tasks_waiting == 0
         semaphore.acquire_nowait()
+
+    async def test_cancelled_head_waiter_does_not_orphan_later_waiter(
+        self,
+    ) -> None:
+        semaphore = Semaphore(0, max_value=1)
+        gate = Event()
+        last_task_acquired = False
+
+        async def acquire_after_gate() -> None:
+            nonlocal last_task_acquired
+            await gate.wait()
+            await semaphore.acquire()
+            try:
+                last_task_acquired = True
+            finally:
+                semaphore.release()
+
+        async with create_task_group() as tg:
+            task1 = tg.create_task(semaphore.acquire())
+            task2 = tg.create_task(semaphore.acquire())
+            last_task = tg.create_task(acquire_after_gate())
+            await wait_all_tasks_blocked()
+            assert semaphore.statistics().tasks_waiting == 2
+
+            gate.set()
+            task1.cancel()
+            task2.cancel()
+            semaphore.release()
+            with fail_after(1):
+                await last_task
+
+            with pytest.raises(TaskCancelled):
+                await task1
+
+            with pytest.raises(TaskCancelled):
+                await task2
+
+        assert last_task_acquired
+        assert semaphore.value == 1
+        assert semaphore.statistics().tasks_waiting == 0
+
+    async def test_cancelled_head_waiter_does_not_overrelease(self) -> None:
+        semaphore = Semaphore(0)
+
+        async with create_task_group() as tg:
+            task = tg.create_task(semaphore.acquire())
+            await wait_all_tasks_blocked()
+            assert semaphore.statistics().tasks_waiting == 1
+
+            task.cancel()
+            semaphore.release()
+
+            with pytest.raises(TaskCancelled):
+                await task
+
+        assert semaphore.value == 1
+        assert semaphore.statistics().tasks_waiting == 0
 
     def test_instantiate_outside_event_loop(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -13,7 +13,6 @@ from anyio import (
     Event,
     Lock,
     Semaphore,
-    TaskCancelled,
     WouldBlock,
     create_task_group,
     fail_after,
@@ -215,46 +214,17 @@ class TestLock:
         assert statistics.tasks_waiting == 0
         lock.acquire_nowait()
 
-    async def test_cancelled_head_waiter_does_not_orphan_later_waiter(
-        self,
-    ) -> None:
+    async def test_cancelled_after_acquire(self) -> None:
         lock = Lock()
         lock.acquire_nowait()
-        gate = Event()
-        last_task_acquired = False
-
-        async def acquire_after_gate() -> None:
-            nonlocal last_task_acquired
-            await gate.wait()
-            await lock.acquire()
-            try:
-                last_task_acquired = True
-            finally:
-                lock.release()
-
         async with create_task_group() as tg:
             task1 = tg.create_task(lock.acquire())
-            task2 = tg.create_task(lock.acquire())
-            last_task = tg.create_task(acquire_after_gate())
             await wait_all_tasks_blocked()
-            assert lock.statistics().tasks_waiting == 2
-
-            gate.set()
             task1.cancel()
-            task2.cancel()
             lock.release()
-            with fail_after(1):
-                await last_task
-
-            with pytest.raises(TaskCancelled):
-                await task1
-
-            with pytest.raises(TaskCancelled):
-                await task2
-
-        assert last_task_acquired
-        assert not lock.locked()
-        assert lock.statistics().tasks_waiting == 0
+            assert lock.statistics().tasks_waiting == 0
+            with fail_after(3):
+                await lock.acquire()
 
     def test_instantiate_outside_event_loop(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
@@ -703,62 +673,17 @@ class TestSemaphore:
         assert semaphore.statistics().tasks_waiting == 0
         semaphore.acquire_nowait()
 
-    async def test_cancelled_head_waiter_does_not_orphan_later_waiter(
-        self,
-    ) -> None:
-        semaphore = Semaphore(0, max_value=1)
-        gate = Event()
-        last_task_acquired = False
-
-        async def acquire_after_gate() -> None:
-            nonlocal last_task_acquired
-            await gate.wait()
-            await semaphore.acquire()
-            try:
-                last_task_acquired = True
-            finally:
-                semaphore.release()
-
+    async def test_cancelled_after_acquire(self) -> None:
+        semaphore = Semaphore(1, max_value=1)
+        semaphore.acquire_nowait()
         async with create_task_group() as tg:
             task1 = tg.create_task(semaphore.acquire())
-            task2 = tg.create_task(semaphore.acquire())
-            last_task = tg.create_task(acquire_after_gate())
             await wait_all_tasks_blocked()
-            assert semaphore.statistics().tasks_waiting == 2
-
-            gate.set()
             task1.cancel()
-            task2.cancel()
             semaphore.release()
-            with fail_after(1):
-                await last_task
-
-            with pytest.raises(TaskCancelled):
-                await task1
-
-            with pytest.raises(TaskCancelled):
-                await task2
-
-        assert last_task_acquired
-        assert semaphore.value == 1
-        assert semaphore.statistics().tasks_waiting == 0
-
-    async def test_cancelled_head_waiter_does_not_overrelease(self) -> None:
-        semaphore = Semaphore(0)
-
-        async with create_task_group() as tg:
-            task = tg.create_task(semaphore.acquire())
-            await wait_all_tasks_blocked()
-            assert semaphore.statistics().tasks_waiting == 1
-
-            task.cancel()
-            semaphore.release()
-
-            with pytest.raises(TaskCancelled):
-                await task
-
-        assert semaphore.value == 1
-        assert semaphore.statistics().tasks_waiting == 0
+            assert semaphore.statistics().tasks_waiting == 0
+            with fail_after(3):
+                await semaphore.acquire()
 
     def test_instantiate_outside_event_loop(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Cancelled asyncio lock/semaphore waiters can be observed by `release()` before their `acquire()` cleanup has removed them from the wait queue. In that window, `release()` skipped the cancelled waiter but left it queued, allowing a later live waiter to become stranded with no future release to wake it.

This PR prunes cancelled waiters during asyncio `Lock` and `Semaphore` release, while preserving the existing cancellation-after-handoff behavior. It also adds regression coverage for the interleaving where a cancelled head waiter would otherwise orphan a later waiter.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
