### PR TITLE
(stacked PR) Fix `start(sync_fn, return_handle=True)`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- **BACKWARDS INCOMPATIBLE** ``TaskGroup.start`` no longer accepts synchronous functions
+  that call ``task_status.started()`` before they return a coroutine object
 - Added support for Python 3.15
 - Added an asynchronous implementation of the ``itertools`` module
   (`#998 <https://github.com/agronholm/anyio/issues/998>`_; PR by @11kkw)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -110,6 +110,11 @@ if TYPE_CHECKING:
 else:
     FileDescriptorLike = object
 
+if sys.version_info >= (3, 13):
+    from typing import TypeVar
+else:
+    from typing_extensions import TypeVar
+
 if sys.version_info >= (3, 11):
     from asyncio import Runner
     from typing import TypeVarTuple, Unpack
@@ -302,6 +307,7 @@ else:
 T_Retval = TypeVar("T_Retval")
 T_co = TypeVar("T_co", covariant=True)
 T_contra = TypeVar("T_contra", contravariant=True)
+T_contra_None = TypeVar("T_contra_None", contravariant=True, default=None)
 PosArgsT = TypeVarTuple("PosArgsT")
 P = ParamSpec("P")
 
@@ -720,12 +726,32 @@ _task_states: WeakKeyDictionary[asyncio.Task, TaskState] = WeakKeyDictionary()
 #
 
 
-class _AsyncioTaskStatus(abc.TaskStatus):
-    def __init__(self, future: asyncio.Future, parent_id: int):
+class _AsyncioTaskStatus(abc.TaskStatus[T_contra_None]):
+    def __init__(
+        self,
+        future: asyncio.Future[T_contra_None],
+        parent_id: int,
+        func: Callable[..., Coroutine[Any, Any, T_co]],
+    ):
         self._future = future
         self._parent_id = parent_id
+        self._func = func
+        self._func_returned_coro = False
 
-    def started(self, value: T_contra | None = None) -> None:
+    def started(
+        self,
+        value: T_contra_None = None,  # type: ignore[assignment]
+    ) -> None:
+        if not self._func_returned_coro:
+            # `func` called `started` before returning a coroutine object.
+            prefix = (
+                f"{self._func.__module__}." if hasattr(self._func, "__module__") else ""
+            )
+            raise TypeError(
+                f"{prefix}{self._func.__qualname__}() called task_status.started() "
+                "before returning a coroutine object"
+            )
+
         try:
             self._future.set_result(value)
         except asyncio.InvalidStateError:
@@ -941,8 +967,9 @@ class TaskGroup(abc.TaskGroup):
 
         future: asyncio.Future = asyncio.Future()
         final_name = get_callable_name(func, name)
-        task_status = _AsyncioTaskStatus(future, id(self.cancel_scope._host_task))
+        task_status = _AsyncioTaskStatus(future, id(self.cancel_scope._host_task), func)
         coro = call_for_coroutine(func, args, task_status=task_status)
+        task_status._func_returned_coro = True
         handle = self._spawn(coro, final_name, future)
 
         # If the task raises an exception after sending a start value without a switch

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -84,11 +84,16 @@ from .._core._tasks import CancelScope as BaseCancelScope
 from .._core._tasks import TaskHandle
 from ..abc import IPSockAddrType, UDPPacketType, UNIXDatagramPacketType
 from ..abc._eventloop import AsyncBackend, StrOrBytesPath
-from ..abc._tasks import get_callable_name
+from ..abc._tasks import call_for_coroutine, get_callable_name
 from ..streams.memory import MemoryObjectSendStream
 
 if TYPE_CHECKING:
     from _typeshed import FileDescriptorLike
+
+if sys.version_info >= (3, 13):
+    from typing import TypeVar
+else:
+    from typing_extensions import TypeVar
 
 if sys.version_info >= (3, 11):
     from typing import TypeVarTuple, Unpack
@@ -99,6 +104,7 @@ else:
 T = TypeVar("T")
 T_Retval = TypeVar("T_Retval")
 T_co = TypeVar("T_co", covariant=True)
+T_contra_None = TypeVar("T_contra_None", contravariant=True, default=None)
 T_SockAddr = TypeVar("T_SockAddr", str, IPSockAddrType)
 PosArgsT = TypeVarTuple("PosArgsT")
 P = ParamSpec("P")
@@ -170,6 +176,60 @@ class CancelScope(BaseCancelScope):
 #
 # Task groups
 #
+
+
+class _TaskHandleTaskStatus(
+    abc.TaskStatus[T_contra_None], Generic[T_co, T_contra_None]
+):
+    __slots__ = (
+        "_func",
+        "_wrapped",
+        "_handle",
+    )
+
+    def __init__(
+        self,
+        func: Callable[..., Coroutine[Any, Any, T_co]],
+        wrapped: trio.TaskStatus[TaskHandle[T_co, T_contra_None]],
+    ) -> None:
+        self._func = func
+        self._wrapped = wrapped
+        self._handle: TaskHandle[T_co, T_contra_None] | None = None
+
+    @overload
+    def started(self: _TaskHandleTaskStatus) -> None: ...
+
+    @overload
+    def started(self, value: T_contra_None) -> None: ...
+
+    def started(
+        self,
+        value: T_contra_None = None,  # type: ignore[assignment]
+    ) -> None:
+        try:
+            self._handle  # noqa: B018
+        except AttributeError:
+            raise RuntimeError(
+                "called 'started' twice on the same task status"
+            ) from None
+
+        if self._handle is None:
+            # `func` called `started` before returning a coroutine object.
+            prefix = (
+                f"{self._func.__module__}." if hasattr(self._func, "__module__") else ""
+            )
+            raise TypeError(
+                f"{prefix}{self._func.__qualname__}() called task_status.started() "
+                "before returning a coroutine object"
+            )
+
+        self._handle._start_value = value
+        self._wrapped.started(self._handle)
+        # Break the reference cycle.
+        try:
+            del self._handle
+        except AttributeError:
+            pass
 
 
 class TaskGroup(abc.TaskGroup):
@@ -244,25 +304,21 @@ class TaskGroup(abc.TaskGroup):
         name: object = None,
         return_handle: Literal[False] | Literal[True] = False,
     ) -> Any:
-        handle: TaskHandle[T_co]
-
         async def run_coro_with_task_status(
-            *, task_status: trio.TaskStatus[Any]
+            *, task_status: trio.TaskStatus[TaskHandle[T_co, Any]]
         ) -> None:
-            nonlocal handle
-            coro = func(*args, task_status=task_status)
-            handle = TaskHandle(coro, name)
+            user_task_status = _TaskHandleTaskStatus(func, task_status)
+            coro = call_for_coroutine(func, args, task_status=user_task_status)
+            handle = user_task_status._handle = TaskHandle(coro, name)
             await handle._run_coro()
 
         self._check_active()
         final_name = get_callable_name(func, name)
+        handle = await self._nursery.start(run_coro_with_task_status, name=final_name)
         if return_handle:
-            handle._start_value = await self._nursery.start(
-                run_coro_with_task_status, name=final_name
-            )
             return handle
         else:
-            return await self._nursery.start(func, *args, name=final_name)
+            return handle.start_value
 
 
 #

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -330,18 +330,51 @@ async def test_cancel_with_nested_task_groups() -> None:
     assert len(outer_cancel_spy.call_args_list) < 10
 
 
-async def test_start_exception_delivery(anyio_backend_name: str) -> None:
-    def task_fn(*, task_status: TaskStatus[str] = TASK_STATUS_IGNORED) -> None:
-        task_status.started("hello")
+@pytest.mark.parametrize("return_handle", [False, True])
+async def test_start_soon_sync_fn_exception_delivery(return_handle: bool) -> None:
+    def taskfunc() -> None:
+        pass
 
-    if anyio_backend_name == "trio":
-        pattern = "appears to be synchronous"
-    else:
-        pattern = "is not a coroutine object"
+    async with create_task_group() as tg:
+        with pytest.raises(
+            TypeError,
+            match=rf"^{re.escape('Expected tests.test_taskgroups.test_start_soon_sync_fn_exception_delivery.<locals>.taskfunc() to return a coroutine, but the return value (None) is not a coroutine object')}$",
+        ):
+            tg.start_soon(taskfunc)  # type: ignore[arg-type]
 
-    async with anyio.create_task_group() as tg:
-        with pytest.raises(TypeError, match=pattern):
-            await tg.start(task_fn)  # type: ignore[arg-type]
+
+@pytest.mark.parametrize("return_handle", [False, True])
+async def test_start_sync_fn_exception_delivery(return_handle: bool) -> None:
+    def taskfunc(*, task_status: TaskStatus[None]) -> None:
+        pass
+
+    async with create_task_group() as tg:
+        with pytest.raises(
+            TypeError,
+            match=rf"^{re.escape('Expected tests.test_taskgroups.test_start_sync_fn_exception_delivery.<locals>.taskfunc() to return a coroutine, but the return value (None) is not a coroutine object')}$",
+        ):
+            await tg.start(taskfunc, return_handle=return_handle)  # type: ignore[call-overload]
+
+
+@pytest.mark.parametrize("return_handle", [False, True])
+async def test_started_in_sync_fn_exception_delivery(return_handle: bool) -> None:
+    error_msg = "tests.test_taskgroups.test_started_in_sync_fn_exception_delivery.<locals>.taskfunc() called task_status.started() before returning a coroutine object"
+
+    def taskfunc(*, task_status: TaskStatus[None]) -> None:
+        try:
+            task_status.started()
+        except TypeError as exc:
+            assert str(exc) == error_msg
+            raise
+        else:
+            pytest.fail("started() should have raised")
+
+    async with create_task_group() as tg:
+        with pytest.raises(
+            TypeError,
+            match=rf"^{re.escape(error_msg)}$",
+        ):
+            await tg.start(taskfunc, return_handle=return_handle)  # type: ignore[call-overload]
 
 
 async def test_start_cancel_after_error() -> None:


### PR DESCRIPTION
## Changes

This is one proposed way to fix

> encountered an annoying problem with the task handles PR: if a regular function is passed to `TaskGroup.start()`, the coroutine check only happens inside the already-created task, causing the `await tg.start(...)` call to succeed since `task_status.started()` was in fact called, so the exception falls out of the task group [[src](https://matrix.to/#/!JfFIjeKHlqEVmAsxYP:gitter.im/$b_oGr3x6vvwSuIyT-ARf1QzaqiC1jMtnnGiVnVOKUPo?via=gitter.im)]
> 
> it might be unavoidable to pass another task status object to the actual callable [[src](https://matrix.to/#/!JfFIjeKHlqEVmAsxYP:gitter.im/$G5voxgQ258IkGElBqZ3y0Mz0xFzmoUXQCK4npG8mugQ?via=gitter.im)]

The idea is to disallow calling `TaskStatus.started()` prior to when the user-provided `Callable[..., Coroutine[Any, Any, T_co]]` has returned a coroutine object. If the user tries to do so, `TaskStatus.started` will raise an exception instead of reparenting the task and returning success.

This proposal would introduce a slight backward-incompatibility: `start` would no longer accept a `taskfunc` that calls `started()` in a sync callable before returning the coroutine object. For example, with this proposal the following would no longer work:

```python
from __future__ import annotations

from collections.abc import Coroutine
from typing import Any

import anyio
from anyio.abc import TaskStatus


async def real_taskfunc() -> None:
    print("okay")


def fake_taskfunc(task_status: TaskStatus[None]) -> Coroutine[Any, Any, None]:
    task_status.started()
    return real_taskfunc()


async def main() -> None:
    async with anyio.create_task_group() as tg:
        await tg.start(fake_taskfunc)


anyio.run(main, backend="asyncio")
anyio.run(main, backend="trio")
```

Also: Synced up the exception messages on the two backends (https://github.com/agronholm/anyio/pull/1153#discussion_r3308501906).

Also: Did https://github.com/agronholm/anyio/pull/1153#discussion_r3314137998 because doing so provided for a simpler implementation.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.