### PR TITLE
Cancel BlockingPortal tasks after stop

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -46,12 +46,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``UDPSocket.aclose()`` and ``ConnectedUDPSocket.aclose()`` on asyncio returning
   before the underlying socket FD was actually released
   (`#1147 <https://github.com/agronholm/anyio/pull/1147>`_; PR by @matias-arrelid)
-- Fixed cancelling tasks started through a ``BlockingPortal`` after the portal has been
-  stopped
-  (`#1013 <https://github.com/agronholm/anyio/issues/1013>`_; PR by @puneetdixit200)
 - Fixed trio backend test runner hanging indefinitely instead of raising an error
   when dynamically accessing an async fixture via ``request.getfixturevalue``
   (`#1148 <https://github.com/agronholm/anyio/issues/1148>`_; PR by @EmmanuelNiyonshuti)
+- Fixed cancelling tasks started through a ``BlockingPortal`` after the portal has been
+  stopped
+  (`#1013 <https://github.com/agronholm/anyio/issues/1013>`_; PR by @puneetdixit200)
 
 **4.13.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -44,6 +44,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``UDPSocket.aclose()`` and ``ConnectedUDPSocket.aclose()`` on asyncio returning
   before the underlying socket FD was actually released
   (`#1147 <https://github.com/agronholm/anyio/pull/1147>`_; PR by @matias-arrelid)
+- Fixed cancelling tasks started through a ``BlockingPortal`` after the portal has been
+  stopped
+  (`#1013 <https://github.com/agronholm/anyio/issues/1013>`_; PR by @puneetdixit200)
 
 **4.13.0**
 

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -244,12 +244,16 @@ class BlockingPortal:
         kwargs: dict[str, Any],
         future: Future[T_Retval],
     ) -> None:
+        event_loop_thread_id = self._event_loop_thread_id
+
         def callback(f: Future[T_Retval]) -> None:
             if f.cancelled():
-                if self._event_loop_thread_id == get_ident():
+                if event_loop_thread_id == get_ident():
                     scope.cancel("the future was cancelled")
-                elif self._event_loop_thread_id is not None:
-                    self.call(scope.cancel, "the future was cancelled")
+                elif event_loop_thread_id is not None:
+                    run_sync(
+                        scope.cancel, "the future was cancelled", token=self._token
+                    )
 
         try:
             retval_or_awaitable = func(*args, **kwargs)

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -518,6 +518,30 @@ class TestBlockingPortal:
 
         assert cancelled
 
+    def test_start_task_soon_cancel_after_stop(
+        self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
+    ) -> None:
+        cancelled = False
+        done_event = threading.Event()
+
+        async def event_waiter() -> None:
+            nonlocal cancelled
+            try:
+                await sleep(0.5)
+            except get_cancelled_exc_class():
+                cancelled = True
+            finally:
+                done_event.set()
+
+        with start_blocking_portal(anyio_backend_name, anyio_backend_options) as portal:
+            future = portal.start_task_soon(event_waiter)
+            portal.call(wait_all_tasks_blocked)
+            portal.call(portal.stop)
+            future.cancel()
+            done_event.wait(1)
+
+        assert cancelled
+
     def test_start_task_soon_with_name(
         self, anyio_backend_name: str, anyio_backend_options: dict[str, Any]
     ) -> None:

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -527,7 +527,7 @@ class TestBlockingPortal:
         async def event_waiter() -> None:
             nonlocal cancelled
             try:
-                await sleep(0.5)
+                await sleep(10)
             except get_cancelled_exc_class():
                 cancelled = True
             finally:
@@ -538,7 +538,7 @@ class TestBlockingPortal:
             portal.call(wait_all_tasks_blocked)
             portal.call(portal.stop)
             future.cancel()
-            done_event.wait(1)
+            done_event.wait(5)
 
         assert cancelled
 


### PR DESCRIPTION
## Changes

Fixes #1013.

This keeps the event-loop thread id captured for each portal task and uses the portal's event-loop token when a returned future is cancelled from another thread. That lets cancellation still reach the task's cancel scope after `BlockingPortal.stop()` has cleared the portal's running-thread marker.

A regression test covers cancelling a `start_task_soon()` future after requesting portal shutdown across the configured backends. I also added the required changelog entry.

Verification:

- `.venv\Scripts\python -m pytest tests\test_from_thread.py::TestBlockingPortal::test_start_task_soon_cancel_after_stop -q`
- `.venv\Scripts\python -m pytest tests\test_from_thread.py::TestBlockingPortal -q`
- `.venv\Scripts\python -m pytest tests\test_from_thread.py -q`
- `uv run --with ruff ruff check src\anyio\from_thread.py tests\test_from_thread.py`
- `uv run --with mypy mypy src\anyio\from_thread.py`
- `git diff --check`

I also ran `.venv\Scripts\python -m pytest -q`; it reached 2,957 passing tests, 778 skipped, and 5 xfailed, then failed only on 64 Windows symlink-permission setup errors in `tests/test_fileio.py` (`WinError 1314`, required privilege not held by the client).

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).