### PR TITLE
Autodetect backend in `start_blocking_portal()`

### DIFF
--- a/docs/threads.rst
+++ b/docs/threads.rst
@@ -168,6 +168,14 @@ event loop in its own dedicated thread::
 
 .. note:: The event loop is shut down as soon as you exit the context manager.
 
+.. note::
+    If the ``backend`` argument is omitted, the backend is detected automatically:
+    first from :mod:`sniffio` (or a running asyncio loop), then from the
+    ``anyio_backend`` pytest fixture when running under pytest, and finally by
+    inspecting which of ``trio`` and ``asyncio`` are present in :data:`sys.modules`.
+    Pass an explicit ``backend`` argument to silence the warning that is emitted
+    when both backends are imported and no other detection method succeeds.
+
 Spawning tasks
 ++++++++++++++
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -14,6 +14,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   functions and classes
 - Added the ``create_task()`` task group method for easier asyncio migration
   and to allow retrieving task return values more easily
+- Added backend autodetection to :func:`~anyio.from_thread.start_blocking_portal`
+  and :class:`~anyio.from_thread.BlockingPortalProvider`. When the ``backend``
+  argument is ``None`` (the new default), the backend is detected from
+  :mod:`sniffio`, then from the ``anyio_backend`` pytest fixture, then by
+  inspecting which of ``trio`` and ``asyncio`` are present in :data:`sys.modules`
+  (`#1151 <https://github.com/agronholm/anyio/pull/1151>`_; PR by @Zac-HD)
 - Improved the error message when a known backend is not installed to suggest the
   install command
   (`#1115 <https://github.com/agronholm/anyio/pull/1115>`_; PR by @EmmanuelNiyonshuti)

--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import math
 import sys
 import threading
+import warnings
 from collections.abc import Awaitable, Callable, Generator
 from contextlib import contextmanager
-from contextvars import Token
+from contextvars import ContextVar, Token
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -33,6 +34,52 @@ PosArgsT = TypeVarTuple("PosArgsT")
 
 threadlocals = threading.local()
 loaded_backends: dict[str, type[AsyncBackend]] = {}
+
+#: Context variable used by the pytest plugin to communicate the active
+#: ``anyio_backend`` name to functions performing backend autodetection.
+_pytest_backend_cvar: ContextVar[str | None] = ContextVar(
+    "_pytest_backend_cvar", default=None
+)
+
+
+def _detect_backend() -> str:
+    """
+    Detect the asynchronous backend to use, returning its name.
+
+    The detection follows this order:
+
+    1. :func:`sniffio.current_async_library` (or a fallback that checks for a
+       running asyncio loop if sniffio is not installed).
+    2. The ``anyio_backend`` set by the anyio pytest plugin.
+    3. The presence of ``trio`` and ``asyncio`` in :data:`sys.modules`:
+
+       - if only ``trio`` is imported, return ``"trio"``;
+       - if only ``asyncio`` is imported, return ``"asyncio"``;
+       - if both are imported, emit a warning and return ``"asyncio"``;
+       - if neither is imported, return ``"asyncio"``.
+
+    """
+    # 1. Check sniffio / a running asyncio loop
+    if asynclib_name := current_async_library():
+        return asynclib_name
+
+    # 2. Check the pytest plugin contextvar
+    if (pytest_backend := _pytest_backend_cvar.get()) is not None:
+        return pytest_backend
+
+    # 3. Fall back to inspecting which backends have been imported
+    trio_imported = "trio" in sys.modules
+    asyncio_imported = "asyncio" in sys.modules
+    if trio_imported and not asyncio_imported:
+        return "trio"
+    elif trio_imported and asyncio_imported:
+        warnings.warn(
+            "Both `trio` and `asyncio` are imported; defaulting to `asyncio`. "
+            "Pass an explicit `backend` argument to silence this warning.",
+            stacklevel=3,
+        )
+
+    return "asyncio"
 
 
 def run(

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -31,6 +31,7 @@ from typing import (
 )
 
 from ._core._eventloop import (
+    _detect_backend,
     get_cancelled_exc_class,
     threadlocals,
 )
@@ -450,13 +451,16 @@ class BlockingPortalProvider:
 
     The parameters are the same as for :func:`~anyio.run`.
 
-    :param backend: name of the backend
+    :param backend: name of the backend, or ``None`` to autodetect it (see
+        :func:`start_blocking_portal` for details)
     :param backend_options: backend options
 
     .. versionadded:: 4.4
+    .. versionchanged:: 4.14.0
+        ``backend`` now defaults to ``None``, which triggers autodetection.
     """
 
-    backend: str = "asyncio"
+    backend: str | None = None
     backend_options: dict[str, Any] | None = None
     _lock: Lock = field(init=False, default_factory=Lock)
     _leases: int = field(init=False, default=0)
@@ -498,7 +502,7 @@ class BlockingPortalProvider:
 
 @contextmanager
 def start_blocking_portal(
-    backend: str = "asyncio",
+    backend: str | None = None,
     backend_options: dict[str, Any] | None = None,
     *,
     name: str | None = None,
@@ -508,15 +512,24 @@ def start_blocking_portal(
 
     The parameters are the same as for :func:`~anyio.run`.
 
-    :param backend: name of the backend
+    :param backend: name of the backend, or ``None`` to autodetect it (see below)
     :param backend_options: backend options
     :param name: name of the thread
     :return: a context manager that yields a blocking portal
 
     .. versionchanged:: 3.0
         Usage as a context manager is now required.
+    .. versionchanged:: 4.14.0
+        ``backend`` now defaults to ``None``. When ``None``, the backend is detected
+        in this order: from :mod:`sniffio` (or a running asyncio loop), from the
+        ``anyio_backend`` pytest fixture, and finally by checking which of
+        ``trio`` and ``asyncio`` are present in :data:`sys.modules`. If both are
+        imported (or no detection method succeeded) the choice falls back to
+        ``"asyncio"``.
 
     """
+    if backend is None:
+        backend = _detect_backend()
 
     async def run_portal() -> None:
         async with BlockingPortal() as portal_:

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -16,6 +16,7 @@ from _pytest.scope import Scope
 
 from . import get_available_backends
 from ._core._eventloop import (
+    _pytest_backend_cvar,
     current_async_library,
     get_async_backend,
     reset_current_async_library,
@@ -264,6 +265,23 @@ def pytest_pyfunc_call(pyfuncitem: Any) -> bool | None:
 @pytest.fixture(scope="module", params=get_available_backends())
 def anyio_backend(request: Any) -> Any:
     return request.param
+
+
+@pytest.fixture(autouse=True)
+def _publish_anyio_backend(request: SubRequest) -> Generator[None]:
+    """Publish the active ``anyio_backend`` for backend autodetection."""
+    token = None
+    if "anyio_backend" in request.fixturenames:
+        backend_name, _ = extract_backend_and_options(
+            request.getfixturevalue("anyio_backend")
+        )
+        token = _pytest_backend_cvar.set(backend_name)
+
+    try:
+        yield
+    finally:
+        if token is not None:
+            _pytest_backend_cvar.reset(token)
 
 
 @pytest.fixture

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -457,6 +457,52 @@ class TestBlockingPortal:
 
         exc.match("No such backend: foo")
 
+    def test_start_backend_autodetect_from_pytest(
+        self, anyio_backend_name: str
+    ) -> None:
+        async def get_async_lib() -> str:
+            from anyio._core._eventloop import current_async_library
+
+            return current_async_library() or ""
+
+        # No backend passed - should be picked up from the anyio_backend fixture
+        # via the contextvar
+        with start_blocking_portal() as portal:
+            assert portal.call(get_async_lib) == anyio_backend_name
+
+    def test_detect_backend_both_imported(self) -> None:
+        import warnings
+
+        # Ensure trio is in sys.modules
+        pytest.importorskip("trio")
+
+        from anyio._core._eventloop import _detect_backend, _pytest_backend_cvar
+
+        # Clear the pytest cvar so we hit the sys.modules-based fallback
+        token = _pytest_backend_cvar.set(None)
+        try:
+            with warnings.catch_warnings(record=True) as recorded:
+                warnings.simplefilter("always")
+                backend = _detect_backend()
+        finally:
+            _pytest_backend_cvar.reset(token)
+
+        assert backend == "asyncio"
+        assert any(
+            "Both `trio` and `asyncio` are imported" in str(w.message) for w in recorded
+        ), [str(w.message) for w in recorded]
+
+    def test_blocking_portal_provider_autodetect(self, anyio_backend_name: str) -> None:
+        from anyio.from_thread import BlockingPortalProvider
+
+        async def get_async_lib() -> str:
+            from anyio._core._eventloop import current_async_library
+
+            return current_async_library() or ""
+
+        with BlockingPortalProvider() as portal:
+            assert portal.call(get_async_lib) == anyio_backend_name
+
     def test_call_stopped_portal(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Changes

`start_blocking_portal()` and `BlockingPortalProvider` previously defaulted to the asyncio backend, which silently mismatches anywhere the caller is actually using trio. Both now default `backend=None` and detect the active backend in order:

1. `sniffio.current_async_library()` (or a fallback that probes for a running asyncio loop when sniffio is missing);
2. a new private ContextVar (`_pytest_backend_cvar`) set by the anyio pytest plugin's `pytest_runtest_call` hookwrapper, so portals opened from a test pick up the parametrised `anyio_backend`. If pytest is running and the cvar is unset, a warning points the user to the fixture;
3. `sys.modules`: trio-only -> trio, both -> warn and pick asyncio, otherwise asyncio.

My motivation here is writing sync tests for Trio-based Starlette apps, where the `TestClient` defers to `start_blocking_portal()` and I would like to stop writing `backend="Trio"` in hundreds of places.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).