### PR TITLE
Fixed cancel scope crash without a current task on the asyncio backend

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -57,6 +57,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``anyio.run()``; the options are now passed as keyword arguments to ``trio.run()``
   again, as documented (a regression from AnyIO 3)
   (`#1161 <https://github.com/agronholm/anyio/pull/1161>`_; PR by @Zac-HD)
+- Fixed ``TypeError: cannot create weak reference to 'NoneType' object`` on the asyncio
+  backend when a cancel scope or ``cancel_shielded_checkpoint()`` was used while
+  ``current_task()`` returned ``None``
+  (`#1163 <https://github.com/agronholm/anyio/pull/1163>`_; PR by @inoue22)
 
 **4.13.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -416,7 +416,11 @@ class CancelScope(BaseCancelScope):
                 "Each CancelScope may only be used for a single 'with' block"
             )
 
-        self._host_task = host_task = cast(asyncio.Task, current_task())
+        host_task = current_task()
+        if host_task is None:
+            raise RuntimeError("A cancel scope can only be entered from within a task")
+
+        self._host_task = host_task
         self._tasks.add(host_task)
         try:
             task_state = _task_states[host_task]
@@ -2424,6 +2428,10 @@ class AsyncIOBackend(AsyncBackend):
 
     @classmethod
     async def cancel_shielded_checkpoint(cls) -> None:
+        if current_task() is None:
+            await sleep(0)
+            return
+
         with CancelScope(shield=True):
             await sleep(0)
 

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -46,6 +46,8 @@ class CancelScope:
     :param shield: ``True`` to shield the cancel scope from external cancellation
     :raises NoEventLoopError: if no supported asynchronous event loop is running in the
         current thread
+    :raises RuntimeError: if the scope is entered while there is no current task in the
+        running event loop
     """
 
     def __new__(

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
 
 from anyio import create_task_group, run
+from anyio._backends import _asyncio
+from anyio._backends._asyncio import AsyncIOBackend, CancelScope
 from anyio.lowlevel import (
     RunVar,
     cancel_shielded_checkpoint,
@@ -84,6 +87,43 @@ async def test_checkpoint(cancel: bool) -> None:
 
     assert finished != cancel
     assert second_finished
+
+
+def test_cancel_scope_without_running_task(
+    asyncio_event_loop: asyncio.AbstractEventLoop,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entering a cancel scope without a current task raises a clear error (asyncio).
+
+    Regression test: previously this raised an obscure
+    ``TypeError: cannot create weak reference to 'NoneType' object`` because
+    ``current_task()`` returned ``None`` and that ``None`` was then used as a key in
+    a ``WeakKeyDictionary``.
+    """
+    monkeypatch.setattr(_asyncio, "current_task", lambda: None)
+
+    async def main() -> None:
+        with pytest.raises(
+            RuntimeError, match="can only be entered from within a task"
+        ):
+            with CancelScope():
+                pass
+
+    asyncio_event_loop.run_until_complete(main())
+
+
+def test_cancel_shielded_checkpoint_without_task(
+    asyncio_event_loop: asyncio.AbstractEventLoop,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cancel_shielded_checkpoint() must not crash without a current task (asyncio).
+
+    Library primitives such as ``CapacityLimiter`` reach this code path while
+    ``current_task()`` may return ``None``; it must degrade to a plain checkpoint
+    instead of raising ``TypeError``.
+    """
+    monkeypatch.setattr(_asyncio, "current_task", lambda: None)
+    asyncio_event_loop.run_until_complete(AsyncIOBackend.cancel_shielded_checkpoint())
 
 
 class TestRunVar:

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -104,7 +104,7 @@ def test_cancel_scope_without_running_task(
 
     async def main() -> None:
         with pytest.raises(
-            RuntimeError, match="can only be entered from within a task"
+            RuntimeError, match="A cancel scope can only be entered from within a task"
         ):
             with CancelScope():
                 pass


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

On the asyncio backend, entering a cancel scope while `asyncio.current_task()` returns `None` raised an obscure `TypeError: cannot create weak reference to 'NoneType' object`. `CancelScope.__enter__` used the host task as a key in a `WeakKeyDictionary` (`_task_states[host_task]`) without a `None` check.

This is reached through `CancelScope(shield=True)` inside `cancel_shielded_checkpoint()`, which primitives such as `CapacityLimiter` and `Lock` rely on, so using any of those while `current_task()` is `None` crashes instead of behaving gracefully.

This is inconsistent with the rest of the backend: `checkpoint_if_cancelled()` and `current_effective_deadline()` already treat `current_task() is None` as a benign no-op.

This PR makes the asyncio backend consistent:

- `cancel_shielded_checkpoint()` falls back to a plain checkpoint (`await sleep(0)`) when `current_task()` is `None` — with no current task there is nothing to shield from cancellation, mirroring `checkpoint_if_cancelled()`.
- `CancelScope.__enter__` now raises a clear `RuntimeError("A cancel scope can only be entered from within a task")` instead of the weakref `TypeError`. The `CancelScope` docstring documents the new `:raises RuntimeError:`.

The defect is independent of the Python version (reproduced identically on 3.12, 3.13 and 3.14).

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features (N/A)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.