### PR TITLE
Fix UDPSocket.aclose() returning before FD release on asyncio backend

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -41,8 +41,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``SocketListener.from_socket()`` returning a TCP listener for ``AF_UNIX``
   listening sockets, causing ``accept()`` to fail with ``ENOTSUP``
   (`#1132 <https://github.com/agronholm/anyio/issues/1132>`_; PR by @kudato)
-- Fixed ``UDPSocket.aclose()`` on asyncio returning before the underlying
-  socket FD was actually released
+- Fixed ``UDPSocket.aclose()`` and ``ConnectedUDPSocket.aclose()`` on asyncio returning
+  before the underlying socket FD was actually released
   (`#1147 <https://github.com/agronholm/anyio/pull/1147>`_; PR by @matias-arrelid)
 
 **4.13.0**

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,13 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed ``UDPSocket.aclose()`` (asyncio backend) returning before the underlying
+  socket FD was actually released. Callers binding a fresh socket to the same
+  ``(host, port)`` on the next line (the typical ``from_socket`` pattern) raced
+  the asyncio-scheduled ``connection_lost`` callback and saw ``EADDRINUSE``
+  despite ``lsof`` reporting the port free. ``aclose`` now awaits a
+  ``closed_event`` set from ``DatagramProtocol.connection_lost``, honouring
+  ``AsyncResource.aclose``'s "close the resource" contract.
 - Added an asynchronous implementation of the ``itertools`` module
   (`#998 <https://github.com/agronholm/anyio/issues/998>`_; PR by @11kkw)
 - Added the ``local_port`` parameter to :func:`connect_tcp` to allow binding to a

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,13 +5,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Fixed ``UDPSocket.aclose()`` (asyncio backend) returning before the underlying
-  socket FD was actually released. Callers binding a fresh socket to the same
-  ``(host, port)`` on the next line (the typical ``from_socket`` pattern) raced
-  the asyncio-scheduled ``connection_lost`` callback and saw ``EADDRINUSE``
-  despite ``lsof`` reporting the port free. ``aclose`` now awaits a
-  ``closed_event`` set from ``DatagramProtocol.connection_lost``, honouring
-  ``AsyncResource.aclose``'s "close the resource" contract.
 - Added an asynchronous implementation of the ``itertools`` module
   (`#998 <https://github.com/agronholm/anyio/issues/998>`_; PR by @11kkw)
 - Added the ``local_port`` parameter to :func:`connect_tcp` to allow binding to a
@@ -48,6 +41,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``SocketListener.from_socket()`` returning a TCP listener for ``AF_UNIX``
   listening sockets, causing ``accept()`` to fail with ``ENOTSUP``
   (`#1132 <https://github.com/agronholm/anyio/issues/1132>`_; PR by @kudato)
+- Fixed ``UDPSocket.aclose()`` on asyncio returning before the underlying
+  socket FD was actually released
+  (`#1147 <https://github.com/agronholm/anyio/pull/1147>`_; PR by @matias-arrelid)
 
 **4.13.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1629,6 +1629,7 @@ class UDPSocket(abc.UDPSocket):
         self._closed = True
         if not self._transport.is_closing():
             self._transport.close()
+
         await self._protocol.closed_event.wait()
 
     async def receive(self) -> tuple[bytes, IPSockAddrType]:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1237,17 +1237,20 @@ class DatagramProtocol(asyncio.DatagramProtocol):
     read_queue: deque[tuple[bytes, IPSockAddrType]]
     read_event: asyncio.Event
     write_event: asyncio.Event
+    closed_event: asyncio.Event
     exception: Exception | None = None
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.read_queue = deque(maxlen=100)  # arbitrary value
         self.read_event = asyncio.Event()
         self.write_event = asyncio.Event()
+        self.closed_event = asyncio.Event()
         self.write_event.set()
 
     def connection_lost(self, exc: Exception | None) -> None:
         self.read_event.set()
         self.write_event.set()
+        self.closed_event.set()
 
     def datagram_received(self, data: bytes, addr: IPSockAddrType) -> None:
         addr = convert_ipv6_sockaddr(addr)
@@ -1626,6 +1629,7 @@ class UDPSocket(abc.UDPSocket):
         self._closed = True
         if not self._transport.is_closing():
             self._transport.close()
+        await self._protocol.closed_event.wait()
 
     async def receive(self) -> tuple[bytes, IPSockAddrType]:
         with self._receive_guard:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1680,6 +1680,8 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
         if not self._transport.is_closing():
             self._transport.close()
 
+        await self._protocol.closed_event.wait()
+
     async def receive(self) -> bytes:
         with self._receive_guard:
             await AsyncIOBackend.checkpoint()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1695,6 +1695,55 @@ async def test_multi_listener(tmp_path_factory: TempPathFactory) -> None:
 @pytest.mark.network
 @pytest.mark.usefixtures("check_asyncio_bug")
 class TestUDPSocket:
+    async def test_aclose_waits_for_fd_release(
+        self, family: AnyIPAddressFamily
+    ) -> None:
+        """Regression: ``UDPSocket.aclose`` must not return before the FD is released.
+
+        ``AsyncResource.aclose`` is documented as "close the resource".
+        Callers reasonably expect the local ``(host, port)`` to be
+        immediately rebindable once ``async with udp:`` returns.
+
+        The asyncio backend used to delegate ``aclose`` to
+        ``DatagramTransport.close``, which only *schedules* the FD-closing
+        ``connection_lost`` callback via ``loop.call_soon`` and returns
+        immediately. A caller who bound a fresh socket on the next line
+        (the typical ``from_socket`` pattern: ``socket()`` -> ``bind()``
+        -> ``UDPSocket.from_socket(sock)``) raced the scheduled close and
+        saw ``EADDRINUSE`` even though ``lsof`` reported the port free.
+
+        ``create_udp_socket`` happens to mask this because its own
+        ``await loop.create_datagram_endpoint(local_addr=...)`` yields
+        once, which drains the queued ``connection_lost``. The
+        ``from_socket`` path doesn't yield between aclose and rebind, so
+        it manifested the bug. This test exercises ``from_socket``
+        specifically.
+        """
+        host = "127.0.0.1" if family == socket.AF_INET else "::1"
+
+        # Get a port the kernel just freed so we know nothing else has it.
+        probe = socket.socket(family, socket.SOCK_DGRAM)
+        probe.bind((host, 0))
+        port = probe.getsockname()[1]
+        probe.close()
+
+        def bound(host: str, port: int) -> socket.socket:
+            sock = socket.socket(family, socket.SOCK_DGRAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((host, port))
+            sock.setblocking(False)
+            return sock
+
+        udp_a = await UDPSocket.from_socket(bound(host, port))
+        async with udp_a:
+            pass
+
+        # No yield between aclose returning and rebinding. If aclose
+        # returns before the previous FD is released, this bind fails.
+        udp_b = await UDPSocket.from_socket(bound(host, port))
+        async with udp_b:
+            pass
+
     async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:
         async with await create_udp_socket(
             family=family, local_host="localhost"

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1876,6 +1876,29 @@ class TestUDPSocket:
 @pytest.mark.network
 @pytest.mark.usefixtures("check_asyncio_bug")
 class TestConnectedUDPSocket:
+    async def test_aclose_waits_for_fd_release(
+        self, family: AnyIPAddressFamily, free_udp_port: int
+    ) -> None:
+        """Regression: ``ConnectedUDPSocket.aclose`` must not return before the FD is
+        released. Same race as ``UDPSocket.aclose``; see that test for the full
+        explanation.
+        """
+        host = "127.0.0.1" if family == socket.AF_INET else "::1"
+        peer = socket.socket(family, socket.SOCK_DGRAM)
+        peer.bind((host, 0))
+        try:
+            peer_addr = peer.getsockname()
+            for _ in range(2):
+                sock = socket.socket(family, socket.SOCK_DGRAM)
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                sock.bind((host, free_udp_port))
+                sock.connect(peer_addr)
+                sock.setblocking(False)
+                udp = await ConnectedUDPSocket.from_socket(sock)
+                await udp.aclose()
+        finally:
+            peer.close()
+
     async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:
         async with await create_connected_udp_socket(
             "localhost", 5000, family=family

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1696,7 +1696,7 @@ async def test_multi_listener(tmp_path_factory: TempPathFactory) -> None:
 @pytest.mark.usefixtures("check_asyncio_bug")
 class TestUDPSocket:
     async def test_aclose_waits_for_fd_release(
-        self, family: AnyIPAddressFamily
+        self, family: AnyIPAddressFamily, free_udp_port: int
     ) -> None:
         """Regression: ``UDPSocket.aclose`` must not return before the FD is released.
 
@@ -1720,29 +1720,13 @@ class TestUDPSocket:
         specifically.
         """
         host = "127.0.0.1" if family == socket.AF_INET else "::1"
-
-        # Get a port the kernel just freed so we know nothing else has it.
-        probe = socket.socket(family, socket.SOCK_DGRAM)
-        probe.bind((host, 0))
-        port = probe.getsockname()[1]
-        probe.close()
-
-        def bound(host: str, port: int) -> socket.socket:
+        for _ in range(2):
             sock = socket.socket(family, socket.SOCK_DGRAM)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind((host, port))
+            sock.bind((host, free_udp_port))
             sock.setblocking(False)
-            return sock
-
-        udp_a = await UDPSocket.from_socket(bound(host, port))
-        async with udp_a:
-            pass
-
-        # No yield between aclose returning and rebinding. If aclose
-        # returns before the previous FD is released, this bind fails.
-        udp_b = await UDPSocket.from_socket(bound(host, port))
-        async with udp_b:
-            pass
+            udp = await UDPSocket.from_socket(sock)
+            await udp.aclose()
 
     async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:
         async with await create_udp_socket(


### PR DESCRIPTION
**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

`UDPSocket.aclose()` on the asyncio backend returned before the underlying
socket FD was actually released. It delegated to
`asyncio.DatagramTransport.close()`, which only *schedules* the FD-closing
`connection_lost` callback via `loop.call_soon` and returns immediately. A
caller binding a fresh socket to the same `(host, port)` on the next line
(the typical `from_socket` pattern: `socket()` → `bind()` →
`UDPSocket.from_socket(sock)`) raced the scheduled close and saw
`EADDRINUSE`.

`create_udp_socket()` happened to mask the bug because its own
`await loop.create_datagram_endpoint(local_addr=...)` yields once, draining
the queued `connection_lost`. The `from_socket` path doesn't yield between
the prior `aclose` and the next sync `bind()`, so it manifested the bug.
Both paths produce the same `UDPSocket` wrapper, so the fix lives there.

Patch: `DatagramProtocol` now sets a `closed_event` from `connection_lost`,
and `UDPSocket.aclose()` (and `ConnectedUDPSocket.aclose()`) awaits it —
honouring `AsyncResource.aclose`'s "close the resource" contract.

The trio backend already releases the FD synchronously
(`_TrioSocketMixin.aclose` calls `trio_socket.close()` which is
synchronous-on-return), so no patch needed there.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).