### PR TITLE
Added task handle support to start() and start_soon()

### DIFF
--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -44,44 +44,84 @@ Here's a demonstration::
 Working with task handles
 -------------------------
 
-As an alternative way to spawn tasks, you can use the :meth:`~.TaskGroup.create_task`
-method which will return a :class:`~.TaskHandle`. This handle can be used to:
+Both :meth:`~.abc.TaskGroup.start_soon` and :meth:`~.TaskGroup.create_task` return a
+:class:`~.TaskHandle`. This handle can be used to:
 
 #. Wait for the task to finish before exiting the task group
 #. Retrieve the task's return value or exception
 #. Cancel the task
 #. Check the task's status
 
-::
+.. tabs::
 
-    from anyio import TaskHandle, create_task_group, run, sleep
+   .. tab:: create_task()
+
+      ::
+
+          from anyio import TaskHandle, create_task_group, run, sleep
 
 
-    async def sometask(num: int) -> str:
-        await sleep(1)
-        return str(num)
+          async def sometask(num: int) -> str:
+              await sleep(1)
+              return str(num)
 
 
-    async def main() -> None:
-        async with create_task_group() as tg:
-            handles = [
-                tg.create_task(sometask(num)) for num in range(5)
-            ]
-            handles[1].cancel()
-            print(await handles[2])
+          async def main() -> None:
+              async with create_task_group() as tg:
+                  handles = [
+                      tg.create_task(sometask(num)) for num in range(5)
+                  ]
+                  handles[1].cancel()
+                  print(await handles[2])
 
-        print(
-            'Tasks finished:',
-            ', '.join(
-                handle.return_value for handle in handles
-                if handle.status is TaskHandle.Status.FINISHED
-            )
-        )
-        # Should print:
-        #   2
-        #   Tasks finished: 0, 2, 3, 4
+              print(
+                  'Tasks finished:',
+                  ', '.join(
+                      handle.return_value for handle in handles
+                      if handle.status is TaskHandle.Status.FINISHED
+                  )
+              )
+              # Should print:
+              #   2
+              #   Tasks finished: 0, 2, 3, 4
 
-    run(main)
+          run(main)
+
+   .. tab:: start_soon()
+
+      ::
+
+          from anyio import TaskHandle, create_task_group, run, sleep
+
+
+          async def sometask(num: int) -> str:
+              await sleep(1)
+              return str(num)
+
+
+          async def main() -> None:
+              async with create_task_group() as tg:
+                  handles = [
+                      tg.start_soon(sometask, num) for num in range(5)
+                  ]
+                  handles[1].cancel()
+                  print(await handles[2])
+
+              print(
+                  'Tasks finished:',
+                  ', '.join(
+                      handle.return_value for handle in handles
+                      if handle.status is TaskHandle.Status.FINISHED
+                  )
+              )
+              # Should print:
+              #   2
+              #   Tasks finished: 0, 2, 3, 4
+
+          run(main)
+
+.. versionchanged:: 4.14.0
+    :meth:`~.abc.TaskGroup.start_soon` now returns a :class:`~.TaskHandle`.
 
 .. _start_initialize:
 
@@ -137,6 +177,40 @@ until then. If the spawned task never calls it, then the
 
 .. note:: Unlike :meth:`~.abc.TaskGroup.start_soon`, :meth:`~.abc.TaskGroup.start` needs
    an ``await``.
+
+Getting a task handle from ``start()``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, :meth:`TaskGroup.start() <.abc.TaskGroup.start>` returns the value passed to
+``task_status.started()``. If you also need a :class:`~.TaskHandle` for the started task
+(e.g. to cancel it or await its return value), pass ``return_handle=True``. In this
+mode, the method returns a :class:`~.TaskHandle` whose :attr:`~.TaskHandle.start_value`
+property contains the value passed to ``task_status.started()``::
+
+    from anyio import create_task_group, run, sleep
+    from anyio.abc import TaskStatus
+
+
+    async def start_some_service(
+        port: int, *, task_status: TaskStatus[int] = TASK_STATUS_IGNORED
+    ) -> int:
+        task_status.started(port)
+        await sleep(10)
+        return 42
+
+
+    async def main() -> None:
+        async with create_task_group() as tg:
+            handle = await tg.start(start_some_service, 5000, return_handle=True)
+            print(f"Service started on port {handle.start_value}")
+            handle.cancel()
+            await handle.wait()
+
+    run(main)
+
+.. versionadded:: 4.14.0
+    The ``return_handle`` parameter was added to
+    :meth:`TaskGroup.start() <.abc.TaskGroup.start>`.
 
 Handling multiple errors in a task group
 ----------------------------------------
@@ -217,10 +291,19 @@ the context of the task group's host task that will be copied, but the context o
 task that calls :meth:`TaskGroup.start() <.abc.TaskGroup.start>` or
 :meth:`TaskGroup.start_soon() <.abc.TaskGroup.start_soon>`.
 
+If you need a task to run in a specific context, you can pass a
+:class:`~contextvars.Context` object to
+:meth:`TaskGroup.create_task() <.abc.TaskGroup.create_task>` via its ``context`` keyword
+argument. When provided, the task will run in the given context instead of inheriting a
+copy of the caller's context.
+
 .. _context: https://docs.python.org/3/library/contextvars.html
 
+Asyncio-specific notes
+----------------------
+
 Differences with asyncio.TaskGroup
-----------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :class:`asyncio.TaskGroup` class, added in Python 3.11, is very similar in design to
 the AnyIO :class:`~.abc.TaskGroup` class. The asyncio counterpart has some important
@@ -229,8 +312,8 @@ differences in its semantics, however:
 * The task group itself is instantiated directly, rather than using a factory function
 * Tasks are spawned solely through :meth:`~asyncio.TaskGroup.create_task`; there is no
   ``start()`` or ``start_soon()`` method
-* The :meth:`~asyncio.TaskGroup.create_task` method returns a task object which can be
-  awaited on (or cancelled)
+* The :meth:`~asyncio.TaskGroup.create_task` method returns an :class:`asyncio.Task`,
+  while AnyIO's :meth:`~.TaskGroup.create_task` returns a :class:`~.TaskHandle`
 * Tasks spawned via :meth:`~asyncio.TaskGroup.create_task` can only be cancelled
   individually (there is no ``cancel()`` method or similar in the task group)
 * When a task spawned via :meth:`~asyncio.TaskGroup.create_task` is cancelled before its
@@ -241,8 +324,8 @@ differences in its semantics, however:
 * Tasks spawned from :class:`asyncio.TaskGroup` use different cancellation semantics
   (see the notes on :ref:`asyncio cancellation semantics <asyncio cancellation>`)
 
-Asyncio call graph introspection support
-----------------------------------------
+Call graph introspection support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. versionadded:: 4.12.0
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -31,9 +31,14 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   any ``ReadableBuffer``, thus allowing it to accept ``bytearray`` and ``memoryview`` to
   match ``pathlib.Path.write_bytes()``
   (`#1135 <https://github.com/agronholm/anyio/issues/1135>`_; PR by @SAY-5)
-- Changed the type annotations for ``TaskGroup.start_soon()`` and ``TaskGroup.start()``
-  to only accept callables returning coroutine-like objects instead of arbitrary
-  awaitables. This reverts an earlier change from v3.7.0 which was made in error.
+- Changed several type annotations to only accept callables returning coroutine-like
+  objects instead of arbitrary awaitables:
+
+  - ``TaskGroup.start_soon()``
+  - ``TaskGroup.start()``
+  - ``anyio.from_thread.run()``
+
+  This reverts an earlier change from v3.7.0 which was made in error.
   (`#1153 <https://github.com/agronholm/anyio/pull/1153>`_)
 - Fixed cancellation exception escaping a cancel scope when triggered via
   ``check_cancelled()`` in a worker thread

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -30,6 +30,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   any ``ReadableBuffer``, thus allowing it to accept ``bytearray`` and ``memoryview`` to
   match ``pathlib.Path.write_bytes()``
   (`#1135 <https://github.com/agronholm/anyio/issues/1135>`_; PR by @SAY-5)
+- Changed the type annotations for ``TaskGroup.start_soon()`` and ``TaskGroup.start()``
+  to only accept callables returning coroutine-like objects instead of arbitrary
+  awaitables. This reverts an earlier change from v3.7.0 which was made in error.
+  (`#1153 <https://github.com/agronholm/anyio/pull/1153>`_)
 - Fixed cancellation exception escaping a cancel scope when triggered via
   ``check_cancelled()`` in a worker thread
   (`#1113 <https://github.com/agronholm/anyio/issues/1113>`_)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -12,8 +12,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#1067 <https://github.com/agronholm/anyio/issues/1067>`_; PR by @nullwiz)
 - Added support for custom capacity limiters in async path and file I/O
   functions and classes
-- Added the ``create_task()`` task group method for easier asyncio migration
-  and to allow retrieving task return values more easily
+- Added the ``create_task()`` task group method for easier asyncio migration (returns a
+  ``TaskHandle``)
+  (`#1098 <https://github.com/agronholm/anyio/pull/1098>`_)
+- Changed ``TaskGroup.start_soon()`` to return a ``TaskHandle``
+- Added an option for ``TaskGroup.start()`` to return a ``TaskHandle`` (which then
+  contains the start value in the ``start_value`` property)
 - Improved the error message when a known backend is not installed to suggest the
   install command
   (`#1115 <https://github.com/agronholm/anyio/pull/1115>`_; PR by @EmmanuelNiyonshuti)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -923,7 +923,7 @@ class TaskGroup(abc.TaskGroup):
             )
 
         if context is not None:
-            return context.run(partial(self._spawn, coro, name=name))
+            return context.run(self._spawn, coro, name=name)
         else:
             return self._spawn(coro, name=name)
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -380,6 +380,22 @@ def is_anyio_cancellation(exc: CancelledError) -> bool:
 
 
 class CancelScope(BaseCancelScope):
+    __slots__ = (
+        "_active",
+        "_cancel_called",
+        "_cancel_handle",
+        "_cancel_reason",
+        "_cancelled_caught",
+        "_child_scopes",
+        "_deadline",
+        "_host_task",
+        "_parent_scope",
+        "_pending_uncancellations",
+        "_shield",
+        "_tasks",
+        "_timeout_handle",
+    )
+
     def __new__(
         cls, *, deadline: float = math.inf, shield: bool = False
     ) -> CancelScope:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -352,11 +352,7 @@ def _task_started(task: asyncio.Task) -> bool:
     # task list
     coro = task.get_coro()
     assert coro is not None
-    try:
-        return getcoroutinestate(coro) in (CORO_RUNNING, CORO_SUSPENDED)
-    except AttributeError:
-        # task coro is async_genenerator_asend https://bugs.python.org/issue37771
-        raise Exception(f"Cannot determine if task {task} has started or not") from None
+    return getcoroutinestate(coro) in (CORO_RUNNING, CORO_SUSPENDED)
 
 
 #

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2570,11 +2570,11 @@ class AsyncIOBackend(AsyncBackend):
     @classmethod
     def run_async_from_thread(
         cls,
-        func: Callable[[Unpack[PosArgsT]], Awaitable[T_Retval]],
+        func: Callable[[Unpack[PosArgsT]], Coroutine[Any, Any, T_co]],
         args: tuple[Unpack[PosArgsT]],
         token: object,
-    ) -> T_Retval:
-        async def task_wrapper() -> T_Retval:
+    ) -> T_co:
+        async def task_wrapper() -> T_co:
             __tracebackhide__ = True
             if scope is not None:
                 task = cast(asyncio.Task, current_task())
@@ -2597,7 +2597,7 @@ class AsyncIOBackend(AsyncBackend):
         context = copy_context()
         context.run(set_current_async_library, "asyncio")
         scope = getattr(threadlocals, "current_cancel_scope", None)
-        f: concurrent.futures.Future[T_Retval] = context.run(
+        f: concurrent.futures.Future[T_co] = context.run(
             asyncio.run_coroutine_threadsafe, task_wrapper(), loop=loop
         )
         return f.result()

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -32,7 +32,7 @@ from collections.abc import (
     Sequence,
 )
 from concurrent.futures import Future
-from contextlib import AbstractContextManager, suppress
+from contextlib import AbstractContextManager
 from contextvars import Context, copy_context
 from dataclasses import dataclass, field
 from functools import partial, wraps
@@ -40,7 +40,6 @@ from inspect import (
     CORO_RUNNING,
     CORO_SUSPENDED,
     getcoroutinestate,
-    iscoroutine,
 )
 from io import IOBase
 from os import PathLike
@@ -53,6 +52,7 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Any,
+    Literal,
     ParamSpec,
     TypeVar,
     cast,
@@ -92,6 +92,7 @@ from .._core._synchronization import (
 )
 from .._core._synchronization import Semaphore as BaseSemaphore
 from .._core._tasks import CancelScope as BaseCancelScope
+from .._core._tasks import TaskHandle
 from ..abc import (
     AsyncBackend,
     IPSockAddrType,
@@ -100,6 +101,7 @@ from ..abc import (
     UNIXDatagramPacketType,
 )
 from ..abc._eventloop import StrOrBytesPath
+from ..abc._tasks import call_for_coroutine, get_callable_name
 from ..lowlevel import RunVar
 from ..streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
@@ -298,6 +300,7 @@ else:
 
 
 T_Retval = TypeVar("T_Retval")
+T_co = TypeVar("T_co", covariant=True)
 T_contra = TypeVar("T_contra", contravariant=True)
 PosArgsT = TypeVarTuple("PosArgsT")
 P = ParamSpec("P")
@@ -334,12 +337,6 @@ def find_root_task() -> asyncio.Task:
             return cast(asyncio.Task, cancel_scope._host_task)
 
     return task
-
-
-def get_callable_name(func: Callable) -> str:
-    module = getattr(func, "__module__", None)
-    qualname = getattr(func, "__qualname__", None)
-    return ".".join([x for x in (module, qualname) if x])
 
 
 #
@@ -816,11 +813,10 @@ class TaskGroup(abc.TaskGroup):
 
     def _spawn(
         self,
-        func: Callable[[Unpack[PosArgsT]], Awaitable[Any]],
-        args: tuple[Unpack[PosArgsT]],
+        coro: Coroutine[Any, Any, T_co],
         name: object,
         task_status_future: asyncio.Future | None = None,
-    ) -> asyncio.Task:
+    ) -> TaskHandle[T_co]:
         def task_done(_task: asyncio.Task) -> None:
             if sys.version_info >= (3, 14) and self.cancel_scope._host_task is not None:
                 asyncio.future_discard_from_awaited_by(
@@ -868,39 +864,23 @@ class TaskGroup(abc.TaskGroup):
                     RuntimeError("Child exited without calling task_status.started()")
                 )
 
-        if not self._entered or not self.cancel_scope._active:
-            raise RuntimeError(
-                "This task group is not active; no new tasks can be started."
-            )
-
-        kwargs = {}
         if task_status_future:
             parent_id = id(current_task())
-            kwargs["task_status"] = _AsyncioTaskStatus(
-                task_status_future, id(self.cancel_scope._host_task)
-            )
         else:
             parent_id = id(self.cancel_scope._host_task)
 
-        coro = func(*args, **kwargs)
-        if not iscoroutine(coro):
-            prefix = f"{func.__module__}." if hasattr(func, "__module__") else ""
-            raise TypeError(
-                f"Expected {prefix}{func.__qualname__}() to return a coroutine, but "
-                f"the return value ({coro!r}) is not a coroutine object"
-            )
-
-        name = get_callable_name(func) if name is None else str(name)
+        handle = TaskHandle(coro, name)
         loop = asyncio.get_running_loop()
+        wrapper_coro = handle._run_coro()
         if (
             (factory := loop.get_task_factory())
             and getattr(factory, "__code__", None) is _eager_task_factory_code
             and (closure := getattr(factory, "__closure__", None))
         ):
             custom_task_constructor = closure[0].cell_contents
-            task = custom_task_constructor(coro, loop=loop, name=name)
+            task = custom_task_constructor(wrapper_coro, loop=loop, name=handle.name)
         else:
-            task = create_task(coro, name=name)
+            task = loop.create_task(wrapper_coro, name=handle.name)
 
         # Make the spawned task inherit the task group's cancel scope
         _task_states[task] = TaskState(
@@ -912,35 +892,62 @@ class TaskGroup(abc.TaskGroup):
             asyncio.future_add_to_awaited_by(task, self.cancel_scope._host_task)
 
         task.add_done_callback(task_done)
-        return task
+        return handle
 
-    def start_soon(
+    def create_task(
         self,
-        func: Callable[[Unpack[PosArgsT]], Awaitable[Any]],
-        *args: Unpack[PosArgsT],
+        coro: Coroutine[Any, Any, T_co],
+        *,
         name: object = None,
-    ) -> None:
-        self._spawn(func, args, name)
+        context: Context | None = None,
+    ) -> TaskHandle[T_co]:
+        if not isinstance(coro, Coroutine):
+            raise TypeError(f"expected a coroutine, got {coro.__class__.__qualname__}")
+
+        if not self._entered or not self.cancel_scope._active:
+            coro.close()
+            raise RuntimeError(
+                "This task group is not active; no new tasks can be started."
+            )
+
+        if context is not None:
+            return context.run(partial(self._spawn, coro, name=name))
+        else:
+            return self._spawn(coro, name=name)
 
     async def start(
-        self, func: Callable[..., Awaitable[Any]], *args: object, name: object = None
+        self,
+        func: Callable[[Unpack[PosArgsT]], Coroutine[Any, Any, T_co]],
+        *args: Unpack[PosArgsT],
+        name: object = None,
+        return_handle: Literal[False] | Literal[True] = False,
     ) -> Any:
         future: asyncio.Future = asyncio.Future()
-        task = self._spawn(func, args, name, future)
+        final_name = get_callable_name(func, name)
+        task_status = _AsyncioTaskStatus(future, id(self.cancel_scope._host_task))
+        coro = call_for_coroutine(func, args, task_status=task_status)
+        handle = self._spawn(coro, final_name, future)
 
         # If the task raises an exception after sending a start value without a switch
         # point between, the task group is cancelled and this method never proceeds to
         # process the completed future. That's why we have to have a shielded cancel
         # scope here.
         try:
-            return await future
-        except CancelledError:
-            # Cancel the task and wait for it to exit before returning
-            task.cancel()
-            with CancelScope(shield=True), suppress(CancelledError):
-                await task
+            await future
+        except BaseException:
+            if handle.status is TaskHandle.Status.PENDING:
+                # Cancel the task and wait for it to exit before returning
+                handle.cancel()
+                with CancelScope(shield=True):
+                    await handle.wait()
 
             raise
+
+        if return_handle:
+            handle._start_value = future.result()
+            return handle
+        else:
+            return future.result()
 
 
 #

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -918,6 +918,11 @@ class TaskGroup(abc.TaskGroup):
         name: object = None,
         return_handle: Literal[False] | Literal[True] = False,
     ) -> Any:
+        if not self._entered or not self.cancel_scope._active:
+            raise RuntimeError(
+                "This task group is not active; no new tasks can be started."
+            )
+
         future: asyncio.Future = asyncio.Future()
         final_name = get_callable_name(func, name)
         task_status = _AsyncioTaskStatus(future, id(self.cancel_scope._host_task))

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -84,7 +84,7 @@ from .._core._tasks import CancelScope as BaseCancelScope
 from .._core._tasks import TaskHandle
 from ..abc import IPSockAddrType, UDPPacketType, UNIXDatagramPacketType
 from ..abc._eventloop import AsyncBackend, StrOrBytesPath
-from ..abc._tasks import T_contra, get_callable_name
+from ..abc._tasks import T_contra, call_for_coroutine, get_callable_name
 from ..streams.memory import MemoryObjectSendStream
 
 if TYPE_CHECKING:
@@ -255,8 +255,8 @@ class TaskGroup(abc.TaskGroup):
 
     async def start(
         self,
-        func: Callable[..., Coroutine[Any, Any, T_co]],
-        *args: object,
+        func: Callable[[Unpack[PosArgsT]], Coroutine[Any, Any, T_co]],
+        *args: Unpack[PosArgsT],
         name: object = None,
         return_handle: Literal[False] | Literal[True] = False,
     ) -> Any:
@@ -267,10 +267,7 @@ class TaskGroup(abc.TaskGroup):
         ) -> None:
             nonlocal handle
             wrapper_task_status = _TrioTaskStatus()
-            coro = func(*args, task_status=wrapper_task_status)
-            if not isinstance(coro, Coroutine):
-                raise TypeError(f"{coro!r} is not a coroutine object")
-
+            coro = call_for_coroutine(func, args, task_status=wrapper_task_status)
             if wrapper_task_status.early_start_value is not empty_start_value:
                 task_status.started(wrapper_task_status.early_start_value)
             else:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1103,10 +1103,10 @@ class TrioBackend(AsyncBackend):
     @classmethod
     def run_async_from_thread(
         cls,
-        func: Callable[[Unpack[PosArgsT]], Awaitable[T_Retval]],
+        func: Callable[[Unpack[PosArgsT]], Coroutine[Any, Any, T_co]],
         args: tuple[Unpack[PosArgsT]],
         token: object,
-    ) -> T_Retval:
+    ) -> T_co:
         trio_token = cast("trio.lowlevel.TrioToken | None", token)
         try:
             return trio.from_thread.run(func, *args, trio_token=trio_token)

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -18,7 +18,9 @@ from collections.abc import (
     Sequence,
 )
 from contextlib import AbstractContextManager
+from contextvars import Context
 from dataclasses import dataclass
+from functools import partial
 from io import IOBase
 from os import PathLike
 from signal import Signals
@@ -29,6 +31,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
+    Literal,
     NoReturn,
     ParamSpec,
     TypeVar,
@@ -78,8 +81,10 @@ from .._core._synchronization import (
 )
 from .._core._synchronization import Semaphore as BaseSemaphore
 from .._core._tasks import CancelScope as BaseCancelScope
+from .._core._tasks import TaskHandle
 from ..abc import IPSockAddrType, UDPPacketType, UNIXDatagramPacketType
 from ..abc._eventloop import AsyncBackend, StrOrBytesPath
+from ..abc._tasks import get_callable_name
 from ..streams.memory import MemoryObjectSendStream
 
 if TYPE_CHECKING:
@@ -93,6 +98,7 @@ else:
 
 T = TypeVar("T")
 T_Retval = TypeVar("T_Retval")
+T_co = TypeVar("T_co", covariant=True)
 T_SockAddr = TypeVar("T_SockAddr", str, IPSockAddrType)
 PosArgsT = TypeVarTuple("PosArgsT")
 P = ParamSpec("P")
@@ -199,28 +205,62 @@ class TaskGroup(abc.TaskGroup):
             del exc_val, exc_tb
             self._active = False
 
-    def start_soon(
-        self,
-        func: Callable[[Unpack[PosArgsT]], Awaitable[Any]],
-        *args: Unpack[PosArgsT],
-        name: object = None,
-    ) -> None:
+    def _check_active(self, coro: Coroutine | None = None) -> None:
         if not self._active:
+            if coro is not None:
+                coro.close()
+
             raise RuntimeError(
                 "This task group is not active; no new tasks can be started."
             )
 
-        self._nursery.start_soon(func, *args, name=name)
+    def create_task(
+        self,
+        coro: Coroutine[Any, Any, T_co],
+        *,
+        name: object = None,
+        context: Context | None = None,
+    ) -> TaskHandle[T_co]:
+        if not isinstance(coro, Coroutine):
+            raise TypeError(f"expected a coroutine, got {coro.__class__.__qualname__}")
+
+        self._check_active(coro)
+        handle = TaskHandle(coro, name)
+        if context is not None:
+            context.run(
+                partial(self._nursery.start_soon, handle._run_coro, name=handle.name)
+            )
+        else:
+            self._nursery.start_soon(handle._run_coro, name=handle.name)
+
+        return handle
 
     async def start(
-        self, func: Callable[..., Awaitable[Any]], *args: object, name: object = None
-    ) -> Any:
-        if not self._active:
-            raise RuntimeError(
-                "This task group is not active; no new tasks can be started."
-            )
+        self,
+        func: Callable[..., Coroutine[Any, Any, T_co]],
+        *args: object,
+        name: object = None,
+        return_handle: Literal[False] | Literal[True] = False,
+    ) -> TaskHandle[T_co]:
+        handle: TaskHandle[T_co]
 
-        return await self._nursery.start(func, *args, name=name)
+        async def run_coro_with_task_status(
+            *, task_status: trio.TaskStatus[Any]
+        ) -> None:
+            nonlocal handle
+            coro = func(*args, task_status=task_status)
+            handle = TaskHandle(coro, name)
+            await handle._run_coro()
+
+        self._check_active()
+        final_name = get_callable_name(func, name)
+        if return_handle:
+            handle._start_value = await self._nursery.start(  # noqa: F821
+                run_coro_with_task_status, name=final_name
+            )
+            return handle  # noqa: F821
+        else:
+            return await self._nursery.start(func, *args, name=final_name)
 
 
 #

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -175,7 +175,7 @@ empty_start_value = object()
 
 
 class _TrioTaskStatus(Generic[T_contra], abc.TaskStatus[T_contra]):
-    early_start_value: Any = empty_start_value
+    early_start_value: T_contra | object = empty_start_value
     real_task_status: trio.TaskStatus[T_contra | None] | None = None
 
     def started(self, value: T_contra | None = None) -> None:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -117,6 +117,8 @@ RunVar = trio.lowlevel.RunVar
 
 
 class CancelScope(BaseCancelScope):
+    __slots__ = ("__original",)
+
     def __new__(
         cls, original: trio.CancelScope | None = None, **kwargs: object
     ) -> CancelScope:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -255,10 +255,10 @@ class TaskGroup(abc.TaskGroup):
         self._check_active()
         final_name = get_callable_name(func, name)
         if return_handle:
-            handle._start_value = await self._nursery.start(  # noqa: F821
+            handle._start_value = await self._nursery.start(
                 run_coro_with_task_status, name=final_name
             )
-            return handle  # noqa: F821
+            return handle
         else:
             return await self._nursery.start(func, *args, name=final_name)
 

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -84,7 +84,7 @@ from .._core._tasks import CancelScope as BaseCancelScope
 from .._core._tasks import TaskHandle
 from ..abc import IPSockAddrType, UDPPacketType, UNIXDatagramPacketType
 from ..abc._eventloop import AsyncBackend, StrOrBytesPath
-from ..abc._tasks import get_callable_name
+from ..abc._tasks import T_contra, get_callable_name
 from ..streams.memory import MemoryObjectSendStream
 
 if TYPE_CHECKING:
@@ -171,6 +171,22 @@ class CancelScope(BaseCancelScope):
 # Task groups
 #
 
+empty_start_value = object()
+
+
+class _TrioTaskStatus(Generic[T_contra], abc.TaskStatus[T_contra]):
+    early_start_value: Any = empty_start_value
+    real_task_status: trio.TaskStatus[T_contra | None] | None = None
+
+    def started(self, value: T_contra | None = None) -> None:
+        if self.real_task_status is None:
+            if self.early_start_value is not empty_start_value:
+                raise RuntimeError("called 'started' twice on the same task status")
+
+            self.early_start_value = value
+        else:
+            self.real_task_status.started(value)
+
 
 class TaskGroup(abc.TaskGroup):
     def __init__(self) -> None:
@@ -250,19 +266,29 @@ class TaskGroup(abc.TaskGroup):
             *, task_status: trio.TaskStatus[Any]
         ) -> None:
             nonlocal handle
-            coro = func(*args, task_status=task_status)
+            wrapper_task_status = _TrioTaskStatus()
+            coro = func(*args, task_status=wrapper_task_status)
+            if not isinstance(coro, Coroutine):
+                raise TypeError(f"{coro!r} is not a coroutine object")
+
+            if wrapper_task_status.early_start_value is not empty_start_value:
+                task_status.started(wrapper_task_status.early_start_value)
+            else:
+                wrapper_task_status.real_task_status = task_status
+
             handle = TaskHandle(coro, name)
             await handle._run_coro()
 
         self._check_active()
         final_name = get_callable_name(func, name)
+        start_value = await self._nursery.start(
+            run_coro_with_task_status, name=final_name
+        )
         if return_handle:
-            handle._start_value = await self._nursery.start(
-                run_coro_with_task_status, name=final_name
-            )
+            handle._start_value = start_value
             return handle
         else:
-            return await self._nursery.start(func, *args, name=final_name)
+            return start_value
 
 
 #

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -241,7 +241,7 @@ class TaskGroup(abc.TaskGroup):
         *args: object,
         name: object = None,
         return_handle: Literal[False] | Literal[True] = False,
-    ) -> TaskHandle[T_co]:
+    ) -> Any:
         handle: TaskHandle[T_co]
 
         async def run_coro_with_task_status(

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -197,10 +197,10 @@ def create_task_group() -> TaskGroup:
 @final
 class TaskHandle(Generic[T_co]):
     """
-    Returned from :meth:`TaskGroup.create_task() <.abc.TaskGroup.create_task>`.
-    Can be awaited on to get the return value of the task (or the raised exception).
-    If the task was terminated by a :exc:`BaseException`, :exc:`TaskFailed` will be
-    raised (or its subclass :exc:`TaskCancelled` if the task was cancelled).
+    Returned from the task-spawning methods of :class:`TaskGroup`. Can be awaited on to
+    get the return value of the task (or the raised exception). If the task was
+    terminated by a :exc:`BaseException`, :exc:`TaskFailed` will be raised (or its
+    subclass :exc:`TaskCancelled` if the task was cancelled).
 
     .. versionadded:: 4.14.0
     """

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -55,6 +55,8 @@ class CancelScope:
         current thread
     """
 
+    __slots__ = ()
+
     def __new__(
         cls, *, deadline: float = math.inf, shield: bool = False
     ) -> CancelScope:

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -239,18 +239,26 @@ class TaskHandle(Generic[T_co]):
         "_cancel_scope",
         "_finished_event",
         "_return_value",
+        "_start_value",
         "_exception",
     )
 
     _return_value: T_co
+    _start_value: Any
 
-    def __init__(self, coro: Coroutine[Any, Any, T_co], name: str | None) -> None:
+    def __init__(self, coro: Coroutine[Any, Any, T_co], name: object) -> None:
         from ._synchronization import Event
+
+        if not isinstance(coro, Coroutine):
+            coro.close()
+            raise TypeError(
+                f"expected a coroutine object, got {coro.__class__.__qualname__}"
+            )
 
         self._coro = coro
         self._cancel_scope = CancelScope()
         self._finished_event = Event()
-        self._name = name or coro.__qualname__
+        self._name = str(name) if name is not None else coro.__qualname__
         self._exception: BaseException | None = None
 
     async def _run_coro(self) -> None:
@@ -266,6 +274,7 @@ class TaskHandle(Generic[T_co]):
                 self._return_value = retval
             finally:
                 self._finished_event.set()
+                del self  # Break the reference cycle
 
     def cancel(self) -> None:
         """
@@ -358,6 +367,15 @@ class TaskHandle(Generic[T_co]):
                 raise TaskCancelled("the task was cancelled") from self._exception
             case TaskHandle.Status.FAILED:
                 raise TaskFailed("the task raised an exception") from self._exception
+
+    @property
+    def start_value(self) -> Any:
+        try:
+            return self._start_value
+        except AttributeError:
+            raise RuntimeError(
+                "the task was not started with TaskGroup.start()"
+            ) from None
 
     async def wait(self) -> None:
         """

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -11,6 +11,7 @@ from contextlib import (
 )
 from contextvars import ContextVar
 from enum import Enum, auto
+from inspect import iscoroutine
 from types import TracebackType
 from typing import Any, Generic, final
 
@@ -264,8 +265,14 @@ class TaskHandle(Generic[T_co, T_startval]):
         self._coro = coro
         self._cancel_scope = CancelScope()
         self._finished_event = Event()
-        self._name = str(name) if name is not None else coro.__qualname__
         self._exception: BaseException | None = None
+
+        if name is not None:
+            self._name = str(name)
+        elif iscoroutine(coro):
+            self._name = coro.__qualname__
+        else:
+            self._name = str(coro)  # coroutine-like object (e.g. asend() objects)
 
     async def _run_coro(self) -> None:
         __tracebackhide__ = True

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -258,12 +258,6 @@ class TaskHandle(Generic[T_co, T_startval]):
     def __init__(self, coro: Coroutine[Any, Any, T_co], name: object) -> None:
         from ._synchronization import Event
 
-        if not isinstance(coro, Coroutine):
-            coro.close()
-            raise TypeError(
-                f"expected a coroutine object, got {coro.__class__.__qualname__}"
-            )
-
         self._coro = coro
         self._cancel_scope = CancelScope()
         self._finished_event = Event()

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -373,6 +373,12 @@ class TaskHandle(Generic[T_co]):
 
     @property
     def start_value(self) -> Any:
+        """
+        The value passed to :meth:`task_status.started() <.abc.TaskStatus.started>`,
+
+        :raises RuntimeError: if the task was not started with :meth:`TaskGroup.start()
+            <.abc.TaskGroup.start>`
+        """
         try:
             return self._start_value
         except AttributeError:

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -291,7 +291,10 @@ class TaskHandle(Generic[T_co]):
 
     @property
     def coro(self) -> Coroutine[Any, Any, T_co]:
-        """The coroutine object that was passed to :meth:`TaskGroup.create_task`."""
+        """
+        The coroutine object that was passed to one of the task-spawning methods in
+        :class:`TaskGroup`.
+        """
         return self._coro
 
     @property

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -12,19 +12,25 @@ from contextlib import (
 from contextvars import ContextVar
 from enum import Enum, auto
 from types import TracebackType
-from typing import Any, Generic, TypeVar, final
+from typing import Any, Generic, final
 
 from ..abc import TaskGroup, TaskStatus
 from ._eventloop import get_async_backend, get_cancelled_exc_class
 from ._exceptions import TaskCancelled, TaskFailed, TaskNotFinished
 
-if sys.version_info >= (3, 11):
-    from typing import TypeVarTuple
+if sys.version_info >= (3, 13):
+    from typing import TypeVar
 else:
-    from typing_extensions import TypeVarTuple
+    from typing_extensions import TypeVar
+
+if sys.version_info >= (3, 11):
+    from typing import Never, TypeVarTuple
+else:
+    from typing_extensions import Never, TypeVarTuple
 
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
+T_startval = TypeVar("T_startval", covariant=True, default=Never)
 PosArgsT = TypeVarTuple("PosArgsT")
 
 _current_task_handle: ContextVar[TaskHandle] = ContextVar("_current_task_handle")
@@ -195,7 +201,7 @@ def create_task_group() -> TaskGroup:
 
 
 @final
-class TaskHandle(Generic[T_co]):
+class TaskHandle(Generic[T_co, T_startval]):
     """
     Returned from the task-spawning methods of :class:`TaskGroup`. Can be awaited on to
     get the return value of the task (or the raised exception). If the task was
@@ -244,7 +250,7 @@ class TaskHandle(Generic[T_co]):
     )
 
     _return_value: T_co
-    _start_value: Any
+    _start_value: T_startval
 
     def __init__(self, coro: Coroutine[Any, Any, T_co], name: object) -> None:
         from ._synchronization import Event
@@ -372,7 +378,7 @@ class TaskHandle(Generic[T_co]):
                 raise TaskFailed("the task raised an exception") from self._exception
 
     @property
-    def start_value(self) -> Any:
+    def start_value(self) -> T_startval:
         """
         The value passed to :meth:`task_status.started() <.abc.TaskStatus.started>`,
 

--- a/src/anyio/abc/_eventloop.py
+++ b/src/anyio/abc/_eventloop.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import sys
 from abc import ABCMeta, abstractmethod
-from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Sequence
 from contextlib import AbstractContextManager
 from os import PathLike
 from signal import Signals
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from ._testing import TestRunner
 
 T_Retval = TypeVar("T_Retval")
+T_co = TypeVar("T_co", covariant=True)
 PosArgsT = TypeVarTuple("PosArgsT")
 StrOrBytesPath: TypeAlias = str | bytes | PathLike[str] | PathLike[bytes]
 
@@ -209,10 +210,10 @@ class AsyncBackend(metaclass=ABCMeta):
     @abstractmethod
     def run_async_from_thread(
         cls,
-        func: Callable[[Unpack[PosArgsT]], Awaitable[T_Retval]],
+        func: Callable[[Unpack[PosArgsT]], Coroutine[Any, Any, T_co]],
         args: tuple[Unpack[PosArgsT]],
         token: object,
-    ) -> T_Retval:
+    ) -> T_co:
         pass
 
     @classmethod

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import sys
 from abc import ABCMeta, abstractmethod
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Callable, Coroutine
 from contextvars import Context
-from functools import partial
-from inspect import iscoroutine
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Protocol, overload
+from typing import TYPE_CHECKING, Any, Literal, Protocol, final, overload
 
 if sys.version_info >= (3, 13):
     from typing import TypeVar
@@ -22,9 +20,41 @@ else:
 if TYPE_CHECKING:
     from .._core._tasks import CancelScope, TaskHandle
 
-T_Retval = TypeVar("T_Retval")
+T_co = TypeVar("T_co", covariant=True)
 T_contra = TypeVar("T_contra", contravariant=True, default=None)
 PosArgsT = TypeVarTuple("PosArgsT")
+
+
+def get_callable_name(func: Callable, override: object = None) -> str:
+    if override is not None:
+        return str(override)
+
+    module = getattr(func, "__module__", None)
+    qualname = getattr(func, "__qualname__", None)
+    return ".".join([x for x in (module, qualname) if x])
+
+
+def call_for_coroutine(
+    func: Callable[[Unpack[PosArgsT]], Coroutine[Any, Any, T_co]],
+    args: tuple[Unpack[PosArgsT]],
+    **kwargs: Any,
+) -> Coroutine[Any, Any, T_co]:
+    """
+    Call the given function with the given positional and keyword arguments.
+
+    :return: the resulting coroutine
+    :raises TypeError: if the return value was not a coroutine object
+
+    """
+    coro = func(*args, **kwargs)
+    if not isinstance(coro, Coroutine):
+        prefix = f"{func.__module__}." if hasattr(func, "__module__") else ""
+        raise TypeError(
+            f"Expected {prefix}{func.__qualname__}() to return a coroutine, but "
+            f"the return value ({coro!r}) is not a coroutine object"
+        )
+
+    return coro
 
 
 class TaskStatus(Protocol[T_contra]):
@@ -58,13 +88,14 @@ class TaskGroup(metaclass=ABCMeta):
 
     cancel_scope: CancelScope
 
+    @abstractmethod
     def create_task(
         self,
-        coro: Coroutine[Any, Any, T_Retval],
+        coro: Coroutine[Any, Any, T_co],
         *,
-        name: str | None = None,
+        name: object = None,
         context: Context | None = None,
-    ) -> TaskHandle[T_Retval]:
+    ) -> TaskHandle[T_co]:
         """
         Create a new task from a coroutine object and schedule it to run.
 
@@ -74,44 +105,56 @@ class TaskGroup(metaclass=ABCMeta):
         :return: a task handle
 
         .. versionadded:: 4.14.0
-
         """
-        from .._core._tasks import TaskHandle
 
-        if not iscoroutine(coro):
-            raise TypeError(f"expected a coroutine, got {coro.__class__.__qualname__}")
-
-        handle = TaskHandle[T_Retval](coro, name)
-        if context is not None:
-            context.run(partial(self.start_soon, handle._run_coro, name=handle.name))
-        else:
-            self.start_soon(handle._run_coro, name=handle.name)
-
-        return handle
-
-    @abstractmethod
+    @final
     def start_soon(
         self,
-        func: Callable[[Unpack[PosArgsT]], Awaitable[Any]],
+        func: Callable[[Unpack[PosArgsT]], Coroutine[Any, Any, T_co]],
         *args: Unpack[PosArgsT],
         name: object = None,
-    ) -> None:
+    ) -> TaskHandle[T_co]:
         """
         Start a new task in this task group.
 
         :param func: a coroutine function
         :param args: positional arguments to call the function with
         :param name: name of the task, for the purposes of introspection and debugging
+        :return: a task handle
 
         .. versionadded:: 3.0
+        .. versionchanged:: 4.14.0
+            This method now returns a task handle.
+
         """
+        final_name = get_callable_name(func, name)
+        return self.create_task(call_for_coroutine(func, args), name=final_name)
+
+    @overload
+    async def start(
+        self,
+        func: Callable[..., Coroutine[Any, Any, T_co]],
+        *args: object,
+        name: object = None,
+        return_handle: Literal[False] = ...,
+    ) -> Any: ...
+
+    @overload
+    async def start(
+        self,
+        func: Callable[..., Coroutine[Any, Any, T_co]],
+        *args: object,
+        name: object = None,
+        return_handle: Literal[True],
+    ) -> TaskHandle[T_co]: ...
 
     @abstractmethod
     async def start(
         self,
-        func: Callable[..., Awaitable[Any]],
+        func: Callable[..., Coroutine[Any, Any, T_co]],
         *args: object,
         name: object = None,
+        return_handle: Literal[False] | Literal[True] = False,
     ) -> Any:
         """
         Start a new task and wait until it signals for readiness.
@@ -128,6 +171,8 @@ class TaskGroup(metaclass=ABCMeta):
             argument
         :param args: positional arguments to call the function with
         :param name: an optional name for the task, for introspection and debugging
+        :param return_handle: if ``True``, return a :class:`TaskHandle` which also
+            contains the start value in ``start_value``
         :return: the value passed to ``task_status.started()``
         :raises RuntimeError: if the task finishes without calling
             ``task_status.started()``

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -159,7 +159,7 @@ class TaskGroup(metaclass=ABCMeta):
         *args: object,
         name: object = None,
         return_handle: Literal[True],
-    ) -> TaskHandle[T_co]: ...
+    ) -> TaskHandle[T_co, Any]: ...
 
     @abstractmethod
     async def start(

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -10,7 +10,7 @@ __all__ = (
 )
 
 import sys
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable, Coroutine, Generator
 from concurrent.futures import Future
 from contextlib import (
     AbstractAsyncContextManager,
@@ -65,10 +65,10 @@ def _token_or_error(token: EventLoopToken | None) -> EventLoopToken:
 
 
 def run(
-    func: Callable[[Unpack[PosArgsT]], Awaitable[T_Retval]],
+    func: Callable[[Unpack[PosArgsT]], Coroutine[Any, Any, T_co]],
     *args: Unpack[PosArgsT],
     token: EventLoopToken | None = None,
-) -> T_Retval:
+) -> T_co:
     """
     Call a coroutine function from a worker thread.
 

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -4,7 +4,7 @@ import math
 import sys
 import threading
 import time
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import AsyncGenerator, Callable, Coroutine
 from concurrent import futures
 from concurrent.futures import CancelledError, Future, ThreadPoolExecutor
 from contextlib import asynccontextmanager, suppress
@@ -39,7 +39,7 @@ from .conftest import asyncio_params
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
 
-T_Retval = TypeVar("T_Retval")
+T_co = TypeVar("T_co")
 
 
 async def async_add(a: int, b: int) -> int:
@@ -57,13 +57,13 @@ def sync_add(a: int, b: int) -> int:
 
 
 def thread_worker_async(
-    func: Callable[..., Awaitable[T_Retval]], *args: Any
-) -> T_Retval:
+    func: Callable[..., Coroutine[Any, Any, T_co]], *args: Any
+) -> T_co:
     assert threading.current_thread() is not threading.main_thread()
     return from_thread.run(func, *args)
 
 
-def thread_worker_sync(func: Callable[..., T_Retval], *args: Any) -> T_Retval:
+def thread_worker_sync(func: Callable[..., T_co], *args: Any) -> T_co:
     assert threading.current_thread() is not threading.main_thread()
     return from_thread.run_sync(func, *args)
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -286,8 +286,13 @@ async def test_propagate_native_cancellation_from_taskgroup() -> None:
 async def test_cancel_with_nested_task_groups() -> None:
     """Regression test for #695."""
 
+    from anyio._backends import _asyncio
+
+    class EditableCancelScope(_asyncio.CancelScope):
+        pass
+
     async def shield_task() -> None:
-        with CancelScope(shield=True) as scope:
+        with EditableCancelScope(shield=True) as scope:
             with mock.patch.object(
                 scope,
                 "_deliver_cancellation",
@@ -311,15 +316,16 @@ async def test_cancel_with_nested_task_groups() -> None:
             assert len(middle_cancel_spy.call_args_list) < 10
             assert len(outer_cancel_spy.call_args_list) < 10
 
-    async with create_task_group() as tg:
-        with mock.patch.object(
-            tg.cancel_scope,
-            "_deliver_cancellation",
-            wraps=getattr(tg.cancel_scope, "_deliver_cancellation"),
-        ) as outer_cancel_spy:
-            tg.start_soon(middle_task, name="middle task")
-            await wait_all_tasks_blocked()
-            tg.cancel_scope.cancel()
+    with mock.patch.object(_asyncio, "CancelScope", EditableCancelScope):
+        async with create_task_group() as tg:
+            with mock.patch.object(
+                tg.cancel_scope,
+                "_deliver_cancellation",
+                wraps=getattr(tg.cancel_scope, "_deliver_cancellation"),
+            ) as outer_cancel_spy:
+                tg.start_soon(middle_task, name="middle task")
+                await wait_all_tasks_blocked()
+                tg.cancel_scope.cancel()
 
     assert len(outer_cancel_spy.call_args_list) < 10
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -8,6 +8,7 @@ import sys
 import time
 from asyncio import CancelledError
 from collections.abc import AsyncGenerator, Coroutine, Generator
+from contextlib import aclosing
 from contextvars import ContextVar, copy_context
 from typing import Any, NoReturn, cast
 from unittest import mock
@@ -2217,3 +2218,20 @@ class TestCreateTask:
         assert str(handle.exception) == "dummy error"
         assert handle.status is TaskHandle.Status.FAILED
         await handle.wait()
+
+
+@pytest.mark.parametrize("create_task", [False, True])
+async def test_task_from_asyncgen_asend(create_task: bool) -> None:
+    async def genfunc(x: int, y: int) -> AsyncGenerator[int, None]:
+        yield x + y
+
+    async with create_task_group() as tg:
+        async with aclosing(genfunc(3, 5)) as g:
+            if create_task:
+                handle = tg.create_task(g.asend(None))
+                assert handle.name.startswith("<async_generator_asend object at ")
+            else:
+                handle = tg.start_soon(g.asend, None)
+                assert handle.name == "async_generator.asend"
+
+            assert await handle == 8

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1223,36 +1223,6 @@ def test_cancel_generator_based_task() -> None:
     anyio.run(generator_part, backend="asyncio")
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 11),
-    reason="Generator based coroutines have been removed in Python 3.11",
-)
-@pytest.mark.filterwarnings(
-    'ignore:"@coroutine" decorator is deprecated:DeprecationWarning'
-)
-@pytest.mark.parametrize("anyio_backend", asyncio_params)
-async def test_schedule_old_style_coroutine_func() -> None:
-    """
-    Test that we give a sensible error when a user tries to spawn a task from a
-    generator-style coroutine function.
-    """
-
-    @asyncio.coroutine  # type: ignore[attr-defined, untyped-decorator]
-    def corofunc() -> Generator[Any, Any, None]:
-        yield from asyncio.sleep(1)  # type: ignore[misc]
-
-    async with create_task_group() as tg:
-        funcname = (
-            f"{__name__}.test_schedule_old_style_coroutine_func.<locals>.corofunc"
-        )
-        with pytest.raises(
-            TypeError,
-            match=f"Expected {funcname}\\(\\) to return a coroutine, but the return "
-            f"value \\(<generator .+>\\) is not a coroutine object",
-        ):
-            tg.start_soon(corofunc)
-
-
 @pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_cancel_native_future_tasks() -> None:
     async def wait_native_future() -> None:
@@ -1375,24 +1345,18 @@ async def test_cancelscope_exit_before_enter() -> None:
     "anyio_backend", asyncio_params
 )  # trio does not check for this yet
 async def test_cancelscope_exit_in_wrong_task() -> None:
-    async def enter_scope(scope: CancelScope) -> None:
-        scope.__enter__()
-
     async def exit_scope(scope: CancelScope) -> None:
         scope.__exit__(None, None, None)
 
-    scope = CancelScope()
-    async with create_task_group() as tg:
-        tg.start_soon(enter_scope, scope)
-
-    with pytest.raises(ExceptionGroup) as exc:
-        async with create_task_group() as tg:
-            tg.start_soon(exit_scope, scope)
-
-    assert len(exc.value.exceptions) == 1
-    assert str(exc.value.exceptions[0]) == (
-        "Attempted to exit cancel scope in a different task than it was entered in"
-    )
+    with CancelScope() as scope:
+        with pytest.RaisesGroup(
+            pytest.RaisesExc(
+                RuntimeError,
+                match="Attempted to exit cancel scope in a different task than it was entered in",
+            )
+        ):
+            async with create_task_group() as tg:
+                tg.start_soon(exit_scope, scope)
 
 
 def test_unhandled_exception_group(caplog: pytest.LogCaptureFixture) -> None:
@@ -1698,6 +1662,31 @@ async def test_start_cancels_parent_scope() -> None:
     assert not tg.cancel_scope.cancel_called
 
 
+async def test_start_return_handle_success() -> None:
+    async def taskfunc(x: int, y: int, *, task_status: TaskStatus[int]) -> int:
+        task_status.started(3)
+        await checkpoint()
+        return x + y
+
+    async with create_task_group() as tg:
+        handle = await tg.start(taskfunc, 4, 5, return_handle=True)
+        assert handle.start_value == 3
+        assert await handle == 9
+
+
+async def test_start_return_handle_cancel() -> None:
+    async def taskfunc(*, task_status: TaskStatus[int]) -> int:
+        task_status.started(3)
+        await sleep(5)
+        pytest.fail("should not reach this point")
+
+    async with create_task_group() as tg:
+        handle = await tg.start(taskfunc, return_handle=True)
+        handle.cancel()
+        await handle.wait()
+        assert handle.start_value == 3
+
+
 @pytest.mark.skipif(
     sys.implementation.name == "pypy",
     reason=(
@@ -1748,7 +1737,6 @@ class TestRefcycles:
     async def test_exception_refcycles_parent_task(self) -> None:
         """Test that TaskGroup's cancel_scope deletes self._host_task"""
         tg = create_task_group()
-        exc = None
 
         class _Done(Exception):
             pass
@@ -1757,13 +1745,12 @@ class TestRefcycles:
             async with tg:
                 raise _Done
 
-        try:
+        with pytest.RaisesGroup(pytest.RaisesGroup(pytest.RaisesExc(_Done))) as excinfo:
             async with anyio.create_task_group() as tg2:
                 tg2.start_soon(coro_fn)
-        except ExceptionGroup as excs:
-            exc = excs.exceptions[0].exceptions[0]
 
-        assert isinstance(exc, _Done)
+        exc = excinfo.value.exceptions[0].exceptions[0]
+        del excinfo
         assert gc.get_referrers(exc) == no_other_refs()
 
     async def test_exception_refcycles_propagate_cancellation_error(self) -> None:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1247,6 +1247,36 @@ def test_cancel_generator_based_task() -> None:
     anyio.run(generator_part, backend="asyncio")
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11),
+    reason="Generator based coroutines have been removed in Python 3.11",
+)
+@pytest.mark.filterwarnings(
+    'ignore:"@coroutine" decorator is deprecated:DeprecationWarning'
+)
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
+async def test_schedule_old_style_coroutine_func() -> None:
+    """
+    Test that we give a sensible error when a user tries to spawn a task from a
+    generator-style coroutine function.
+    """
+
+    @asyncio.coroutine  # type: ignore[attr-defined, untyped-decorator]
+    def corofunc() -> Generator[Any, Any, None]:
+        yield from asyncio.sleep(1)  # type: ignore[misc]
+
+    async with create_task_group() as tg:
+        funcname = (
+            f"{__name__}.test_schedule_old_style_coroutine_func.<locals>.corofunc"
+        )
+        with pytest.raises(
+            TypeError,
+            match=f"Expected {funcname}\\(\\) to return a coroutine, but the return "
+            f"value \\(<generator .+>\\) is not a coroutine object",
+        ):
+            tg.start_soon(corofunc)
+
+
 @pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_cancel_native_future_tasks() -> None:
     async def wait_native_future() -> None:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -360,7 +360,8 @@ async def test_cancel_with_nested_task_groups() -> None:
     assert len(outer_cancel_spy.call_args_list) < 10
 
 
-async def test_start_exception_delivery() -> None:
+@pytest.mark.parametrize("return_handle", [False, True])
+async def test_start_exception_delivery(return_handle: bool) -> None:
     def task_fn(*, task_status: TaskStatus[str] = TASK_STATUS_IGNORED) -> None:
         task_status.started("hello")
 
@@ -370,7 +371,7 @@ async def test_start_exception_delivery() -> None:
     )
     with pytest.RaisesGroup(pytest.RaisesExc(TypeError, match=pattern)):
         async with anyio.create_task_group() as tg:
-            await tg.start(task_fn)  # type: ignore[arg-type]
+            await tg.start(task_fn, return_handle=return_handle)  # type: ignore[call-overload]
 
 
 async def test_start_cancel_after_error() -> None:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -364,8 +364,12 @@ async def test_start_exception_delivery() -> None:
     def task_fn(*, task_status: TaskStatus[str] = TASK_STATUS_IGNORED) -> None:
         task_status.started("hello")
 
-    async with anyio.create_task_group() as tg:
-        with pytest.raises(TypeError, match="is not a coroutine object"):
+    pattern = (
+        r"^Expected .*\(\) to return a coroutine, but the return value \(None\) is not "
+        r"a coroutine object$"
+    )
+    with pytest.RaisesGroup(pytest.RaisesExc(TypeError, match=pattern)):
+        async with anyio.create_task_group() as tg:
             await tg.start(task_fn)  # type: ignore[arg-type]
 
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -149,6 +149,36 @@ async def test_start_called_twice() -> None:
         assert value is None
 
 
+async def test_start_sync_wrapper() -> None:
+    async def taskfunc() -> int:
+        return 8
+
+    def wrapper(*, task_status: TaskStatus[int]) -> Coroutine[Any, Any, int]:
+        task_status.started(5)
+        return taskfunc()
+
+    async with create_task_group() as tg:
+        handle = await tg.start(wrapper, return_handle=True)
+        assert handle.start_value == 5
+        assert await handle == 8
+
+
+async def test_start_sync_wrapper_called_twice() -> None:
+    async def taskfunc() -> None:
+        pass
+
+    def wrapper(*, task_status: TaskStatus) -> Coroutine[Any, Any, None]:
+        task_status.started()
+        task_status.started()
+        return taskfunc()
+
+    async with create_task_group() as tg:
+        with pytest.raises(
+            RuntimeError, match="called 'started' twice on the same task status"
+        ):
+            await tg.start(wrapper)
+
+
 async def test_no_called_started_twice() -> None:
     async def taskfunc(*, task_status: TaskStatus) -> None:
         task_status.started()
@@ -330,17 +360,12 @@ async def test_cancel_with_nested_task_groups() -> None:
     assert len(outer_cancel_spy.call_args_list) < 10
 
 
-async def test_start_exception_delivery(anyio_backend_name: str) -> None:
+async def test_start_exception_delivery() -> None:
     def task_fn(*, task_status: TaskStatus[str] = TASK_STATUS_IGNORED) -> None:
         task_status.started("hello")
 
-    if anyio_backend_name == "trio":
-        pattern = "appears to be synchronous"
-    else:
-        pattern = "is not a coroutine object"
-
     async with anyio.create_task_group() as tg:
-        with pytest.raises(TypeError, match=pattern):
+        with pytest.raises(TypeError, match="is not a coroutine object"):
             await tg.start(task_fn)  # type: ignore[arg-type]
 
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -112,6 +112,19 @@ async def test_start_soon_after_error() -> None:
     exc.match("This task group is not active; no new tasks can be started")
 
 
+async def test_start_already_closed() -> None:
+    async def taskfunc(*, task_status: TaskStatus) -> None:
+        task_status.started()
+
+    async with create_task_group() as tg:
+        pass
+
+    with pytest.raises(RuntimeError) as exc:
+        await tg.start(taskfunc)
+
+    exc.match("This task group is not active; no new tasks can be started")
+
+
 async def test_start_no_value() -> None:
     async def taskfunc(*, task_status: TaskStatus) -> None:
         task_status.started()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Adds `TaskHandle` support to `TaskGroup.start_soon()` and `TaskGroup.start()` as per the group consensus.
The latter method has a feature flag for this to preserve backwards compatibility.
<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
