### PR TITLE
implement future container types

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -46,6 +46,10 @@ Task groups
 .. autoclass:: anyio.abc.TaskGroup
 .. autoclass:: anyio.abc.TaskStatus
 
+Future objects
+--------------
+.. autoclass:: anyio.Future
+
 Running code in worker threads
 ------------------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -48,10 +48,6 @@ Task groups
 .. autoclass:: anyio.abc.TaskGroup
 .. autoclass:: anyio.abc.TaskStatus
 
-Future objects
---------------
-.. autoclass:: anyio.Future
-
 Running code in worker threads
 ------------------------------
 
@@ -198,6 +194,7 @@ Synchronization
 ---------------
 
 .. autoclass:: anyio.Event
+.. autoclass:: anyio.Future
 .. autoclass:: anyio.Lock
 .. autoclass:: anyio.Condition
 .. autoclass:: anyio.Semaphore

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added an implementation of the ``asyncio.Future`` object for single pending objects.
+  (`#1146 <https://github.com/agronholm/anyio/pull/1146>`_; PR by @Vizonex)
 - Added an asynchronous implementation of the ``itertools`` module
   (`#998 <https://github.com/agronholm/anyio/issues/998>`_; PR by @11kkw)
 - Added the ``local_port`` parameter to :func:`connect_tcp` to allow binding to a

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added the ``anyio.Future`` synchronization primitive which behaves similar to
+  ``asyncio.Future``, allowing tasks to wait for a value (or exception) from another
+  task (`#1146 <https://github.com/agronholm/anyio/pull/1146>`_; PR by @Vizonex)
 - Added the ``move_on_at()`` and ``fail_at()`` functions to complement
   ``move_on_after()`` and ``fail_after()``
 - Changed the default name for a task spawned with ``TaskGroup.create_task(func())`` to
@@ -84,8 +87,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **4.14.0**
 
-- Added an implementation of the ``asyncio.Future`` object for single pending objects.
-  (`#1146 <https://github.com/agronholm/anyio/pull/1146>`_; PR by @Vizonex)
 - Added support for Python 3.15
 - Added an asynchronous implementation of the ``itertools`` module
   (`#998 <https://github.com/agronholm/anyio/issues/998>`_; PR by @11kkw)

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -20,7 +20,6 @@ from ._core._exceptions import DelimiterNotFound as DelimiterNotFound
 from ._core._exceptions import EndOfStream as EndOfStream
 from ._core._exceptions import FutureAlreadyFinished as FutureAlreadyFinished
 from ._core._exceptions import FutureCancelled as FutureCancelled
-from ._core._exceptions import FutureNotFinished as FutureNotFinished
 from ._core._exceptions import IncompleteRead as IncompleteRead
 from ._core._exceptions import NoEventLoopError as NoEventLoopError
 from ._core._exceptions import RunFinishedError as RunFinishedError

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -18,6 +18,9 @@ from ._core._exceptions import ClosedResourceError as ClosedResourceError
 from ._core._exceptions import ConnectionFailed as ConnectionFailed
 from ._core._exceptions import DelimiterNotFound as DelimiterNotFound
 from ._core._exceptions import EndOfStream as EndOfStream
+from ._core._exceptions import FutureAlreadyFinished as FutureAlreadyFinished
+from ._core._exceptions import FutureCancelled as FutureCancelled
+from ._core._exceptions import FutureNotFinished as FutureNotFinished
 from ._core._exceptions import IncompleteRead as IncompleteRead
 from ._core._exceptions import NoEventLoopError as NoEventLoopError
 from ._core._exceptions import RunFinishedError as RunFinishedError
@@ -30,6 +33,7 @@ from ._core._fileio import AsyncFile as AsyncFile
 from ._core._fileio import Path as Path
 from ._core._fileio import open_file as open_file
 from ._core._fileio import wrap_file as wrap_file
+from ._core._futures import Future as Future
 from ._core._resources import aclose_forcefully as aclose_forcefully
 from ._core._signals import open_signal_receiver as open_signal_receiver
 from ._core._sockets import TCPConnectable as TCPConnectable

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -20,6 +20,8 @@ from ._core._exceptions import DelimiterNotFound as DelimiterNotFound
 from ._core._exceptions import EndOfStream as EndOfStream
 from ._core._exceptions import FutureAlreadyFinished as FutureAlreadyFinished
 from ._core._exceptions import FutureCancelled as FutureCancelled
+from ._core._exceptions import FutureFailed as FutureFailed
+from ._core._exceptions import FutureNotFinished as FutureNotFinished
 from ._core._exceptions import IncompleteRead as IncompleteRead
 from ._core._exceptions import NoEventLoopError as NoEventLoopError
 from ._core._exceptions import RunFinishedError as RunFinishedError

--- a/src/anyio/_core/_exceptions.py
+++ b/src/anyio/_core/_exceptions.py
@@ -180,7 +180,7 @@ class TaskNotFinished(Exception):
 class FutureCancelled(Exception):
     """
     Raised when attempting to access the return value or exception of a
-    :class `.Future`: that is still pending completion.
+    :class:`.Future` that is still pending completion.
     """
 
 

--- a/src/anyio/_core/_exceptions.py
+++ b/src/anyio/_core/_exceptions.py
@@ -183,11 +183,13 @@ class FutureCancelled(Exception):
     :class `.Future`: that is still pending completion.
     """
 
+
 class FutureNotFinished(Exception):
     """
     Raised when attempting to access the return value or exception of a
     :class:`.Future` that is still pending completion.
     """
+
 
 class FutureAlreadyFinished(Exception):
     """

--- a/src/anyio/_core/_exceptions.py
+++ b/src/anyio/_core/_exceptions.py
@@ -184,13 +184,6 @@ class FutureCancelled(Exception):
     """
 
 
-class FutureNotFinished(Exception):
-    """
-    Raised when attempting to access the return value or exception of a
-    :class:`.Future` that is still pending completion.
-    """
-
-
 class FutureAlreadyFinished(Exception):
     """
     Raised when attempting set a result of or await a

--- a/src/anyio/_core/_exceptions.py
+++ b/src/anyio/_core/_exceptions.py
@@ -180,7 +180,7 @@ class TaskNotFinished(Exception):
 class FutureCancelled(Exception):
     """
     Raised when attempting to access the return value or exception of a
-    :class:`.Future` that is still pending completion.
+    :class:`.Future` that was cancelled.
     """
 
 

--- a/src/anyio/_core/_exceptions.py
+++ b/src/anyio/_core/_exceptions.py
@@ -179,7 +179,7 @@ class TaskNotFinished(Exception):
 
 class FutureCancelled(Exception):
     """
-    Rasied when attempting to access the return value or exception of a
+    Raised when attempting to access the return value or exception of a
     :class `.Future`: that is still pending completion.
     """
 

--- a/src/anyio/_core/_exceptions.py
+++ b/src/anyio/_core/_exceptions.py
@@ -175,3 +175,22 @@ class TaskNotFinished(Exception):
     Raised when attempting to access the return value or exception of a
     :class:`.TaskHandle` that is still pending completion.
     """
+
+
+class FutureCancelled(Exception):
+    """
+    Rasied when attempting to access the return value or exception of a
+    :class `.Future`: that is still pending completion.
+    """
+
+class FutureNotFinished(Exception):
+    """
+    Raised when attempting to access the return value or exception of a
+    :class:`.Future` that is still pending completion.
+    """
+
+class FutureAlreadyFinished(Exception):
+    """
+    Raised when attempting set a result of or await a
+    :class:`.Future` that has already completed.
+    """

--- a/src/anyio/_core/_exceptions.py
+++ b/src/anyio/_core/_exceptions.py
@@ -177,7 +177,14 @@ class TaskNotFinished(Exception):
     """
 
 
-class FutureCancelled(Exception):
+class FutureFailed(Exception):
+    """
+    Raised when awaiting on, or attempting to access the return value of, a
+    :class:`.Future` that raised an exception.
+    """
+
+
+class FutureCancelled(FutureFailed):
     """
     Raised when attempting to access the return value or exception of a
     :class:`.Future` that was cancelled.
@@ -188,13 +195,6 @@ class FutureNotFinished(Exception):
     """
     Raised when attempting to access the return value or exception of a
     :class:`.Future` that is still pending completion.
-    """
-
-
-class FutureFailed(Exception):
-    """
-    Raised when awaiting on, or attempting to access the return value of, a
-    :class:`.Future` that raised an exception.
     """
 
 

--- a/src/anyio/_core/_exceptions.py
+++ b/src/anyio/_core/_exceptions.py
@@ -184,6 +184,20 @@ class FutureCancelled(Exception):
     """
 
 
+class FutureNotFinished(Exception):
+    """
+    Raised when attempting to access the return value or exception of a
+    :class:`.Future` that is still pending completion.
+    """
+
+
+class FutureFailed(Exception):
+    """
+    Raised when awaiting on, or attempting to access the return value of, a
+    :class:`.Future` that raised an exception.
+    """
+
+
 class FutureAlreadyFinished(Exception):
     """
     Raised when attempting set a result of or await a

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -14,6 +14,7 @@ from ._synchronization import Event
 
 T = TypeVar("T")
 
+
 class Future(Generic[T]):
     """
     An awaitable object that works similar to a :class:`asyncio.Future` but

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -47,7 +47,7 @@ class Future(Generic[T]):
             case Future.Status.PENDING:
                 return
             case Future.Status.FINISHED:
-                raise FutureAlreadyFinished("future has already finished.")
+                raise FutureAlreadyFinished("future has already finished")
             case Future.Status.FAILED:
                 raise FutureAlreadyFinished("future already failed")
             case Future.Status.CANCELLING:
@@ -81,6 +81,20 @@ class Future(Generic[T]):
         self._check_status()
         self._exception = exception
         self._finished_event.set()
+
+    def cancel(self) -> None:
+        match self.status:
+            case Future.Status.PENDING:
+                return self._cancel_scope.cancel()
+            case Future.Status.FINISHED:
+                raise FutureAlreadyFinished("future has already finished")
+            case Future.Status.FAILED:
+                raise FutureAlreadyFinished("future already failed")
+            case Future.Status.CANCELLING:
+                return
+            case Future.Status.CANCELLED:
+                return
+
 
     @property
     def exception(self) -> BaseException | None:

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -1,153 +1,144 @@
 from __future__ import annotations
 
-import sys
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Generator
 from enum import Enum, auto
-from typing import Any, TypeVar
+from typing import Any, Generic, TypeVar
 
-from .. import Event
-from ..lowlevel import RunVar
-from ._exceptions import FutureAlreadyFinished, FutureCancelled, FutureNotFinished
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
-
+from ._eventloop import get_cancelled_exc_class
+from ._exceptions import (
+    FutureAlreadyFinished,
+    FutureCancelled,
+    TaskFailed,
+    TaskNotFinished,
+)
+from ._synchronization import Event
+from ._tasks import CancelScope
 
 T = TypeVar("T")
 
 
-class Future(Awaitable[T]):
-    """A asynchronous container object for waiting on single objects to be completed."""
-
+class Future(Generic[T]):
     class Status(Enum):
+        """The status of a future handle."""
+
         PENDING = auto()
-        CANCELLED = auto()
         FINISHED = auto()
+        FAILED = auto()
+        CANCELLING = auto()
+        CANCELLED = auto()
 
-    def __init__(self) -> None:
-        self._event = Event()
-        self._state = self.Status.PENDING
-        self._result: T = None
+    __slots__ = (
+        "_result_value",
+        "_finished_event",
+        "_cancel_scope",
+        "_exception",
+        "_name",
+    )
+    _result_value: T
+
+    def __init__(self, *, name: str | None = None) -> None:
+        self._finished_event = Event()
+        self._cancel_scope = CancelScope()
         self._exception: BaseException | None = None
-        self._cancelled_exc: BaseException | None = None
+        self._name = name
 
-        self._done_callbacks: list[
-            tuple[RunVar[Any] | None, Callable[[Self], Any]]
-        ] = []
-        self._cancel_msg = None
+    def _check_status(self) -> None:
+        match self.status:
+            case Future.Status.PENDING:
+                return
+            case Future.Status.FINISHED:
+                raise FutureAlreadyFinished("future has already finished.")
+            case Future.Status.FAILED:
+                raise FutureAlreadyFinished("future already failed")
+            case Future.Status.CANCELLING:
+                raise FutureCancelled("future was cancelled")
+            case Future.Status.CANCELLED:
+                raise FutureCancelled("future was cancelled") from self._exception
 
-    def __check_not_done(self) -> None:
-        if self._state != self.Status.PENDING:
-            raise FutureAlreadyFinished("Future has already finished.")
+    async def wait(self) -> None:
+        """
+        Waits for the future to finish.
 
-    def __check_done(self) -> None:
-        if self._state == self.Status.CANCELLED:
-            exc = self._make_cancelled_error()
-            raise exc
-        if self._state != self.Status.FINISHED:
-            raise FutureNotFinished("Result is not ready.")
+        This method will attempt to wait for a result or exception
+        """
+        with self._cancel_scope:
+            try:
+                await self._finished_event.wait()
+            except BaseException as e:
+                self._exception = e
+                raise
+            finally:
+                self._finished_event.set()
 
-    def __schedule_callbacks(self) -> None:
-        # set event so that anything awaiting this object
-        # can be notified that it is now ready for use.
-        self._event.set()
-        for rv, cb in self._done_callbacks:
-            if rv:
-                with rv:
-                    cb(self)
-            else:
-                cb(self)
-
-    def cancel(self, msg=None) -> bool:
-        """Cancel the future and schedules callbacks"""
-        if self._state != self.Status.PENDING:
-            return False
-        self._state = self.Status.CANCELLED
-        self._cancel_msg = msg
-        self.__schedule_callbacks()
-        return True
-
-    def done(self) -> bool:
-        """Return True if future was completed."""
-        return self._state != self.Status.PENDING
-
-    def cancelled(self):
-        """Return True if future was cancelled."""
-        return self._state != self.Status.CANCELLED
-
-    def _make_cancelled_error(self) -> FutureCancelled:
-        """Creates a :class:`.FutureCancelled` exception."""
-        if self._cancelled_exc is not None:
-            exc = self._cancelled_exc
-            self._cancelled_exc = None
-            return exc
-
-        exc = (
-            FutureCancelled()
-            if self._cancel_msg is not None
-            else FutureCancelled(self._cancel_msg)
-        )
-        exc.__context__ = self._cancelled_exc
-        self._cancelled_exc = None
-        return exc
-
-    def result(self) -> T:
-        """Gets the result of a :class:`.Future` if completed."""
-        self.__check_done()
-        if self._exception is not None:
-            raise self._exception
-        return self._result
-
-    def exception(self) -> BaseException | None:
-        """Gets the exception of a :class:`.Future` if completed it will be done if there is instead a successful result."""
-        self.__check_done()
-        return self._exception
-
-    def add_done_callback(
-        self, fn: Callable[[Self], Any], *, context: RunVar[Self] | None = None
-    ) -> None:
-        """Creates a synchronous callback for when a future is considered as being completed or not."""
-        if self._state != self.Status.PENDING:
-            if context:
-                with context:
-                    fn(self)
-            else:
-                fn(self)
-        else:
-            self._done_callbacks.append((context, fn))
-
-    def remove_done_callback(self, fn: Callable[[Self], Any]):
-        filtered_callbacks = [(f, ctx) for (f, ctx) in self._done_callbacks if f != fn]
-        removed_count = len(self._done_callbacks) - len(filtered_callbacks)
-        if removed_count:
-            self._done_callbacks[:] = filtered_callbacks
-        return removed_count
-
-    def set_result(self, result: T) -> None:
-        """sets the results of a :class:`.Future` object."""
-        self.__check_not_done()
-        self._result = result
-        self._state = self.Status.FINISHED
-        self.__schedule_callbacks()
+    def set_result(self, value: T) -> None:
+        """Send pending result for a container object"""
+        self._check_status()
+        self._result_value = value
+        self._finished_event.set()
 
     def set_exception(self, exception: BaseException) -> None:
-        """sets the exception of a :class:`.Future` object."""
-        self.__check_not_done()
+        """Send exception result for a container object"""
+        self._check_status()
         self._exception = exception
-        self._state = self.Status.FINISHED
-        self.__schedule_callbacks()
+        self._finished_event.set()
 
-    # Mostly used as a proxy for awaiting on a pending object.
-    async def wait(self) -> T:
-        await self._event.wait()
-        return self.result()
+    @property
+    def exception(self) -> BaseException | None:
+        match self.status:
+            case Future.Status.PENDING:
+                raise TaskNotFinished("the future has not finished yet")
+            case Future.Status.FINISHED:
+                return None
+            case Future.Status.CANCELLING:
+                raise FutureCancelled("the future was cancelled")
+            case Future.Status.CANCELLED:
+                raise FutureCancelled("the future was cancelled") from self._exception
+            case Future.Status.FAILED:
+                return self._exception
 
-    def __await__(self) -> Generator[Any, None, T]:
-        return self.wait().__await__()
+    @property
+    def return_value(self) -> T:
+        """
+        The return value of the future.
 
+        :raises TaskNotFinished: if the future has not finished yet
+        :raises FutureCancelled: if the future was cancelled
+        :raises TaskFailed: if the future raised an exception
 
-def create_future() -> Future[T]:
-    """Shortcut method for creating a new :class:`.Future` object."""
-    return Future()
+        """
+        match self.status:
+            case Future.Status.PENDING:
+                raise TaskNotFinished("the future has not finished yet")
+            case Future.Status.FINISHED:
+                return self._result_value
+            case Future.Status.CANCELLING:
+                raise FutureCancelled("the future was cancelled")
+            case Future.Status.CANCELLED:
+                raise FutureCancelled("the future was cancelled") from self._exception
+            case Future.Status.FAILED:
+                raise TaskFailed("the future raised an exception") from self._exception
+
+    @property
+    def status(self) -> Future.Status:
+        if not self._finished_event.is_set():
+            if self._cancel_scope.cancel_called:
+                return Future.Status.CANCELLING
+            else:
+                return Future.Status.PENDING
+        elif self._exception is not None:
+            if isinstance(self._exception, get_cancelled_exc_class()):
+                return Future.Status.CANCELLED
+            else:
+                return Future.Status.FAILED
+        else:
+            return Future.Status.FINISHED
+
+    def __await__(self) -> Generator[Any, Any, T]:
+        yield from self.wait().__await__()
+        return self.return_value
+
+    def __repr__(self) -> str:
+        return (
+            f"<{self.__class__.__name__} {self.status.name.lower()} "
+            f"name={self._name!r}>"
+        )

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -93,10 +93,8 @@ class Future(Generic[T]):
             try:
                 await self._finished_event.wait()
             except BaseException as e:
-                self._exception = e
+                self.set_exception(e)
                 raise
-            finally:
-                self._finished_event.set()
 
     def set_result(self, value: T) -> None:
         """

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -107,11 +107,11 @@ class Future(Generic[T]):
     def cancel(self) -> None:
         """Cancels a pending `.Future` object
 
-        :raises FutureAlreadyFinished: if future was already given a result or exception.
+        Does nothing if the Future was already finished.
         """
-        self._check_pending()
-        self._cancelled = True
-        self._finished_event.set()
+        if self.status is Future.Status.PENDING:
+            self._cancelled = True
+            self._finished_event.set()
 
     @property
     def exception(self) -> BaseException | None:

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -4,7 +4,6 @@ from collections.abc import Generator
 from enum import Enum, auto
 from typing import Any, Generic, TypeVar
 
-from ._eventloop import get_cancelled_exc_class
 from ._exceptions import (
     FutureAlreadyFinished,
     FutureCancelled,
@@ -12,10 +11,8 @@ from ._exceptions import (
     TaskNotFinished,
 )
 from ._synchronization import Event
-from ._tasks import CancelScope
 
 T = TypeVar("T")
-
 
 class Future(Generic[T]):
     """
@@ -33,9 +30,6 @@ class Future(Generic[T]):
         .. attribute:: FINISHED
 
             The future has finished with a return value.
-        .. attribute:: CANCELLING
-
-            The future has been cancelled but has not finished yet.
         .. attribute:: CANCELLED
 
             The future was cancelled and has finished since.
@@ -46,14 +40,13 @@ class Future(Generic[T]):
 
         PENDING = auto()
         FINISHED = auto()
-        CANCELLING = auto()
         CANCELLED = auto()
         FAILED = auto()
 
     __slots__ = (
+        "_cancelled",
         "_result_value",
         "_finished_event",
-        "_cancel_scope",
         "_exception",
         "_name",
     )
@@ -61,8 +54,8 @@ class Future(Generic[T]):
 
     def __init__(self, *, name: str | None = None) -> None:
         self._finished_event = Event()
-        self._cancel_scope = CancelScope()
         self._exception: BaseException | None = None
+        self._cancelled: bool = False
         self._name = name
 
     def _check_pending(self) -> None:
@@ -78,10 +71,8 @@ class Future(Generic[T]):
                 raise FutureAlreadyFinished("future has already finished")
             case Future.Status.FAILED:
                 raise FutureAlreadyFinished("future already failed")
-            case Future.Status.CANCELLING:
-                raise FutureCancelled("future was cancelled")
             case Future.Status.CANCELLED:
-                raise FutureCancelled("future was cancelled") from self._exception
+                raise FutureCancelled("future was cancelled")
 
     async def wait(self) -> None:
         """
@@ -89,12 +80,7 @@ class Future(Generic[T]):
 
         This method will attempt to wait for a result or exception
         """
-        with self._cancel_scope:
-            try:
-                await self._finished_event.wait()
-            except BaseException as e:
-                self.set_exception(e)
-                raise
+        await self._finished_event.wait()
 
     def set_result(self, value: T) -> None:
         """
@@ -120,19 +106,11 @@ class Future(Generic[T]):
     def cancel(self) -> None:
         """Cancels a pending `.Future` object
 
-        :raises FutureAlreadyFinished: if future was already given a result or exception.
+        Does nothing if the Future was already finished.
         """
-        match self.status:
-            case Future.Status.PENDING:
-                return self._cancel_scope.cancel()
-            case Future.Status.FINISHED:
-                raise FutureAlreadyFinished("future has already finished")
-            case Future.Status.FAILED:
-                raise FutureAlreadyFinished("future already failed")
-            case Future.Status.CANCELLING:
-                return
-            case Future.Status.CANCELLED:
-                return
+        if self.status is Future.Status.PENDING:
+            self._cancelled = True
+            self._finished_event.set()
 
     @property
     def exception(self) -> BaseException | None:
@@ -150,10 +128,8 @@ class Future(Generic[T]):
                 raise TaskNotFinished("the future has not finished yet")
             case Future.Status.FINISHED:
                 return None
-            case Future.Status.CANCELLING:
-                raise FutureCancelled("the future was cancelled")
             case Future.Status.CANCELLED:
-                raise FutureCancelled("the future was cancelled") from self._exception
+                raise FutureCancelled("the future was cancelled")
             case Future.Status.FAILED:
                 return self._exception
 
@@ -172,10 +148,8 @@ class Future(Generic[T]):
                 raise TaskNotFinished("the future has not finished yet")
             case Future.Status.FINISHED:
                 return self._result_value
-            case Future.Status.CANCELLING:
-                raise FutureCancelled("the future was cancelled")
             case Future.Status.CANCELLED:
-                raise FutureCancelled("the future was cancelled") from self._exception
+                raise FutureCancelled("the future was cancelled")
             case Future.Status.FAILED:
                 raise TaskFailed("the future raised an exception") from self._exception
 
@@ -193,15 +167,11 @@ class Future(Generic[T]):
         raised, if any. No other status transitions will happen.
         """
         if not self._finished_event.is_set():
-            if self._cancel_scope.cancel_called:
-                return Future.Status.CANCELLING
-            else:
-                return Future.Status.PENDING
+            return Future.Status.PENDING
+        elif self._cancelled:
+            return Future.Status.CANCELLED
         elif self._exception is not None:
-            if isinstance(self._exception, get_cancelled_exc_class()):
-                return Future.Status.CANCELLED
-            else:
-                return Future.Status.FAILED
+            return Future.Status.FAILED
         else:
             return Future.Status.FINISHED
 

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -17,8 +17,10 @@ else:
 
 T = TypeVar("T")
 
+
 class Future(Awaitable[T]):
     """A asynchronous container object for waiting on single objects to be completed."""
+
     class Status(Enum):
         PENDING = auto()
         CANCELLED = auto()
@@ -31,7 +33,9 @@ class Future(Awaitable[T]):
         self._exception: BaseException | None = None
         self._cancelled_exc: BaseException | None = None
 
-        self._done_callbacks: list[tuple[RunVar[Any] | None , Callable[[Self], Any]]] = []
+        self._done_callbacks: list[
+            tuple[RunVar[Any] | None, Callable[[Self], Any]]
+        ] = []
         self._cancel_msg = None
 
     def __check_not_done(self) -> None:
@@ -80,7 +84,11 @@ class Future(Awaitable[T]):
             self._cancelled_exc = None
             return exc
 
-        exc = FutureCancelled() if self._cancel_msg is not None else FutureCancelled(self._cancel_msg)
+        exc = (
+            FutureCancelled()
+            if self._cancel_msg is not None
+            else FutureCancelled(self._cancel_msg)
+        )
         exc.__context__ = self._cancelled_exc
         self._cancelled_exc = None
         return exc
@@ -97,7 +105,9 @@ class Future(Awaitable[T]):
         self.__check_done()
         return self._exception
 
-    def add_done_callback(self, fn: Callable[[Self], Any], *, context: RunVar[Self] | None = None) -> None:
+    def add_done_callback(
+        self, fn: Callable[[Self], Any], *, context: RunVar[Self] | None = None
+    ) -> None:
         """Creates a synchronous callback for when a future is considered as being completed or not."""
         if self._state != self.Status.PENDING:
             if context:
@@ -109,9 +119,7 @@ class Future(Awaitable[T]):
             self._done_callbacks.append((context, fn))
 
     def remove_done_callback(self, fn: Callable[[Self], Any]):
-        filtered_callbacks = [(f, ctx)
-                              for (f, ctx) in self._done_callbacks
-                              if f != fn]
+        filtered_callbacks = [(f, ctx) for (f, ctx) in self._done_callbacks if f != fn]
         removed_count = len(self._done_callbacks) - len(filtered_callbacks)
         if removed_count:
             self._done_callbacks[:] = filtered_callbacks
@@ -138,6 +146,7 @@ class Future(Awaitable[T]):
 
     def __await__(self) -> Generator[Any, None, T]:
         return self.wait().__await__()
+
 
 def create_future() -> Future[T]:
     """Shortcut method for creating a new :class:`.Future` object."""

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -16,11 +16,13 @@ from ._tasks import CancelScope
 
 T = TypeVar("T")
 
+
 class Future(Generic[T]):
     """
     An awaitable object that works simillar to a :class:`asyncio.Future` but
     with simillar characteristics to a :class:`.TaskHandle`.
     """
+
     class Status(Enum):
         """
         The status of a future handle.

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Awaitable, Callable, Generator
+from enum import Enum, auto
+from typing import Any, TypeVar
+
+from .. import Event
+from ..lowlevel import RunVar
+from ._exceptions import FutureAlreadyFinished, FutureCancelled, FutureNotFinished
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+
+T = TypeVar("T")
+
+class Future(Awaitable[T]):
+    """A asynchronous container object for waiting on single objects to be completed."""
+    class Status(Enum):
+        PENDING = auto()
+        CANCELLED = auto()
+        FINISHED = auto()
+
+    def __init__(self) -> None:
+        self._event = Event()
+        self._state = self.Status.PENDING
+        self._result: T = None
+        self._exception: BaseException | None = None
+        self._cancelled_exc: BaseException | None = None
+
+        self._done_callbacks: list[tuple[RunVar[Any] | None , Callable[[Self], Any]]] = []
+        self._cancel_msg = None
+
+    def __check_not_done(self) -> None:
+        if self._state != self.Status.PENDING:
+            raise FutureAlreadyFinished("Future has already finished.")
+
+    def __check_done(self) -> None:
+        if self._state == self.Status.CANCELLED:
+            exc = self._make_cancelled_error()
+            raise exc
+        if self._state != self.Status.FINISHED:
+            raise FutureNotFinished("Result is not ready.")
+
+    def __schedule_callbacks(self) -> None:
+        # set event so that anything awaiting this object
+        # can be notified that it is now ready for use.
+        self._event.set()
+        for rv, cb in self._done_callbacks:
+            if rv:
+                with rv:
+                    cb(self)
+            else:
+                cb(self)
+
+    def cancel(self, msg=None) -> bool:
+        """Cancel the future and schedules callbacks"""
+        if self._state != self.Status.PENDING:
+            return False
+        self._state = self.Status.CANCELLED
+        self._cancel_msg = msg
+        self.__schedule_callbacks()
+        return True
+
+    def done(self) -> bool:
+        """Return True if future was completed."""
+        return self._state != self.Status.PENDING
+
+    def cancelled(self):
+        """Return True if future was cancelled."""
+        return self._state != self.Status.CANCELLED
+
+    def _make_cancelled_error(self) -> FutureCancelled:
+        """Creates a :class:`.FutureCancelled` exception."""
+        if self._cancelled_exc is not None:
+            exc = self._cancelled_exc
+            self._cancelled_exc = None
+            return exc
+
+        exc = FutureCancelled() if self._cancel_msg is not None else FutureCancelled(self._cancel_msg)
+        exc.__context__ = self._cancelled_exc
+        self._cancelled_exc = None
+        return exc
+
+    def result(self) -> T:
+        """Gets the result of a :class:`.Future` if completed."""
+        self.__check_done()
+        if self._exception is not None:
+            raise self._exception
+        return self._result
+
+    def exception(self) -> BaseException | None:
+        """Gets the exception of a :class:`.Future` if completed it will be done if there is instead a successful result."""
+        self.__check_done()
+        return self._exception
+
+    def add_done_callback(self, fn: Callable[[Self], Any], *, context: RunVar[Self] | None = None) -> None:
+        """Creates a synchronous callback for when a future is considered as being completed or not."""
+        if self._state != self.Status.PENDING:
+            if context:
+                with context:
+                    fn(self)
+            else:
+                fn(self)
+        else:
+            self._done_callbacks.append((context, fn))
+
+    def remove_done_callback(self, fn: Callable[[Self], Any]):
+        filtered_callbacks = [(f, ctx)
+                              for (f, ctx) in self._done_callbacks
+                              if f != fn]
+        removed_count = len(self._done_callbacks) - len(filtered_callbacks)
+        if removed_count:
+            self._done_callbacks[:] = filtered_callbacks
+        return removed_count
+
+    def set_result(self, result: T) -> None:
+        """sets the results of a :class:`.Future` object."""
+        self.__check_not_done()
+        self._result = result
+        self._state = self.Status.FINISHED
+        self.__schedule_callbacks()
+
+    def set_exception(self, exception: BaseException) -> None:
+        """sets the exception of a :class:`.Future` object."""
+        self.__check_not_done()
+        self._exception = exception
+        self._state = self.Status.FINISHED
+        self.__schedule_callbacks()
+
+    # Mostly used as a proxy for awaiting on a pending object.
+    async def wait(self) -> T:
+        await self._event.wait()
+        return self.result()
+
+    def __await__(self) -> Generator[Any, None, T]:
+        return self.wait().__await__()
+
+def create_future() -> Future[T]:
+    """Shortcut method for creating a new :class:`.Future` object."""
+    return Future()

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -95,7 +95,6 @@ class Future(Generic[T]):
             case Future.Status.CANCELLED:
                 return
 
-
     @property
     def exception(self) -> BaseException | None:
         match self.status:

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -4,7 +4,6 @@ from collections.abc import Generator
 from enum import Enum, auto
 from typing import Any, Generic, TypeVar
 
-from ._eventloop import get_cancelled_exc_class
 from ._exceptions import (
     FutureAlreadyFinished,
     FutureCancelled,
@@ -12,7 +11,6 @@ from ._exceptions import (
     TaskNotFinished,
 )
 from ._synchronization import Event
-from ._tasks import CancelScope
 
 T = TypeVar("T")
 
@@ -33,9 +31,6 @@ class Future(Generic[T]):
         .. attribute:: FINISHED
 
             The future has finished with a return value.
-        .. attribute:: CANCELLING
-
-            The future has been cancelled but has not finished yet.
         .. attribute:: CANCELLED
 
             The future was cancelled and has finished since.
@@ -46,14 +41,13 @@ class Future(Generic[T]):
 
         PENDING = auto()
         FINISHED = auto()
-        CANCELLING = auto()
         CANCELLED = auto()
         FAILED = auto()
 
     __slots__ = (
+        "_cancelled",
         "_result_value",
         "_finished_event",
-        "_cancel_scope",
         "_exception",
         "_name",
     )
@@ -61,8 +55,8 @@ class Future(Generic[T]):
 
     def __init__(self, *, name: str | None = None) -> None:
         self._finished_event = Event()
-        self._cancel_scope = CancelScope()
         self._exception: BaseException | None = None
+        self._cancelled: bool = False
         self._name = name
 
     def _check_pending(self) -> None:
@@ -78,10 +72,8 @@ class Future(Generic[T]):
                 raise FutureAlreadyFinished("future has already finished")
             case Future.Status.FAILED:
                 raise FutureAlreadyFinished("future already failed")
-            case Future.Status.CANCELLING:
-                raise FutureCancelled("future was cancelled")
             case Future.Status.CANCELLED:
-                raise FutureCancelled("future was cancelled") from self._exception
+                raise FutureCancelled("future was cancelled")
 
     async def wait(self) -> None:
         """
@@ -89,12 +81,7 @@ class Future(Generic[T]):
 
         This method will attempt to wait for a result or exception
         """
-        with self._cancel_scope:
-            try:
-                await self._finished_event.wait()
-            except BaseException as e:
-                self.set_exception(e)
-                raise
+        await self._finished_event.wait()
 
     def set_result(self, value: T) -> None:
         """
@@ -122,17 +109,9 @@ class Future(Generic[T]):
 
         :raises FutureAlreadyFinished: if future was already given a result or exception.
         """
-        match self.status:
-            case Future.Status.PENDING:
-                return self._cancel_scope.cancel()
-            case Future.Status.FINISHED:
-                raise FutureAlreadyFinished("future has already finished")
-            case Future.Status.FAILED:
-                raise FutureAlreadyFinished("future already failed")
-            case Future.Status.CANCELLING:
-                return
-            case Future.Status.CANCELLED:
-                return
+        self._check_pending()
+        self._cancelled = True
+        self._finished_event.set()
 
     @property
     def exception(self) -> BaseException | None:
@@ -150,10 +129,8 @@ class Future(Generic[T]):
                 raise TaskNotFinished("the future has not finished yet")
             case Future.Status.FINISHED:
                 return None
-            case Future.Status.CANCELLING:
-                raise FutureCancelled("the future was cancelled")
             case Future.Status.CANCELLED:
-                raise FutureCancelled("the future was cancelled") from self._exception
+                raise FutureCancelled("the future was cancelled")
             case Future.Status.FAILED:
                 return self._exception
 
@@ -172,10 +149,8 @@ class Future(Generic[T]):
                 raise TaskNotFinished("the future has not finished yet")
             case Future.Status.FINISHED:
                 return self._result_value
-            case Future.Status.CANCELLING:
-                raise FutureCancelled("the future was cancelled")
             case Future.Status.CANCELLED:
-                raise FutureCancelled("the future was cancelled") from self._exception
+                raise FutureCancelled("the future was cancelled")
             case Future.Status.FAILED:
                 raise TaskFailed("the future raised an exception") from self._exception
 
@@ -193,15 +168,11 @@ class Future(Generic[T]):
         raised, if any. No other status transitions will happen.
         """
         if not self._finished_event.is_set():
-            if self._cancel_scope.cancel_called:
-                return Future.Status.CANCELLING
-            else:
-                return Future.Status.PENDING
+            return Future.Status.PENDING
+        elif self._cancelled:
+            return Future.Status.CANCELLED
         elif self._exception is not None:
-            if isinstance(self._exception, get_cancelled_exc_class()):
-                return Future.Status.CANCELLED
-            else:
-                return Future.Status.FAILED
+            return Future.Status.FAILED
         else:
             return Future.Status.FINISHED
 

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -16,16 +16,37 @@ from ._tasks import CancelScope
 
 T = TypeVar("T")
 
-
 class Future(Generic[T]):
+    """
+    An awaitable object that works simillar to a :class:`asyncio.Future` but
+    with simillar characteristics to a :class:`.TaskHandle`.
+    """
     class Status(Enum):
-        """The status of a future handle."""
+        """
+        The status of a future handle.
+
+        .. attribute:: PENDING
+
+            The future has not finished yet.
+        .. attribute:: FINISHED
+
+            The future has finished with a return value.
+        .. attribute:: CANCELLING
+
+            The future has been cancelled but has not finished yet.
+        .. attribute:: CANCELLED
+
+            The future was cancelled and has finished since.
+        .. attribute:: FAILED
+
+            The future raised an exception.
+        """
 
         PENDING = auto()
         FINISHED = auto()
-        FAILED = auto()
         CANCELLING = auto()
         CANCELLED = auto()
+        FAILED = auto()
 
     __slots__ = (
         "_result_value",
@@ -42,7 +63,12 @@ class Future(Generic[T]):
         self._exception: BaseException | None = None
         self._name = name
 
-    def _check_status(self) -> None:
+    def _check_pending(self) -> None:
+        """Shortcut for checking if a Future is pending
+
+        :raises FutureAlreadyFinished: if future was already given a result or exception.
+        :raises FutureCancelled: if future has been cancelled previously.
+        """
         match self.status:
             case Future.Status.PENDING:
                 return
@@ -71,18 +97,31 @@ class Future(Generic[T]):
                 self._finished_event.set()
 
     def set_result(self, value: T) -> None:
-        """Send pending result for a container object"""
-        self._check_status()
+        """
+        Send pending result for a `.Future` object
+
+        :raises FutureAlreadyFinished: if future was already given a result or exception.
+        :raises FutureCancelled: if future has been cancelled previously.
+        """
+        self._check_pending()
         self._result_value = value
         self._finished_event.set()
 
     def set_exception(self, exception: BaseException) -> None:
-        """Send exception result for a container object"""
-        self._check_status()
+        """Send exception for a `.Future` object
+
+        :raises FutureAlreadyFinished: if future was already given a result or exception.
+        :raises FutureCancelled: if future has been cancelled previously.
+        """
+        self._check_pending()
         self._exception = exception
         self._finished_event.set()
 
     def cancel(self) -> None:
+        """Cancels a pending `.Future` object
+
+        :raises FutureAlreadyFinished: if future was already given a result or exception.
+        """
         match self.status:
             case Future.Status.PENDING:
                 return self._cancel_scope.cancel()
@@ -97,6 +136,15 @@ class Future(Generic[T]):
 
     @property
     def exception(self) -> BaseException | None:
+        """
+        The exception value of a `.Future`
+
+        :raises TaskNotFinished: if future is still pending
+        :raises FutureCancelled: if future was cancelled
+        :returns: None if future succeeds with a result sent instead
+            otherwise this will be an exception
+        """
+
         match self.status:
             case Future.Status.PENDING:
                 raise TaskNotFinished("the future has not finished yet")
@@ -133,6 +181,17 @@ class Future(Generic[T]):
 
     @property
     def status(self) -> Future.Status:
+        """
+        The current status of a future.
+
+        Every future starts in the :attr:`~Future.Status.PENDING` state.
+        If a future is cancelled while in this state, it will transition to the
+        :attr:`Future.Status.CANCELLING` state. When the task finishes, it will
+        transition to one of the three final states (
+        :attr:`Future.Status.FINISHED`, :attr:`Future.Status.FAILED`, or
+        :attr:`Future.Status.CANCELLING`) depending on the exception the task
+        raised, if any. No other status transitions will happen.
+        """
         if not self._finished_event.is_set():
             if self._cancel_scope.cancel_called:
                 return Future.Status.CANCELLING

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -18,8 +18,8 @@ T = TypeVar("T")
 
 class Future(Generic[T]):
     """
-    An awaitable object that works simillar to a :class:`asyncio.Future` but
-    with simillar characteristics to a :class:`.TaskHandle`.
+    An awaitable object that works similar to a :class:`asyncio.Future` but
+    with similar characteristics to a :class:`.TaskHandle`.
     """
     class Status(Enum):
         """

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -165,10 +165,10 @@ class Future(Generic[T]):
 
         Every future starts in the :attr:`~Future.Status.PENDING` state.
         If a future is cancelled while in this state, it will transition to the
-        :attr:`Future.Status.CANCELLING` state. When the task finishes, it will
+        :attr:`Future.Status.CANCELLED` state. When the task finishes, it will
         transition to one of the three final states (
         :attr:`Future.Status.FINISHED`, :attr:`Future.Status.FAILED`, or
-        :attr:`Future.Status.CANCELLING`) depending on the exception the task
+        :attr:`Future.Status.CANCELLED`) depending on the exception the task
         raised, if any. No other status transitions will happen.
         """
         if not self._finished_event.is_set():

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -152,7 +152,9 @@ class Future(Generic[T]):
             case Future.Status.CANCELLED:
                 raise FutureCancelled("the future was cancelled")
             case Future.Status.FAILED:
-                raise FutureFailed("the future raised an exception") from self._exception
+                raise FutureFailed(
+                    "the future raised an exception"
+                ) from self._exception
 
     @property
     def status(self) -> Future.Status:

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -49,9 +49,9 @@ class Future(Generic[T]):
         "_exception",
         "_finished_event",
         "_name",
-        "_result",
+        "_return_value",
     )
-    _result: T
+    _return_value: T
 
     def __init__(self, *, name: str | None = None) -> None:
         self._finished_event = Event()
@@ -83,27 +83,6 @@ class Future(Generic[T]):
         """
         await self._finished_event.wait()
 
-    def set_result(self, value: T) -> None:
-        """
-        Send pending result for a `.Future` object
-
-        :raises FutureAlreadyFinished: if future was already given a result or exception.
-        :raises FutureCancelled: if future has been cancelled previously.
-        """
-        self._check_pending()
-        self._result = value
-        self._finished_event.set()
-
-    def set_exception(self, exception: BaseException) -> None:
-        """Send exception for a `.Future` object
-
-        :raises FutureAlreadyFinished: if future was already given a result or exception.
-        :raises FutureCancelled: if future has been cancelled previously.
-        """
-        self._check_pending()
-        self._exception = exception
-        self._finished_event.set()
-
     def cancel(self) -> None:
         """Cancels a pending `.Future` object
 
@@ -134,10 +113,21 @@ class Future(Generic[T]):
             case Future.Status.FAILED:
                 return self._exception
 
-    @property
-    def result(self) -> T:
+    @exception.setter
+    def exception(self, exception: BaseException) -> None:
+        """Send exception for a `.Future` object
+
+        :raises FutureAlreadyFinished: if future was already given a result or exception.
+        :raises FutureCancelled: if future has been cancelled previously.
         """
-        The result value of the future.
+        self._check_pending()
+        self._exception = exception
+        self._finished_event.set()
+
+    @property
+    def return_value(self) -> T:
+        """
+        The return value of the future.
 
         :raises FutureNotFinished: if the future has not finished yet
         :raises FutureCancelled: if the future was cancelled
@@ -148,13 +138,25 @@ class Future(Generic[T]):
             case Future.Status.PENDING:
                 raise FutureNotFinished("the future has not finished yet")
             case Future.Status.FINISHED:
-                return self._result
+                return self._return_value
             case Future.Status.CANCELLED:
                 raise FutureCancelled("the future was cancelled")
             case Future.Status.FAILED:
                 raise FutureFailed(
                     "the future raised an exception"
                 ) from self._exception
+
+    @return_value.setter
+    def return_value(self, value: T) -> None:
+        """
+        Send pending result for a `.Future` object
+
+        :raises FutureAlreadyFinished: if future was already given a result or exception.
+        :raises FutureCancelled: if future has been cancelled previously.
+        """
+        self._check_pending()
+        self._return_value = value
+        self._finished_event.set()
 
     @property
     def status(self) -> Future.Status:
@@ -180,7 +182,7 @@ class Future(Generic[T]):
 
     def __await__(self) -> Generator[Any, Any, T]:
         yield from self.wait().__await__()
-        return self.result
+        return self.return_value
 
     def __repr__(self) -> str:
         return (

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -46,12 +46,12 @@ class Future(Generic[T]):
 
     __slots__ = (
         "_cancelled",
-        "_result_value",
-        "_finished_event",
         "_exception",
+        "_finished_event",
         "_name",
+        "_result",
     )
-    _result_value: T
+    _result: T
 
     def __init__(self, *, name: str | None = None) -> None:
         self._finished_event = Event()
@@ -91,7 +91,7 @@ class Future(Generic[T]):
         :raises FutureCancelled: if future has been cancelled previously.
         """
         self._check_pending()
-        self._result_value = value
+        self._result = value
         self._finished_event.set()
 
     def set_exception(self, exception: BaseException) -> None:
@@ -135,9 +135,9 @@ class Future(Generic[T]):
                 return self._exception
 
     @property
-    def return_value(self) -> T:
+    def result(self) -> T:
         """
-        The return value of the future.
+        The result value of the future.
 
         :raises TaskNotFinished: if the future has not finished yet
         :raises FutureCancelled: if the future was cancelled
@@ -148,7 +148,7 @@ class Future(Generic[T]):
             case Future.Status.PENDING:
                 raise TaskNotFinished("the future has not finished yet")
             case Future.Status.FINISHED:
-                return self._result_value
+                return self._result
             case Future.Status.CANCELLED:
                 raise FutureCancelled("the future was cancelled")
             case Future.Status.FAILED:

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -46,10 +46,10 @@ class Future(Generic[T]):
 
     __slots__ = (
         "_cancelled",
-        "_result_value",
-        "_finished_event",
         "_exception",
+        "_finished_event",
         "_name",
+        "_result_value",
     )
     _result_value: T
 

--- a/src/anyio/_core/_futures.py
+++ b/src/anyio/_core/_futures.py
@@ -7,8 +7,8 @@ from typing import Any, Generic, TypeVar
 from ._exceptions import (
     FutureAlreadyFinished,
     FutureCancelled,
-    TaskFailed,
-    TaskNotFinished,
+    FutureFailed,
+    FutureNotFinished,
 )
 from ._synchronization import Event
 
@@ -118,7 +118,7 @@ class Future(Generic[T]):
         """
         The exception value of a `.Future`
 
-        :raises TaskNotFinished: if future is still pending
+        :raises FutureNotFinished: if future is still pending
         :raises FutureCancelled: if future was cancelled
         :returns: None if future succeeds with a result sent instead
             otherwise this will be an exception
@@ -126,7 +126,7 @@ class Future(Generic[T]):
 
         match self.status:
             case Future.Status.PENDING:
-                raise TaskNotFinished("the future has not finished yet")
+                raise FutureNotFinished("the future has not finished yet")
             case Future.Status.FINISHED:
                 return None
             case Future.Status.CANCELLED:
@@ -139,20 +139,20 @@ class Future(Generic[T]):
         """
         The return value of the future.
 
-        :raises TaskNotFinished: if the future has not finished yet
+        :raises FutureNotFinished: if the future has not finished yet
         :raises FutureCancelled: if the future was cancelled
-        :raises TaskFailed: if the future raised an exception
+        :raises FutureFailed: if the future raised an exception
 
         """
         match self.status:
             case Future.Status.PENDING:
-                raise TaskNotFinished("the future has not finished yet")
+                raise FutureNotFinished("the future has not finished yet")
             case Future.Status.FINISHED:
                 return self._result_value
             case Future.Status.CANCELLED:
                 raise FutureCancelled("the future was cancelled")
             case Future.Status.FAILED:
-                raise TaskFailed("the future raised an exception") from self._exception
+                raise FutureFailed("the future raised an exception") from self._exception
 
     @property
     def status(self) -> Future.Status:

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+
+from anyio import (
+    Future,
+    FutureAlreadyFinished,
+    FutureCancelled,
+    # FutureNotFinished,
+    # TaskCancelled,
+    create_task_group,
+)
+from anyio.lowlevel import (
+    # cancel_shielded_checkpoint,
+    checkpoint,
+    # checkpoint_if_cancelled,
+)
+
+
+class TestFuture:
+    async def test_result(self) -> None:
+        future: Future[int] = Future()
+        future.set_result(1)
+
+        result = await future
+        assert result == 1
+
+    def test_disallowing_multiple_results(self) -> None:
+        future: Future[int] = Future()
+        future.set_result(1)
+
+        with pytest.raises(FutureAlreadyFinished, match="future has already finished"):
+            future.set_result(0)
+
+
+    async def test_waiting_for_result(self) -> None:
+        async def task(fut: Future[int], value: int):
+            await checkpoint()
+            fut.set_result(value)
+
+        future: Future[int] = Future()
+        async with create_task_group() as tg:
+            tg.start_soon(task, future, 2)
+            assert (await future) == 2
+
+    async def test_waiting_with_wait(self) -> None:
+        async def task(fut: Future[int], value: int):
+            await checkpoint()
+            fut.set_result(value)
+
+        future: Future[int] = Future()
+        async with create_task_group() as tg:
+            tg.start_soon(task, future, 2)
+            await future.wait()
+            assert future.return_value == 2
+
+    async def test_raising_exception(self) -> None:
+        async def task(fut: Future[int]):
+            await checkpoint()
+            fut.set_exception(RuntimeError("testing runtime error"))
+
+        future: Future[int] = Future()
+        async with create_task_group() as tg:
+            tg.start_soon(task, future, 2)
+            with pytest.raises(RuntimeError, match=r"testing runtime error"):
+                await future
+
+
+    def test_already_cancelled(self) -> None:
+        future: Future[int] = Future()
+        future.cancel()
+        with pytest.raises(FutureCancelled, match=r"future was cancelled"):
+            future.set_result(1)
+
+    async def test_cancelled_wait(self):
+        future: Future[int] = Future()
+        future.cancel()
+        with pytest.raises(FutureCancelled, match=r"future was cancelled"):
+            await future

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -7,6 +7,7 @@ from anyio import (
     FutureAlreadyFinished,
     FutureCancelled,
     TaskFailed,
+    TaskNotFinished,
     create_task_group,
 )
 from anyio.lowlevel import (
@@ -74,3 +75,41 @@ class TestFuture:
         future.cancel()
         with pytest.raises(FutureCancelled, match=r"future was cancelled"):
             await future
+
+    async def test_future_not_finished(self):
+        future: Future[int] = Future()
+        with pytest.raises(TaskNotFinished, match=r"the future has not finished yet"):
+            _ = future.return_value
+
+        with pytest.raises(TaskNotFinished, match=r"the future has not finished yet"):
+            _ = future.exception
+
+    async def test_future_cancelling_already_set_result(self):
+        fut: Future[str] = Future()
+        fut.set_result("Item")
+        with pytest.raises(FutureAlreadyFinished, match=r"future has already finished"):
+            fut.cancel()
+
+    async def test_future_cancelling_already_set_exception(self):
+        fut = Future()
+        fut.set_exception(RuntimeError("Failed"))
+        with pytest.raises(FutureAlreadyFinished, match=r"future already failed"):
+            fut.cancel()
+
+    async def test_future_cancelling_with_result(self):
+        fut: Future[str] = Future()
+        fut.cancel()
+
+        with pytest.raises(FutureCancelled, match=r"future was cancelled"):
+            fut.set_result("Item")
+
+    async def test_future_cancelling_with_await(self):
+        fut: Future[str] = Future()
+        fut.cancel()
+
+        with pytest.raises(FutureCancelled, match=r"future was cancelled"):
+            await fut
+
+    async def test_future_with_repr(self):
+        repr_str = repr(Future(name="name"))
+        assert repr_str == "<Future pending name='name'>"

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -6,8 +6,7 @@ from anyio import (
     Future,
     FutureAlreadyFinished,
     FutureCancelled,
-    # FutureNotFinished,
-    # TaskCancelled,
+    TaskFailed,
     create_task_group,
 )
 from anyio.lowlevel import (
@@ -25,7 +24,7 @@ class TestFuture:
         result = await future
         assert result == 1
 
-    def test_disallowing_multiple_results(self) -> None:
+    async def test_disallowing_multiple_results(self) -> None:
         future: Future[int] = Future()
         future.set_result(1)
 
@@ -61,12 +60,12 @@ class TestFuture:
 
         future: Future[int] = Future()
         async with create_task_group() as tg:
-            tg.start_soon(task, future, 2)
-            with pytest.raises(RuntimeError, match=r"testing runtime error"):
+            tg.start_soon(task, future)
+            with pytest.raises(TaskFailed, match="the future raised an exception"):
                 await future
 
 
-    def test_already_cancelled(self) -> None:
+    async def test_already_cancelled(self) -> None:
         future: Future[int] = Future()
         future.cancel()
         with pytest.raises(FutureCancelled, match=r"future was cancelled"):

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -32,7 +32,7 @@ class TestFuture:
             future.set_result(0)
 
     async def test_waiting_for_result(self) -> None:
-        async def task(fut: Future[int], value: int):
+        async def task(fut: Future[int], value: int) -> None:
             await checkpoint()
             fut.set_result(value)
 
@@ -42,7 +42,7 @@ class TestFuture:
             assert (await future) == 2
 
     async def test_waiting_with_wait(self) -> None:
-        async def task(fut: Future[int], value: int):
+        async def task(fut: Future[int], value: int) -> None:
             await checkpoint()
             fut.set_result(value)
 
@@ -53,7 +53,7 @@ class TestFuture:
             assert future.return_value == 2
 
     async def test_raising_exception(self) -> None:
-        async def task(fut: Future[int]):
+        async def task(fut: Future[int]) -> None:
             await checkpoint()
             fut.set_exception(RuntimeError("testing runtime error"))
 
@@ -69,7 +69,7 @@ class TestFuture:
         with pytest.raises(FutureCancelled, match=r"future was cancelled"):
             future.set_result(1)
 
-    async def test_cancelled_wait(self):
+    async def test_cancelled_wait(self) -> None:
         future: Future[int] = Future()
         future.cancel()
         with pytest.raises(FutureCancelled, match=r"future was cancelled"):

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -90,14 +90,15 @@ class TestFuture:
     async def test_future_cancelling_already_set_result(self) -> None:
         fut: Future[str] = Future()
         fut.set_result("Item")
-        with pytest.raises(FutureAlreadyFinished, match=r"future has already finished"):
-            fut.cancel()
+        fut.cancel()
+        assert await fut == "Item"
 
     async def test_future_cancelling_already_set_exception(self) -> None:
         fut: Future[Any] = Future()
         fut.set_exception(RuntimeError("Failed"))
-        with pytest.raises(FutureAlreadyFinished, match=r"future already failed"):
-            fut.cancel()
+        fut.cancel()
+        with pytest.raises(TaskFailed, match=r"future raised an exception"):
+            await fut
 
     async def test_future_cancelling_with_result(self) -> None:
         fut: Future[str] = Future()

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from anyio import (
@@ -91,7 +93,7 @@ class TestFuture:
             fut.cancel()
 
     async def test_future_cancelling_already_set_exception(self) -> None:
-        fut = Future()
+        fut: Future[Any] = Future()
         fut.set_exception(RuntimeError("Failed"))
         with pytest.raises(FutureAlreadyFinished, match=r"future already failed"):
             fut.cancel()

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -76,7 +76,7 @@ class TestFuture:
         with pytest.raises(FutureCancelled, match=r"future was cancelled"):
             await future
 
-    async def test_future_not_finished(self):
+    async def test_future_not_finished(self) -> None:
         future: Future[int] = Future()
         with pytest.raises(TaskNotFinished, match=r"the future has not finished yet"):
             _ = future.return_value
@@ -84,32 +84,32 @@ class TestFuture:
         with pytest.raises(TaskNotFinished, match=r"the future has not finished yet"):
             _ = future.exception
 
-    async def test_future_cancelling_already_set_result(self):
+    async def test_future_cancelling_already_set_result(self) -> None:
         fut: Future[str] = Future()
         fut.set_result("Item")
         with pytest.raises(FutureAlreadyFinished, match=r"future has already finished"):
             fut.cancel()
 
-    async def test_future_cancelling_already_set_exception(self):
+    async def test_future_cancelling_already_set_exception(self) -> None:
         fut = Future()
         fut.set_exception(RuntimeError("Failed"))
         with pytest.raises(FutureAlreadyFinished, match=r"future already failed"):
             fut.cancel()
 
-    async def test_future_cancelling_with_result(self):
+    async def test_future_cancelling_with_result(self) -> None:
         fut: Future[str] = Future()
         fut.cancel()
 
         with pytest.raises(FutureCancelled, match=r"future was cancelled"):
             fut.set_result("Item")
 
-    async def test_future_cancelling_with_await(self):
+    async def test_future_cancelling_with_await(self) -> None:
         fut: Future[str] = Future()
         fut.cancel()
 
         with pytest.raises(FutureCancelled, match=r"future was cancelled"):
             await fut
 
-    async def test_future_with_repr(self):
+    async def test_future_with_repr(self) -> None:
         repr_str = repr(Future(name="name"))
         assert repr_str == "<Future pending name='name'>"

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -63,7 +63,6 @@ class TestFuture:
             with pytest.raises(TaskFailed, match="the future raised an exception"):
                 await future
 
-
     async def test_already_cancelled(self) -> None:
         future: Future[int] = Future()
         future.cancel()

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -32,7 +32,6 @@ class TestFuture:
         with pytest.raises(FutureAlreadyFinished, match="future has already finished"):
             future.set_result(0)
 
-
     async def test_waiting_for_result(self) -> None:
         async def task(fut: Future[int], value: int):
             await checkpoint()
@@ -64,7 +63,6 @@ class TestFuture:
             tg.start_soon(task, future, 2)
             with pytest.raises(RuntimeError, match=r"testing runtime error"):
                 await future
-
 
     def test_already_cancelled(self) -> None:
         future: Future[int] = Future()

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -8,6 +8,7 @@ from anyio import (
     Future,
     FutureAlreadyFinished,
     FutureCancelled,
+    TaskCancelled,
     TaskFailed,
     TaskNotFinished,
     create_task_group,
@@ -115,3 +116,35 @@ class TestFuture:
     async def test_future_with_repr(self) -> None:
         repr_str = repr(Future(name="name"))
         assert repr_str == "<Future pending name='name'>"
+
+    async def test_future_with_multiple_waiters(self) -> None:
+        async with create_task_group() as tg:
+            f = Future[str]()
+
+            async def task() -> str:
+                return await f
+
+            tasks = (tg.start_soon(task), tg.start_soon(task))
+            tg.cancel_scope.deadline += 2.0
+            f.set_result("Finished")
+            assert [await t for t in tasks] == ["Finished" for _ in tasks]
+
+    async def test_cancelled_waiter_allows_other(self) -> None:
+        async with create_task_group() as tg:
+            f = Future[str]()
+
+            async def task() -> str:
+                return await f
+
+            th1 = tg.start_soon(task)
+            th2 = tg.start_soon(task)
+            await checkpoint()
+
+            th1.cancel()
+            with pytest.raises(TaskCancelled):
+                await th1
+
+            f.set_result("Finished")
+
+            tg.cancel_scope.deadline += 1.0
+            assert await th2 == "Finished"

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -16,139 +16,154 @@ from anyio import (
 from anyio.lowlevel import checkpoint
 
 
-class TestFuture:
-    async def test_result(self) -> None:
-        future: Future[int] = Future()
-        future.return_value = 1
+async def test_result() -> None:
+    future: Future[int] = Future()
+    future.return_value = 1
 
-        result = await future
-        assert result == 1
+    result = await future
+    assert result == 1
 
-    async def test_disallowing_multiple_results(self) -> None:
-        future: Future[int] = Future()
-        future.return_value = 1
 
-        with pytest.raises(FutureAlreadyFinished, match="future has already finished"):
-            future.return_value = 0
+async def test_disallowing_multiple_results() -> None:
+    future: Future[int] = Future()
+    future.return_value = 1
 
-    async def test_waiting_for_result(self) -> None:
-        async def task(fut: Future[int], value: int) -> None:
-            await checkpoint()
-            fut.return_value = value
+    with pytest.raises(FutureAlreadyFinished, match="future has already finished"):
+        future.return_value = 0
 
-        future: Future[int] = Future()
-        async with create_task_group() as tg:
-            tg.start_soon(task, future, 2)
-            assert (await future) == 2
 
-    async def test_waiting_with_wait(self) -> None:
-        async def task(fut: Future[int], value: int) -> None:
-            await checkpoint()
-            fut.return_value = value
+async def test_waiting_for_result() -> None:
+    async def task(fut: Future[int], value: int) -> None:
+        await checkpoint()
+        fut.return_value = value
 
-        future: Future[int] = Future()
-        async with create_task_group() as tg:
-            tg.start_soon(task, future, 2)
-            await future.wait()
-            assert future.return_value == 2
+    future: Future[int] = Future()
+    async with create_task_group() as tg:
+        tg.start_soon(task, future, 2)
+        assert (await future) == 2
 
-    async def test_raising_exception(self) -> None:
-        async def task(fut: Future[int]) -> None:
-            await checkpoint()
-            fut.exception = RuntimeError("testing runtime error")
 
-        future: Future[int] = Future()
-        async with create_task_group() as tg:
-            tg.start_soon(task, future)
-            with pytest.raises(FutureFailed, match="the future raised an exception"):
-                await future
+async def test_waiting_with_wait() -> None:
+    async def task(fut: Future[int], value: int) -> None:
+        await checkpoint()
+        fut.return_value = value
 
-    async def test_already_cancelled(self) -> None:
-        future: Future[int] = Future()
-        future.cancel()
-        with pytest.raises(FutureCancelled, match=r"future was cancelled"):
-            future.return_value = 1
+    future: Future[int] = Future()
+    async with create_task_group() as tg:
+        tg.start_soon(task, future, 2)
+        await future.wait()
+        assert future.return_value == 2
 
-    async def test_cancelled_wait(self) -> None:
-        future: Future[int] = Future()
-        future.cancel()
-        with pytest.raises(FutureCancelled, match=r"future was cancelled"):
+
+async def test_raising_exception() -> None:
+    async def task(fut: Future[int]) -> None:
+        await checkpoint()
+        fut.exception = RuntimeError("testing runtime error")
+
+    future: Future[int] = Future()
+    async with create_task_group() as tg:
+        tg.start_soon(task, future)
+        with pytest.raises(FutureFailed, match="the future raised an exception"):
             await future
 
-    async def test_return_value_when_future_not_finished(self) -> None:
-        future: Future[int] = Future()
-        with pytest.raises(FutureNotFinished, match=r"the future has not finished yet"):
-            _ = future.return_value
 
-    async def test_exception_when_future_not_finished(self) -> None:
-        future: Future[int] = Future()
-        with pytest.raises(FutureNotFinished, match=r"the future has not finished yet"):
-            _ = future.exception
+async def test_already_cancelled() -> None:
+    future: Future[int] = Future()
+    future.cancel()
+    with pytest.raises(FutureCancelled, match=r"future was cancelled"):
+        future.return_value = 1
 
-    async def test_exception_when_future_failed(self) -> None:
-        future: Future[int] = Future()
-        exc = RuntimeError("foo")
-        future.exception = exc
-        assert future.exception is exc
 
-    async def test_exception_when_future_cancelled(self) -> None:
-        future: Future[int] = Future()
-        future.cancel()
-        with pytest.raises(FutureCancelled, match=r"the future was cancelled"):
-            _ = future.exception
+async def test_cancelled_wait() -> None:
+    future: Future[int] = Future()
+    future.cancel()
+    with pytest.raises(FutureCancelled, match=r"future was cancelled"):
+        await future
 
-    async def test_cancelling_already_set_return_value(self) -> None:
-        fut: Future[str] = Future()
+
+async def test_return_value_when_future_not_finished() -> None:
+    future: Future[int] = Future()
+    with pytest.raises(FutureNotFinished, match=r"the future has not finished yet"):
+        _ = future.return_value
+
+
+async def test_exception_when_future_not_finished() -> None:
+    future: Future[int] = Future()
+    with pytest.raises(FutureNotFinished, match=r"the future has not finished yet"):
+        _ = future.exception
+
+
+async def test_exception_when_future_failed() -> None:
+    future: Future[int] = Future()
+    exc = RuntimeError("foo")
+    future.exception = exc
+    assert future.exception is exc
+
+
+async def test_exception_when_future_cancelled() -> None:
+    future: Future[int] = Future()
+    future.cancel()
+    with pytest.raises(FutureCancelled, match=r"the future was cancelled"):
+        _ = future.exception
+
+
+async def test_cancelling_already_set_return_value() -> None:
+    fut: Future[str] = Future()
+    fut.return_value = "Item"
+    fut.cancel()
+    assert await fut == "Item"
+
+
+async def test_cancelling_already_set_exception() -> None:
+    fut: Future[Any] = Future()
+    fut.exception = RuntimeError("Failed")
+    fut.cancel()
+    with pytest.raises(FutureFailed, match=r"future raised an exception"):
+        await fut
+
+
+async def test_cancelling_with_result() -> None:
+    fut: Future[str] = Future()
+    fut.cancel()
+
+    with pytest.raises(FutureCancelled, match=r"future was cancelled"):
         fut.return_value = "Item"
-        fut.cancel()
-        assert await fut == "Item"
 
-    async def test_cancelling_already_set_exception(self) -> None:
-        fut: Future[Any] = Future()
-        fut.exception = RuntimeError("Failed")
-        fut.cancel()
-        with pytest.raises(FutureFailed, match=r"future raised an exception"):
-            await fut
 
-    async def test_cancelling_with_result(self) -> None:
-        fut: Future[str] = Future()
-        fut.cancel()
+async def test_repr() -> None:
+    repr_str = repr(Future(name="name"))
+    assert repr_str == "<Future pending name='name'>"
 
-        with pytest.raises(FutureCancelled, match=r"future was cancelled"):
-            fut.return_value = "Item"
 
-    async def test_future_with_repr(self) -> None:
-        repr_str = repr(Future(name="name"))
-        assert repr_str == "<Future pending name='name'>"
+async def test_multiple_waiters() -> None:
+    async with create_task_group() as tg:
+        f = Future[str]()
 
-    async def test_future_with_multiple_waiters(self) -> None:
-        async with create_task_group() as tg:
-            f = Future[str]()
+        async def task() -> str:
+            return await f
 
-            async def task() -> str:
-                return await f
+        tasks = (tg.start_soon(task), tg.start_soon(task))
+        tg.cancel_scope.deadline += 2.0
+        f.return_value = "Finished"
+        assert [await t for t in tasks] == ["Finished" for _ in tasks]
 
-            tasks = (tg.start_soon(task), tg.start_soon(task))
-            tg.cancel_scope.deadline += 2.0
-            f.return_value = "Finished"
-            assert [await t for t in tasks] == ["Finished" for _ in tasks]
 
-    async def test_cancelled_waiter_allows_other(self) -> None:
-        async with create_task_group() as tg:
-            f = Future[str]()
+async def test_cancelled_waiter_allows_other() -> None:
+    async with create_task_group() as tg:
+        f = Future[str]()
 
-            async def task() -> str:
-                return await f
+        async def task() -> str:
+            return await f
 
-            th1 = tg.start_soon(task)
-            th2 = tg.start_soon(task)
-            await checkpoint()
+        th1 = tg.start_soon(task)
+        th2 = tg.start_soon(task)
+        await checkpoint()
 
-            th1.cancel()
-            with pytest.raises(TaskCancelled):
-                await th1
+        th1.cancel()
+        with pytest.raises(TaskCancelled):
+            await th1
 
-            f.return_value = "Finished"
+        f.return_value = "Finished"
 
             tg.cancel_scope.deadline += 1.0
             assert await th2 == "Finished"

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -13,9 +13,7 @@ from anyio import (
     TaskCancelled,
     create_task_group,
 )
-from anyio.lowlevel import (
-    checkpoint,
-)
+from anyio.lowlevel import checkpoint
 
 
 class TestFuture:

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -19,22 +19,22 @@ from anyio.lowlevel import checkpoint
 class TestFuture:
     async def test_result(self) -> None:
         future: Future[int] = Future()
-        future.set_result(1)
+        future.return_value = 1
 
         result = await future
         assert result == 1
 
     async def test_disallowing_multiple_results(self) -> None:
         future: Future[int] = Future()
-        future.set_result(1)
+        future.return_value = 1
 
         with pytest.raises(FutureAlreadyFinished, match="future has already finished"):
-            future.set_result(0)
+            future.return_value = 0
 
     async def test_waiting_for_result(self) -> None:
         async def task(fut: Future[int], value: int) -> None:
             await checkpoint()
-            fut.set_result(value)
+            fut.return_value = value
 
         future: Future[int] = Future()
         async with create_task_group() as tg:
@@ -44,18 +44,18 @@ class TestFuture:
     async def test_waiting_with_wait(self) -> None:
         async def task(fut: Future[int], value: int) -> None:
             await checkpoint()
-            fut.set_result(value)
+            fut.return_value = value
 
         future: Future[int] = Future()
         async with create_task_group() as tg:
             tg.start_soon(task, future, 2)
             await future.wait()
-            assert future.result == 2
+            assert future.return_value == 2
 
     async def test_raising_exception(self) -> None:
         async def task(fut: Future[int]) -> None:
             await checkpoint()
-            fut.set_exception(RuntimeError("testing runtime error"))
+            fut.exception = RuntimeError("testing runtime error")
 
         future: Future[int] = Future()
         async with create_task_group() as tg:
@@ -67,7 +67,7 @@ class TestFuture:
         future: Future[int] = Future()
         future.cancel()
         with pytest.raises(FutureCancelled, match=r"future was cancelled"):
-            future.set_result(1)
+            future.return_value = 1
 
     async def test_cancelled_wait(self) -> None:
         future: Future[int] = Future()
@@ -78,20 +78,20 @@ class TestFuture:
     async def test_future_not_finished(self) -> None:
         future: Future[int] = Future()
         with pytest.raises(FutureNotFinished, match=r"the future has not finished yet"):
-            _ = future.result
+            _ = future.return_value
 
         with pytest.raises(FutureNotFinished, match=r"the future has not finished yet"):
             _ = future.exception
 
-    async def test_future_cancelling_already_set_result(self) -> None:
+    async def test_future_cancelling_already_set_return_value(self) -> None:
         fut: Future[str] = Future()
-        fut.set_result("Item")
+        fut.return_value = "Item"
         fut.cancel()
         assert await fut == "Item"
 
     async def test_future_cancelling_already_set_exception(self) -> None:
         fut: Future[Any] = Future()
-        fut.set_exception(RuntimeError("Failed"))
+        fut.exception = RuntimeError("Failed")
         fut.cancel()
         with pytest.raises(FutureFailed, match=r"future raised an exception"):
             await fut
@@ -101,7 +101,7 @@ class TestFuture:
         fut.cancel()
 
         with pytest.raises(FutureCancelled, match=r"future was cancelled"):
-            fut.set_result("Item")
+            fut.return_value = "Item"
 
     async def test_future_cancelling_with_await(self) -> None:
         fut: Future[str] = Future()
@@ -123,7 +123,7 @@ class TestFuture:
 
             tasks = (tg.start_soon(task), tg.start_soon(task))
             tg.cancel_scope.deadline += 2.0
-            f.set_result("Finished")
+            f.return_value = "Finished"
             assert [await t for t in tasks] == ["Finished" for _ in tasks]
 
     async def test_cancelled_waiter_allows_other(self) -> None:
@@ -141,7 +141,7 @@ class TestFuture:
             with pytest.raises(TaskCancelled):
                 await th1
 
-            f.set_result("Finished")
+            f.return_value = "Finished"
 
             tg.cancel_scope.deadline += 1.0
             assert await th2 == "Finished"

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -54,7 +54,7 @@ class TestFuture:
         async with create_task_group() as tg:
             tg.start_soon(task, future, 2)
             await future.wait()
-            assert future.return_value == 2
+            assert future.result == 2
 
     async def test_raising_exception(self) -> None:
         async def task(fut: Future[int]) -> None:
@@ -82,7 +82,7 @@ class TestFuture:
     async def test_future_not_finished(self) -> None:
         future: Future[int] = Future()
         with pytest.raises(TaskNotFinished, match=r"the future has not finished yet"):
-            _ = future.return_value
+            _ = future.result
 
         with pytest.raises(TaskNotFinished, match=r"the future has not finished yet"):
             _ = future.exception

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -164,6 +164,5 @@ async def test_cancelled_waiter_allows_other() -> None:
             await th1
 
         f.return_value = "Finished"
-
-            tg.cancel_scope.deadline += 1.0
-            assert await th2 == "Finished"
+        tg.cancel_scope.deadline += 1.0
+        assert await th2 == "Finished"

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -75,40 +75,47 @@ class TestFuture:
         with pytest.raises(FutureCancelled, match=r"future was cancelled"):
             await future
 
-    async def test_future_not_finished(self) -> None:
+    async def test_return_value_when_future_not_finished(self) -> None:
         future: Future[int] = Future()
         with pytest.raises(FutureNotFinished, match=r"the future has not finished yet"):
             _ = future.return_value
 
+    async def test_exception_when_future_not_finished(self) -> None:
+        future: Future[int] = Future()
         with pytest.raises(FutureNotFinished, match=r"the future has not finished yet"):
             _ = future.exception
 
-    async def test_future_cancelling_already_set_return_value(self) -> None:
+    async def test_exception_when_future_failed(self) -> None:
+        future: Future[int] = Future()
+        exc = RuntimeError("foo")
+        future.exception = exc
+        assert future.exception is exc
+
+    async def test_exception_when_future_cancelled(self) -> None:
+        future: Future[int] = Future()
+        future.cancel()
+        with pytest.raises(FutureCancelled, match=r"the future was cancelled"):
+            _ = future.exception
+
+    async def test_cancelling_already_set_return_value(self) -> None:
         fut: Future[str] = Future()
         fut.return_value = "Item"
         fut.cancel()
         assert await fut == "Item"
 
-    async def test_future_cancelling_already_set_exception(self) -> None:
+    async def test_cancelling_already_set_exception(self) -> None:
         fut: Future[Any] = Future()
         fut.exception = RuntimeError("Failed")
         fut.cancel()
         with pytest.raises(FutureFailed, match=r"future raised an exception"):
             await fut
 
-    async def test_future_cancelling_with_result(self) -> None:
+    async def test_cancelling_with_result(self) -> None:
         fut: Future[str] = Future()
         fut.cancel()
 
         with pytest.raises(FutureCancelled, match=r"future was cancelled"):
             fut.return_value = "Item"
-
-    async def test_future_cancelling_with_await(self) -> None:
-        fut: Future[str] = Future()
-        fut.cancel()
-
-        with pytest.raises(FutureCancelled, match=r"future was cancelled"):
-            await fut
 
     async def test_future_with_repr(self) -> None:
         repr_str = repr(Future(name="name"))

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -14,9 +14,7 @@ from anyio import (
     create_task_group,
 )
 from anyio.lowlevel import (
-    # cancel_shielded_checkpoint,
     checkpoint,
-    # checkpoint_if_cancelled,
 )
 
 

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -8,9 +8,9 @@ from anyio import (
     Future,
     FutureAlreadyFinished,
     FutureCancelled,
-    TaskCancelled,
     FutureFailed,
     FutureNotFinished,
+    TaskCancelled,
     create_task_group,
 )
 from anyio.lowlevel import (

--- a/tests/test_futures.py
+++ b/tests/test_futures.py
@@ -9,8 +9,8 @@ from anyio import (
     FutureAlreadyFinished,
     FutureCancelled,
     TaskCancelled,
-    TaskFailed,
-    TaskNotFinished,
+    FutureFailed,
+    FutureNotFinished,
     create_task_group,
 )
 from anyio.lowlevel import (
@@ -62,7 +62,7 @@ class TestFuture:
         future: Future[int] = Future()
         async with create_task_group() as tg:
             tg.start_soon(task, future)
-            with pytest.raises(TaskFailed, match="the future raised an exception"):
+            with pytest.raises(FutureFailed, match="the future raised an exception"):
                 await future
 
     async def test_already_cancelled(self) -> None:
@@ -79,10 +79,10 @@ class TestFuture:
 
     async def test_future_not_finished(self) -> None:
         future: Future[int] = Future()
-        with pytest.raises(TaskNotFinished, match=r"the future has not finished yet"):
+        with pytest.raises(FutureNotFinished, match=r"the future has not finished yet"):
             _ = future.return_value
 
-        with pytest.raises(TaskNotFinished, match=r"the future has not finished yet"):
+        with pytest.raises(FutureNotFinished, match=r"the future has not finished yet"):
             _ = future.exception
 
     async def test_future_cancelling_already_set_result(self) -> None:
@@ -95,7 +95,7 @@ class TestFuture:
         fut: Future[Any] = Future()
         fut.set_exception(RuntimeError("Failed"))
         fut.cancel()
-        with pytest.raises(TaskFailed, match=r"future raised an exception"):
+        with pytest.raises(FutureFailed, match=r"future raised an exception"):
             await fut
 
     async def test_future_cancelling_with_result(self) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->
This change implements an await-like container object meant for single-use instead of a queue-like stream with the aim towards being similar if not the same API as an `asyncio.Future`. It is needed because I'm in the middle of binding pycares to anyio as well as cyares in the future as I'm giving it a full rewrite in order to save myself of bit of maintenance costs  which involves [separating the current cyares architecture into seperate libraries](https://github.com/Vizonex/cyares/issues/56) although I'm focusing on adding in pycares first to the mix but then adding in my own library to allow users to pick and choose between using a cffi or cython backend. In order to successfully do this well I thought about making a new container type to retain similar in behavior to aiodns which involves using awaiting container objects would be a good idea in here. Some code comes from asyncio while the some of the code architecture is inspired by `concurrent.futures` if anybody was curious as to naming and some design choices made.

- NOTE: It's late for me at the moment so this is a draft and not a real PR yet expect to see more develop from this PR on a later day unless this PR is closed in favor of something else.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
