### PR TITLE
Added Python 3.15 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.11-nightly"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy3.11-nightly"]
         extras: ["[trio]"]
         lowest-bound: [false]
         include:

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added support for Python 3.15
 - Added an asynchronous implementation of the ``itertools`` module
   (`#998 <https://github.com/agronholm/anyio/issues/998>`_; PR by @11kkw)
 - Added the ``local_port`` parameter to ``connect_tcp()`` to allow binding to a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
 ]
 requires-python = ">= 3.10"
 dependencies = [
@@ -46,7 +47,7 @@ pytest11 = {anyio = "anyio.pytest_plugin"}
 
 [dependency-groups]
 test = [
-    "blockbuster >= 1.5.23",
+    "blockbuster >= 1.5.23; python_version < '3.15'",
     "coverage[toml] >= 7",
     "hypothesis >= 4.18.2",
     "psutil >= 5.9",
@@ -57,7 +58,7 @@ test = [
     "truststore >= 0.9.1",
     """\
     uvloop >= 0.22.1; platform_python_implementation == 'CPython' \
-    and platform_system != 'Windows' \
+    and platform_system != 'Windows' and python_version < '3.15' \
     """,
     """
     winloop >= 0.2.3; platform_python_implementation == 'CPython' \
@@ -143,7 +144,7 @@ exclude_also = [
 ]
 
 [tool.tox]
-env_list = ["pre-commit", "py310", "py311", "py312", "py313", "py314", "pypy3", "only_asyncio"]
+env_list = ["pre-commit", "py310", "py311", "py312", "py313", "py314", "py315", "pypy3", "only_asyncio"]
 skip_missing_interpreters = true
 requires = ["tox >= 4.22"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,8 @@ filterwarnings = [
     "error",
     # Ignore resource warnings due to a CPython/Windows bug (https://bugs.python.org/issue44428)
     "ignore:unclosed transport <_ProactorSocketTransport.*:ResourceWarning",
+    # Ignore deprecation warning occurring under coverage.py on Python 3.15
+    "ignore:Module globals; __loader__ != __spec__.loader:DeprecationWarning:",
 ]
 markers = [
     "network: marks tests as requiring Internet access",

--- a/tests/test_itertools.py
+++ b/tests/test_itertools.py
@@ -288,7 +288,7 @@ class TestCombinations:
             assert await collect(iterator) == expected
 
     async def test_negative_r(self) -> None:
-        with pytest.raises(ValueError, match="r must be non-negative"):
+        with pytest.raises(ValueError, match="r (cannot be |must be non-)negative"):
             await anext(combinations([1, 2], -1))
 
     async def test_checkpoints_empty_result(self) -> None:
@@ -341,7 +341,7 @@ class TestCombinationsWithReplacement:
             assert await collect(iterator) == expected
 
     async def test_negative_r(self) -> None:
-        with pytest.raises(ValueError, match="r must be non-negative"):
+        with pytest.raises(ValueError, match="r (cannot be |must be non-)negative"):
             await anext(combinations_with_replacement([1, 2], -1))
 
     async def test_checkpoints_empty_results(self) -> None:


### PR DESCRIPTION
Blockbuster does not yet work on 3.15, so it was disabled for that version. Uvloop has 3.15 wheels but they were built for an alpha and so don't work on the current version.

<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

This adds the CI config and classifier for Python 3.15 support. It also fixes a test failure caused by an upstream parameter validation message change in itertools. Blockbuster and uvloop are disabled in the test suite for 3.15 due to compatibility issues.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
