### PR TITLE
Remove unnecessary `typing_extensions.ParamSpec` branching

### DIFF
--- a/src/anyio/functools.py
+++ b/src/anyio/functools.py
@@ -10,7 +10,6 @@ __all__ = (
 )
 
 import functools
-import sys
 from collections import OrderedDict
 from collections.abc import (
     AsyncIterable,
@@ -26,6 +25,7 @@ from typing import (
     Any,
     Generic,
     NamedTuple,
+    ParamSpec,
     TypedDict,
     TypeVar,
     cast,
@@ -37,11 +37,6 @@ from weakref import WeakKeyDictionary
 from ._core._eventloop import current_time
 from ._core._synchronization import Lock
 from .lowlevel import RunVar, checkpoint
-
-if sys.version_info >= (3, 11):
-    from typing import ParamSpec
-else:
-    from typing_extensions import ParamSpec
 
 T = TypeVar("T")
 S = TypeVar("S")


### PR DESCRIPTION
## Changes

Removes an unnecessary `sys.version_info` branch for `typing_extensions.ParamSpec`.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.