### PR TITLE
Fix Process.aclose() deadlock on asyncio with subprocess blocked on a…

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -9,6 +9,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   if a grandchild inherited it), instead of returning once the process exits
   like the other backends do
   (`#1174 <https://github.com/agronholm/anyio/issues/1174>`_; PR by @tapetersen)
+- Fixed ``Process.aclose()`` deadlocking on the asyncio backend when the subprocess is
+  blocked on writing to a stdout or stderr pipe whose buffer is full; closing the
+  process's standard streams now also closes the underlying pipe transports
+  (`#1166 <https://github.com/agronholm/anyio/issues/1166>`_; PR by @tapetersen)
 
 **4.14.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -57,6 +57,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``anyio.run()``; the options are now passed as keyword arguments to ``trio.run()``
   again, as documented (a regression from AnyIO 3)
   (`#1161 <https://github.com/agronholm/anyio/pull/1161>`_; PR by @Zac-HD)
+  Fixed ``Process.wait()`` on asyncio waiting for stdout/stderr kept open (e.g.
+  if a grandchild inherited it), instead of returning once the process exits
+  like the other backends do
+  (`#1174 <https://github.com/agronholm/anyio/issues/1174>`_; PR by @tapetersen)
+
 
 **4.13.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1092,6 +1092,7 @@ class Process(abc.Process):
     _stdin: StreamWriterWrapper | None
     _stdout: StreamReaderWrapper | None
     _stderr: StreamReaderWrapper | None
+    _exited: asyncio.Event
 
     async def aclose(self) -> None:
         with CancelScope(shield=True) as scope:
@@ -1112,7 +1113,9 @@ class Process(abc.Process):
                 raise
 
     async def wait(self) -> int:
-        return await self._process.wait()
+        await self._exited.wait()
+        assert self._process.returncode is not None
+        return self._process.returncode
 
     def terminate(self) -> None:
         self._process.terminate()
@@ -2352,6 +2355,24 @@ class TestRunner(abc.TestRunner):
         self._raise_async_exceptions()
 
 
+class _ProcessStreamProtocol(asyncio.subprocess.SubprocessStreamProtocol):
+    """
+    A subprocess protocol that allows us to be notified of ``process_exited``
+
+    asyncio's own ``Process.wait()`` only resolves once every pipe transport has
+    disconnected so to get same semantics as on trio and uvloop we need this.
+    """
+
+    def __init__(self) -> None:
+        """Match standard factory for asyncio.create_process"""
+        super().__init__(limit=2**16, loop=asyncio.get_running_loop())
+        self.exited = asyncio.Event()
+
+    def process_exited(self) -> None:
+        super().process_exited()
+        self.exited.set()
+
+
 class AsyncIOBackend(AsyncBackend):
     @classmethod
     def run(
@@ -2635,8 +2656,13 @@ class AsyncIOBackend(AsyncBackend):
         if isinstance(command, PathLike):
             command = os.fspath(command)
 
+        # Use loop.subprocess_shell()/subprocess_exec() rather than their
+        # asyncio.create_subprocess_*() counterparts to get access to
+        # transport/protocol.
+        loop = asyncio.get_running_loop()
         if isinstance(command, (str, bytes)):
-            process = await asyncio.create_subprocess_shell(
+            transport, protocol = await loop.subprocess_shell(
+                _ProcessStreamProtocol,
                 command,
                 stdin=stdin,
                 stdout=stdout,
@@ -2644,7 +2670,8 @@ class AsyncIOBackend(AsyncBackend):
                 **kwargs,
             )
         else:
-            process = await asyncio.create_subprocess_exec(
+            transport, protocol = await loop.subprocess_exec(
+                _ProcessStreamProtocol,
                 *command,
                 stdin=stdin,
                 stdout=stdout,
@@ -2652,10 +2679,13 @@ class AsyncIOBackend(AsyncBackend):
                 **kwargs,
             )
 
+        process = asyncio.subprocess.Process(transport, protocol, loop)
         stdin_stream = StreamWriterWrapper(process.stdin) if process.stdin else None
         stdout_stream = StreamReaderWrapper(process.stdout) if process.stdout else None
         stderr_stream = StreamReaderWrapper(process.stderr) if process.stderr else None
-        return Process(process, stdin_stream, stdout_stream, stderr_stream)
+        return Process(
+            process, stdin_stream, stdout_stream, stderr_stream, protocol.exited
+        )
 
     @classmethod
     def setup_process_pool_exit_at_shutdown(cls, workers: set[abc.Process]) -> None:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2738,7 +2738,12 @@ class AsyncIOBackend(AsyncBackend):
         stdout_stream = StreamReaderWrapper(process.stdout) if process.stdout else None
         stderr_stream = StreamReaderWrapper(process.stderr) if process.stderr else None
         return Process(
-            process, stdin_stream, stdout_stream, stderr_stream, protocol.exited, transport
+            process,
+            stdin_stream,
+            stdout_stream,
+            stderr_stream,
+            protocol.exited,
+            transport,
         )
 
     @classmethod

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1117,6 +1117,7 @@ class Process(abc.Process):
     _stdout: StreamReaderWrapper | None
     _stderr: StreamReaderWrapper | None
     _exited: asyncio.Event
+    _transport: asyncio.SubprocessTransport
 
     async def aclose(self) -> None:
         with CancelScope(shield=True) as scope:
@@ -1126,6 +1127,15 @@ class Process(abc.Process):
                 await self._stdout.aclose()
             if self._stderr:
                 await self._stderr.aclose()
+
+            # Close all the pipe transports too (closing the wrapper streams above
+            # doesn't do that). Otherwise the subprocess never gets EPIPE if it's
+            # blocked on writing to a full pipe, and asyncio's Process.wait() won't
+            # return while any pipe is still connected, so wait() below would
+            # deadlock.
+            for fd in (0, 1, 2):
+                if pipe_transport := self._transport.get_pipe_transport(fd):
+                    pipe_transport.close()
 
             scope.shield = False
             try:
@@ -2728,7 +2738,7 @@ class AsyncIOBackend(AsyncBackend):
         stdout_stream = StreamReaderWrapper(process.stdout) if process.stdout else None
         stderr_stream = StreamReaderWrapper(process.stderr) if process.stderr else None
         return Process(
-            process, stdin_stream, stdout_stream, stderr_stream, protocol.exited
+            process, stdin_stream, stdout_stream, stderr_stream, protocol.exited, transport
         )
 
     @classmethod

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -424,3 +424,28 @@ async def test_wait_returns_on_process_exit_with_open_stdout() -> None:
             pass
         async for _ in process.stderr:
             pass
+
+
+async def test_close_with_stdout_blocked_subprocess(anyio_backend_name: str) -> None:
+    """
+    Regression test for #1166.
+
+    Test that closing a process unblocks a subprocess blocked on writing to stdout
+    (because the pipe buffer is full and nobody is reading), instead of deadlocking
+    while waiting for it to exit.
+    """
+    code = dedent("""\
+    import sys
+
+    sys.stdout.write("x" * 1024 * 1024)
+    """)
+
+    process = await open_process([sys.executable, "-c", code])
+    try:
+        with fail_after(5):
+            await process.aclose()
+    except TimeoutError:
+        if anyio_backend_name == "asyncio":
+            process._process._transport.close()  # type: ignore[attr-defined]
+
+        pytest.fail("Process.aclose() deadlocked")

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -17,6 +17,7 @@ from anyio import (
     ClosedResourceError,
     EndOfStream,
     create_task_group,
+    fail_after,
     open_process,
     run_process,
 )
@@ -391,3 +392,35 @@ async def test_close_while_reading() -> None:
             await process.stdout.receive()
 
         process.terminate()
+
+
+async def test_wait_returns_on_process_exit_with_open_stdout() -> None:
+    """
+    wait() should return once the process exits, rather than waiting for the piped
+    stdout/stderr to close. Easiest triggered by a grandchild that inherits the
+    stdout pipe and keeps it open after the immediate child has exited.
+    """
+    code = dedent("""\
+    import subprocess, sys
+
+    subprocess.Popen(
+        [sys.executable, "-c", "import select, sys; select.select([sys.stdin], [], [], 10)"]
+    )
+    """)
+
+    process = await open_process([sys.executable, "-c", code])
+    assert process.stdin is not None
+    assert process.stdout is not None
+    assert process.stderr is not None
+
+    # Closing stdin unblocks the grandchild
+    async with process.stdin:
+        with fail_after(5):
+            assert await process.wait() == 0
+
+    # Wait for grandchild to exit to avoid ResourceWarnings
+    with fail_after(3, shield=True):
+        async for _ in process.stdout:
+            pass
+        async for _ in process.stderr:
+            pass


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Code and description below mostly by claude with very heavy supervision.

Fixes #1166.

Closing a process's standard streams on the asyncio backend only set an exception on the `asyncio.StreamReader` without closing the underlying pipe transports. A subprocess blocked on writing to a full pipe would then never receive `EPIPE`, and since asyncio's `Process.wait()` only resolves once all pipe transports have disconnected (and reading had been paused by the stream reader's flow control), `aclose()` would deadlock waiting for the process to exit.

The subprocess is now launched via `loop.subprocess_exec()`/`subprocess_shell()` so that the subprocess transport is available to ´Process.aclose()´, which closes all the pipe transports before waiting for the process to exit.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
