### PR TITLE
fixes trio backend hangs instead of failing when dynamically accessing async fixture via getfixturevalue

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -44,6 +44,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``UDPSocket.aclose()`` and ``ConnectedUDPSocket.aclose()`` on asyncio returning
   before the underlying socket FD was actually released
   (`#1147 <https://github.com/agronholm/anyio/pull/1147>`_; PR by @matias-arrelid)
+- Fixed trio backend test runner hanging indefinitely instead of raising an error
+  when dynamically accessing an async fixture via ``request.getfixturevalue``
+  (`#1148 <https://github.com/agronholm/anyio/issues/1148>`_; PR by @EmmanuelNiyonshuti)
 
 **4.13.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2219,6 +2219,9 @@ class TestRunner(abc.TestRunner):
     def get_loop(self) -> AbstractEventLoop:
         return self._runner.get_loop()
 
+    def is_running(self) -> bool:
+        return self._runner.get_loop().is_running()
+
     def _exception_handler(
         self, loop: asyncio.AbstractEventLoop, context: dict[str, Any]
     ) -> None:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2220,7 +2220,11 @@ class TestRunner(abc.TestRunner):
         return self._runner.get_loop()
 
     def is_running(self) -> bool:
-        return self._runner.get_loop().is_running()
+        try:
+            asyncio.get_running_loop()
+            return True
+        except RuntimeError:
+            return False
 
     def _exception_handler(
         self, loop: asyncio.AbstractEventLoop, context: dict[str, Any]

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -859,6 +859,7 @@ class TestRunner(abc.TestRunner):
         self._call_queue: Queue[Callable[[], object]] = Queue()
         self._send_stream: MemoryObjectSendStream | None = None
         self._options = options
+        self._runner_task_running: bool = False
 
     def __exit__(
         self,
@@ -892,6 +893,11 @@ class TestRunner(abc.TestRunner):
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> T_Retval:
+        if self._runner_task_running:
+            raise RuntimeError(
+                "Cannot schedule a coroutine in the test runner when another is already running; "
+                "likely caused by request.getfixturevalue() on an async fixture"
+            )
         if self._send_stream is None:
             trio.lowlevel.start_guest_run(
                 self._run_tests_and_fixtures,
@@ -904,8 +910,12 @@ class TestRunner(abc.TestRunner):
 
         outcome_holder: list[Outcome] = []
         self._send_stream.send_nowait((func(*args, **kwargs), outcome_holder))
-        while not outcome_holder:
-            self._call_queue.get()()
+        self._runner_task_running = True
+        try:
+            while not outcome_holder:
+                self._call_queue.get()()
+        finally:
+            self._runner_task_running = False
 
         return outcome_holder[0].unwrap()
 

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -872,6 +872,9 @@ class TestRunner(abc.TestRunner):
             while self._send_stream is not None:
                 self._call_queue.get()()
 
+    def is_running(self) -> bool:
+        return self._runner_task_running
+
     async def _run_tests_and_fixtures(self) -> None:
         self._send_stream, receive_stream = create_memory_object_stream(1)
         with receive_stream:
@@ -893,8 +896,6 @@ class TestRunner(abc.TestRunner):
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> T_Retval:
-        if self._runner_task_running:
-            raise RuntimeError("This event loop is already running")
         if self._send_stream is None:
             trio.lowlevel.start_guest_run(
                 self._run_tests_and_fixtures,

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -894,10 +894,7 @@ class TestRunner(abc.TestRunner):
         **kwargs: P.kwargs,
     ) -> T_Retval:
         if self._runner_task_running:
-            raise RuntimeError(
-                "Cannot schedule a coroutine in the test runner when another is already running; "
-                "likely caused by request.getfixturevalue() on an async fixture"
-            )
+            raise RuntimeError("This event loop is already running")
         if self._send_stream is None:
             trio.lowlevel.start_guest_run(
                 self._run_tests_and_fixtures,

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -859,7 +859,6 @@ class TestRunner(abc.TestRunner):
         self._call_queue: Queue[Callable[[], object]] = Queue()
         self._send_stream: MemoryObjectSendStream | None = None
         self._options = options
-        self._runner_task_running: bool = False
 
     def __exit__(
         self,
@@ -873,7 +872,7 @@ class TestRunner(abc.TestRunner):
                 self._call_queue.get()()
 
     def is_running(self) -> bool:
-        return self._runner_task_running
+        return trio.lowlevel.in_trio_task()
 
     async def _run_tests_and_fixtures(self) -> None:
         self._send_stream, receive_stream = create_memory_object_stream(1)
@@ -908,12 +907,8 @@ class TestRunner(abc.TestRunner):
 
         outcome_holder: list[Outcome] = []
         self._send_stream.send_nowait((func(*args, **kwargs), outcome_holder))
-        self._runner_task_running = True
-        try:
-            while not outcome_holder:
-                self._call_queue.get()()
-        finally:
-            self._runner_task_running = False
+        while not outcome_holder:
+            self._call_queue.get()()
 
         return outcome_holder[0].unwrap()
 

--- a/src/anyio/abc/_testing.py
+++ b/src/anyio/abc/_testing.py
@@ -63,3 +63,11 @@ class TestRunner(metaclass=ABCMeta):
         :param test_func: the test function
         :param kwargs: keyword arguments to call the test function with
         """
+
+    def is_running(self) -> bool:
+        """
+        Check if the test runner is running.
+
+        :return: ``True`` if the coroutine is currently being run, ``False`` otherwise.
+        """
+        return False

--- a/src/anyio/abc/_testing.py
+++ b/src/anyio/abc/_testing.py
@@ -64,10 +64,10 @@ class TestRunner(metaclass=ABCMeta):
         :param kwargs: keyword arguments to call the test function with
         """
 
+    @abstractmethod
     def is_running(self) -> bool:
         """
         Check if the test runner is running.
 
         :return: ``True`` if the coroutine is currently being run, ``False`` otherwise.
         """
-        return False

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -131,6 +131,7 @@ def pytest_fixture_setup(fixturedef: Any, request: Any) -> Generator[Any]:
                     "Cannot schedule a coroutine in the test runner while another is already running; "
                     "likely caused by request.getfixturevalue() on an async fixture."
                 )
+
             if isasyncgenfunction(local_func):
                 yield from runner.run_asyncgen_fixture(local_func, kwargs)
             else:

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -120,6 +120,17 @@ def pytest_fixture_setup(fixturedef: Any, request: Any) -> Generator[Any]:
             kwargs["request"] = request
 
         with get_runner(backend_name, backend_options) as runner:
+            # re-entrant call into the test runner detected. this happens when an async fixture
+            # is dynamically requested via request.getfixturevalue() from inside a running async
+            # test or fixture. on asyncio this raises RuntimeError: This event loop is already
+            # running, on trio the runner deadlocks - the host loop blocks waiting for the
+            # coroutine to return, but the coroutine is waiting for the host loop. raising here
+            # prevents the hang and gives a consistent error across backends.
+            if runner.is_running():
+                raise RuntimeError(
+                    "Cannot schedule a coroutine in the test runner while another is already running; "
+                    "likely caused by request.getfixturevalue() on an async fixture."
+                )
             if isasyncgenfunction(local_func):
                 yield from runner.run_asyncgen_fixture(local_func, kwargs)
             else:

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -585,10 +585,6 @@ def test_dynamic_async_fixture_access_does_not_hang(testdir: Pytester) -> None:
         import pytest
 
         @pytest.fixture
-        def anyio_backend():
-            return "trio"
-
-        @pytest.fixture
         async def f():
             return 1
 
@@ -599,8 +595,8 @@ def test_dynamic_async_fixture_access_does_not_hang(testdir: Pytester) -> None:
         """
     )
 
-    result = testdir.runpytest(*pytest_args)
-    result.assert_outcomes(failed=1)
+    result = testdir.runpytest_subprocess(*pytest_args, timeout=3)
+    result.assert_outcomes(failed=len(get_available_backends()))
 
 
 def test_auto_mode(testdir: Pytester) -> None:

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -596,6 +596,7 @@ def test_dynamic_async_fixture_access_does_not_hang(testdir: Pytester) -> None:
     )
 
     result = testdir.runpytest_subprocess(*pytest_args, timeout=3)
+    result.stdout.fnmatch_lines(["*RuntimeError: This event loop is already running*"])
     result.assert_outcomes(failed=len(get_available_backends()))
 
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -578,6 +578,31 @@ def test_async_fixture_params(testdir: Pytester) -> None:
     result.assert_outcomes(passed=len(get_available_backends()) * 2)
 
 
+def test_dynamic_async_fixture_access_does_not_hang(testdir: Pytester) -> None:
+    # Regression test for #1148
+    testdir.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture
+        def anyio_backend():
+            return "trio"
+
+        @pytest.fixture
+        async def f():
+            return 1
+
+        @pytest.mark.anyio
+        async def test_something(request):
+            value = request.getfixturevalue('f')
+            assert value == 1
+        """
+    )
+
+    result = testdir.runpytest(*pytest_args)
+    result.assert_outcomes(failed=1)
+
+
 def test_auto_mode(testdir: Pytester) -> None:
     testdir.makepyprojecttoml(
         """

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -579,7 +579,14 @@ def test_async_fixture_params(testdir: Pytester) -> None:
 
 
 def test_dynamic_async_fixture_access_does_not_hang(testdir: Pytester) -> None:
-    # Regression test for #1148
+    """
+    Test for a situation when an async test or fixture dynamically request an async fixture
+    via request.getfixturevalue() from causing a re-entrant call into the test runner.
+    on trio it will deadlock, on asyncio it raises RuntimeError. This test is to ensure
+    both backends fail with a clear error.
+
+    Regression test for https://github.com/agronholm/anyio/issues/1148
+    """
     testdir.makepyfile(
         """
         import pytest
@@ -596,7 +603,11 @@ def test_dynamic_async_fixture_access_does_not_hang(testdir: Pytester) -> None:
     )
 
     result = testdir.runpytest_subprocess(*pytest_args, timeout=3)
-    result.stdout.fnmatch_lines(["*RuntimeError: This event loop is already running*"])
+    result.stdout.fnmatch_lines(
+        [
+            "*RuntimeError: Cannot schedule a coroutine in the test runner while another is already running;*"
+        ]
+    )
     result.assert_outcomes(failed=len(get_available_backends()))
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1148

trio backend test runner hangs indefinitely instead of failing when `request.getfixturevalue()` is called on an async fixture mid-test. the asyncio backend raises RuntimeError in the same situation. this PR adds a flag to detect the reentrance and raise a `RuntimeError`.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
