### PR TITLE
Added the TaskGroup.cancel() method

### DIFF
--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -231,8 +231,6 @@ differences in its semantics, however:
   ``start()`` or ``start_soon()`` method
 * The :meth:`~asyncio.TaskGroup.create_task` method returns a task object which can be
   awaited on (or cancelled)
-* Tasks spawned via :meth:`~asyncio.TaskGroup.create_task` can only be cancelled
-  individually (there is no ``cancel()`` method or similar in the task group)
 * When a task spawned via :meth:`~asyncio.TaskGroup.create_task` is cancelled before its
   coroutine has started running, it will not get a chance to handle the cancellation
   exception

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -14,6 +14,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   functions and classes
 - Added the ``create_task()`` task group method for easier asyncio migration
   and to allow retrieving task return values more easily
+- Added the ``cancel()`` convenience method to ``TaskGroup`` as a shortcut for
+  cancelling the task group's cancel scope
 - Improved the error message when a known backend is not installed to suggest the
   install command
   (`#1115 <https://github.com/agronholm/anyio/pull/1115>`_; PR by @EmmanuelNiyonshuti)

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -58,6 +58,19 @@ class TaskGroup(metaclass=ABCMeta):
 
     cancel_scope: CancelScope
 
+    def cancel(self, reason: str | None = None) -> None:
+        """
+        Cancel this task group's cancel scope immediately.
+
+        This is a shortcut for calling ``self.cancel_scope.cancel()``.
+
+        :param reason: a message describing the reason for the cancellation
+
+        .. versionadded:: 4.14.0
+
+        """
+        self.cancel_scope.cancel(reason)
+
     def create_task(
         self,
         coro: Coroutine[Any, Any, T_Retval],

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -62,7 +62,7 @@ class TaskGroup(metaclass=ABCMeta):
         """
         Cancel this task group's cancel scope immediately.
 
-        This is a shortcut for calling ``self.cancel_scope.cancel()``.
+        This is a shortcut for calling ``.cancel_scope.cancel()`` on the task group.
 
         :param reason: a message describing the reason for the cancellation
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -386,6 +386,30 @@ async def test_level_cancellation() -> None:
     assert marker == 1
 
 
+async def test_cancel() -> None:
+    started = False
+
+    async def dummy() -> None:
+        nonlocal started
+        started = True
+        await checkpoint()
+        pytest.fail("Execution should not reach this point")
+
+    async with create_task_group() as tg:
+        tg.start_soon(dummy)
+        assert not started
+        tg.cancel()
+
+    assert started
+
+
+async def test_cancel_with_reason() -> None:
+    async with create_task_group() as tg:
+        tg.cancel("test reason")
+        with pytest.raises(get_cancelled_exc_class(), match="test reason"):
+            await checkpoint()
+
+
 async def test_failing_child_task_cancels_host() -> None:
     async def child() -> NoReturn:
         await wait_all_tasks_blocked()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

This adds the `TaskGroup.cancel()` method as a convenience and to match the `asyncio.TaskGroup` API (this was added to asyncio in Python 3.15).

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
