### PR TITLE
Fix CapacityLimiter over-granting tokens on asyncio

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,11 +8,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when
   ``max_bytes`` is not a positive integer
   (`#1191 <https://github.com/agronholm/anyio/pull/1191>`_)
-- Fixed ``CapacityLimiter.total_tokens`` rejecting ``float("inf")`` when the limiter was
-  instantiated outside of an event loop. The adapter setter checked for infinity by
-  identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,
-  while every backend setter (using ``math.isinf()``) accepts any positive infinity
-  (`#1189 <https://github.com/agronholm/anyio/pull/1189>`_; PR by @greymoth-jp).
 - Fixed ``to_process.run_sync()`` deadlocking when the worker function writes enough data
   to ``sys.stderr`` to fill the (undrained) pipe buffer. The worker process now redirects
   ``sys.stderr`` to ``os.devnull`` as well, matching the documented behavior
@@ -23,6 +18,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``anyio.open_process()`` (and ``run_process()``) ignoring the ``extra_groups``
   argument, as it mistakenly passed the value of the ``group`` argument instead
   (`#1209 <https://github.com/agronholm/anyio/pull/1209>`_)
+- Fixed ``CapacityLimiter.total_tokens`` rejecting ``float("inf")`` when the limiter was
+  instantiated outside of an event loop. The adapter setter checked for infinity by
+  identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,
+  while every backend setter (using ``math.isinf()``) accepts any positive infinity
+  (`#1189 <https://github.com/agronholm/anyio/pull/1189>`_; PR by @greymoth-jp).
 
 **4.14.1**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -50,6 +50,13 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   * ``anyio.Lock``
   * ``anyio.ResourceGuard``
   * ``anyio.Semaphore``
+- Fixed ``CapacityLimiter`` on the asyncio backend over-granting tokens
+  (``borrowed_tokens`` exceeding ``total_tokens`` and ``available_tokens`` going
+  negative) when a non-blocking acquire was made in the window between a token
+  being released and the notified waiter resuming. The freed token is now
+  reserved for the woken waiter right away, so the non-blocking acquire correctly
+  raises ``WouldBlock``
+  (`#1170 <https://github.com/agronholm/anyio/issues/1170>`_; PR by @gaoflow)
 - Fixed cancellation exception escaping a cancel scope when triggered via
   ``check_cancelled()`` in a worker thread
   (`#1113 <https://github.com/agronholm/anyio/issues/1113>`_)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,6 +8,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when
   ``max_bytes`` is not a positive integer
   (`#1191 <https://github.com/agronholm/anyio/pull/1191>`_)
+- Fixed ``CapacityLimiter.total_tokens`` rejecting ``float("inf")`` when the limiter was
+  instantiated outside of an event loop. The adapter setter checked for infinity by
+  identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,
+  while every backend setter (using ``math.isinf()``) accepts any positive infinity
+  (`#1189 <https://github.com/agronholm/anyio/pull/1189>`_; PR by @greymoth-jp).
 - Fixed ``to_process.run_sync()`` deadlocking when the worker function writes enough data
   to ``sys.stderr`` to fill the (undrained) pipe buffer. The worker process now redirects
   ``sys.stderr`` to ``os.devnull`` as well, matching the documented behavior
@@ -18,11 +23,13 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``anyio.open_process()`` (and ``run_process()``) ignoring the ``extra_groups``
   argument, as it mistakenly passed the value of the ``group`` argument instead
   (`#1209 <https://github.com/agronholm/anyio/pull/1209>`_)
-- Fixed ``CapacityLimiter.total_tokens`` rejecting ``float("inf")`` when the limiter was
-  instantiated outside of an event loop. The adapter setter checked for infinity by
-  identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,
-  while every backend setter (using ``math.isinf()``) accepts any positive infinity
-  (`#1189 <https://github.com/agronholm/anyio/pull/1189>`_; PR by @greymoth-jp).
+- Fixed ``CapacityLimiter`` on the asyncio backend over-granting tokens
+  (``borrowed_tokens`` exceeding ``total_tokens`` and ``available_tokens`` going
+  negative) when a non-blocking acquire was made in the window between a token
+  being released and the notified waiter resuming. The freed token is now
+  reserved for the woken waiter right away, so the non-blocking acquire correctly
+  raises ``WouldBlock``
+  (`#1170 <https://github.com/agronholm/anyio/issues/1170>`_; PR by @gaoflow)
 
 **4.14.1**
 
@@ -94,13 +101,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   * ``anyio.Lock``
   * ``anyio.ResourceGuard``
   * ``anyio.Semaphore``
-- Fixed ``CapacityLimiter`` on the asyncio backend over-granting tokens
-  (``borrowed_tokens`` exceeding ``total_tokens`` and ``available_tokens`` going
-  negative) when a non-blocking acquire was made in the window between a token
-  being released and the notified waiter resuming. The freed token is now
-  reserved for the woken waiter right away, so the non-blocking acquire correctly
-  raises ``WouldBlock``
-  (`#1170 <https://github.com/agronholm/anyio/issues/1170>`_; PR by @gaoflow)
 - Fixed cancellation exception escaping a cancel scope when triggered via
   ``check_cancelled()`` in a worker thread
   (`#1113 <https://github.com/agronholm/anyio/issues/1113>`_)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2091,13 +2091,7 @@ class CapacityLimiter(BaseCapacityLimiter):
         return self._total_tokens - len(self._borrowers)
 
     def _notify_next_waiter(self) -> None:
-        """Hand a free token to the next task in line, if any.
-
-        The token is reserved for the woken task right away (the borrower is
-        added to ``_borrowers`` before its event is set) so that the freed token
-        is never momentarily visible as available to a non-blocking acquire made
-        before the woken task has resumed.
-        """
+        """Hand a free token to the next task in line, if any."""
         if self._wait_queue and len(self._borrowers) < self._total_tokens:
             borrower, event = self._wait_queue.popitem(last=False)
             self._borrowers.add(borrower)
@@ -2132,16 +2126,10 @@ class CapacityLimiter(BaseCapacityLimiter):
             except BaseException:
                 self._wait_queue.pop(borrower, None)
                 if event.is_set():
-                    # The token was already reserved for us when we were
-                    # notified; since we're bailing out, release it and pass it
-                    # on to the next waiter.
                     self._borrowers.discard(borrower)
                     self._notify_next_waiter()
 
                 raise
-
-            # The token was reserved for us by the notifying side, so there's no
-            # need to add ourselves to the borrowers here.
         else:
             try:
                 await AsyncIOBackend.cancel_shielded_checkpoint()

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2042,7 +2042,8 @@ class CapacityLimiter(BaseCapacityLimiter):
 
         # Notify waiting tasks that they have acquired the limiter
         while self._wait_queue and waiters_to_notify:
-            event = self._wait_queue.popitem(last=False)[1]
+            borrower, event = self._wait_queue.popitem(last=False)
+            self._borrowers.add(borrower)
             event.set()
             waiters_to_notify -= 1
 
@@ -2055,9 +2056,16 @@ class CapacityLimiter(BaseCapacityLimiter):
         return self._total_tokens - len(self._borrowers)
 
     def _notify_next_waiter(self) -> None:
-        """Notify the next task in line if this limiter has free capacity now."""
+        """Hand a free token to the next task in line, if any.
+
+        The token is reserved for the woken task right away (the borrower is
+        added to ``_borrowers`` before its event is set) so that the freed token
+        is never momentarily visible as available to a non-blocking acquire made
+        before the woken task has resumed.
+        """
         if self._wait_queue and len(self._borrowers) < self._total_tokens:
-            event = self._wait_queue.popitem(last=False)[1]
+            borrower, event = self._wait_queue.popitem(last=False)
+            self._borrowers.add(borrower)
             event.set()
 
     def acquire_nowait(self) -> None:
@@ -2089,11 +2097,16 @@ class CapacityLimiter(BaseCapacityLimiter):
             except BaseException:
                 self._wait_queue.pop(borrower, None)
                 if event.is_set():
+                    # The token was already reserved for us when we were
+                    # notified; since we're bailing out, release it and pass it
+                    # on to the next waiter.
+                    self._borrowers.discard(borrower)
                     self._notify_next_waiter()
 
                 raise
 
-            self._borrowers.add(borrower)
+            # The token was reserved for us by the notifying side, so there's no
+            # need to add ourselves to the borrowers here.
         else:
             try:
                 await AsyncIOBackend.cancel_shielded_checkpoint()

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -994,13 +994,12 @@ class TestCapacityLimiter:
         with pytest.raises(WouldBlock):
             limiter.acquire_on_behalf_of_nowait(borrower2)
 
-    @pytest.mark.parametrize("anyio_backend", asyncio_params)
     async def test_nowait_acquire_after_release_does_not_oversubscribe(self) -> None:
         # Regression test for #1170: a non-blocking acquire issued in the window
         # between releasing a token (which notifies the next waiter) and that
         # waiter actually resuming must not slip through, as the freed token is
-        # already reserved for the woken waiter. This window is specific to the
-        # asyncio backend (the trio backend wraps trio's own CapacityLimiter).
+        # already reserved for the woken waiter. The over-granting bug was
+        # specific to the asyncio backend, but the invariant holds on both.
         limiter = CapacityLimiter(1)
         limiter.acquire_on_behalf_of_nowait("A")
 

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -929,3 +929,32 @@ class TestCapacityLimiter:
             tg.cancel_scope.cancel()
 
         pytest.fail("The second borrower failed to acquire the limiter")
+
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
+    async def test_nowait_acquire_after_release_does_not_oversubscribe(self) -> None:
+        # Regression test for #1170: a non-blocking acquire issued in the window
+        # between releasing a token (which notifies the next waiter) and that
+        # waiter actually resuming must not slip through, as the freed token is
+        # already reserved for the woken waiter. This window is specific to the
+        # asyncio backend (the trio backend wraps trio's own CapacityLimiter).
+        limiter = CapacityLimiter(1)
+        limiter.acquire_on_behalf_of_nowait("A")
+
+        async def waiter() -> None:
+            await limiter.acquire_on_behalf_of("B")
+
+        async with create_task_group() as tg:
+            tg.start_soon(waiter)
+            await wait_all_tasks_blocked()
+            assert limiter.statistics().tasks_waiting == 1
+
+            # Frees the only token and reserves it for the still-parked "B"; no
+            # token is available, so the nowait acquire must raise WouldBlock.
+            limiter.release_on_behalf_of("A")
+            with pytest.raises(WouldBlock):
+                limiter.acquire_on_behalf_of_nowait("X")
+
+        assert limiter.borrowed_tokens <= limiter.total_tokens
+        assert limiter.available_tokens >= 0
+        assert limiter.statistics().borrowers == ("B",)
+        limiter.release_on_behalf_of("B")


### PR DESCRIPTION
## Changes

Fixes #1170.

On the asyncio backend, `CapacityLimiter` could over-grant tokens: a non-blocking acquire issued in the window between a token being released (which notifies the next waiter) and that waiter actually resuming would slip through, leaving `borrowed_tokens > total_tokens` and `available_tokens` negative — two tasks holding a single-token limiter at once.

The cause: `release_on_behalf_of` popped the next waiter out of `_wait_queue` and set its event, but the waiter only added itself to `_borrowers` *after* it resumed. In between, the wait queue was empty and the borrower count was below the limit, so `acquire_on_behalf_of_nowait`'s guard admitted a second borrower for the already-reserved token.

The fix reserves the freed token for the woken waiter the moment its event is set — the borrower is added to `_borrowers` in `_notify_next_waiter` (and when `total_tokens` is increased) rather than after the waiter resumes — mirroring the hand-off that already makes `Semaphore`/`Lock` immune. Consequently:

- the woken waiter no longer re-adds itself to `_borrowers` on resume, and
- a waiter cancelled *after* being granted the token now releases it and passes it on to the next waiter.

Only the asyncio backend is affected; the trio backend wraps trio's own `CapacityLimiter`.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

<!-- Tests: tests/test_synchronization.py::TestCapacityLimiter::test_nowait_acquire_after_release_does_not_oversubscribe (asyncio backends; fails without the patch). No docs change: the patch restores the already-documented WouldBlock contract. -->

---

This change was prepared by an AI agent under my direction; I reviewed and verified it.
