### PR TITLE
Pass `backend_options` to Trio

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -52,6 +52,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed cancelling tasks started through a ``BlockingPortal`` after the portal has been
   stopped
   (`#1013 <https://github.com/agronholm/anyio/issues/1013>`_; PR by @puneetdixit200)
+- Fixed ``backend_options`` being ignored when running the Trio backend via
+  ``anyio.run()``; the options are now passed as keyword arguments to ``trio.run()``
+  again, as documented (a regression from AnyIO 3)
+  (`#1161 <https://github.com/agronholm/anyio/pull/1161>`_; PR by @Zac-HD)
 
 **4.13.0**
 

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -970,7 +970,8 @@ class TrioBackend(AsyncBackend):
         kwargs: dict[str, Any],
         options: dict[str, Any],
     ) -> T_Retval:
-        return trio.run(func, *args)
+        assert not kwargs, "unreachable, and not supported by Trio"
+        return trio.run(func, *args, **options)
 
     @classmethod
     def current_token(cls) -> object:

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import time
 from asyncio import get_running_loop
 from collections.abc import Generator
 from unittest import mock
@@ -10,7 +11,7 @@ from unittest.mock import AsyncMock
 import pytest
 from pytest import MonkeyPatch
 
-from anyio import run, sleep_forever, sleep_until
+from anyio import current_time, run, sleep, sleep_forever, sleep_until
 
 fake_current_time = 1620581544.0
 
@@ -111,3 +112,27 @@ class TestAsyncioOptions:
         winloop = pytest.importorskip("winloop", reason="winloop not installed")
         loop_class = run(main, backend="asyncio", backend_options={"use_uvloop": True})
         assert issubclass(loop_class, winloop.Loop)
+
+
+class TestTrioOptions:
+    def test_clock(self) -> None:
+        """Test that ``backend_options`` are passed to ``trio.run()``."""
+        try:
+            from trio.testing import MockClock
+        except ImportError:
+            pytest.skip(reason="trio not installed")
+
+        async def main() -> float:
+            t1 = current_time()
+            await sleep(10)
+            return current_time() - t1
+
+        rt1 = time.monotonic()
+        trio_time = run(
+            main,
+            backend="trio",
+            backend_options={"clock": MockClock(autojump_threshold=0)},
+        )
+        real_time = time.monotonic() - rt1
+        assert real_time < 1
+        assert trio_time == 10


### PR DESCRIPTION
## Changes

In AnyIO 3.x the module-level `run = trio.run` was invoked as `asynclib.run(func, *args, **backend_options)`, but since 4.0's `AsyncBackend` refactor `anyio.run(..., backend="trio", backend_options={...})` silently discards the `backend_options`.

We still document trio `backend_options` as forwarded to `trio.run`, with `restrict_keyboard_interrupt_to_checkpoints` as an example, so this PR restores support in the obvious way.

A minimal motivating repro:

```python
import time, trio, trio.testing
from fastapi import FastAPI
from fastapi.testclient import TestClient

app = FastAPI()
@app.get("/s")
async def s():
    await trio.sleep(5)
    return {"t": trio.current_time()}

c = TestClient(app, backend="trio",
               backend_options={"clock": trio.testing.MockClock(autojump_threshold=0)})
t0 = time.monotonic()
c.get("/s")
print(f"wall={time.monotonic()-t0:.2f}s")  # 5.01s — clock never reached trio.run
```

Fixes #1162.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (n/a; restoring already-documented behavior)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
