### PR TITLE
Fix asyncio waiting on closing streams in ``Process.wait()``

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -14,6 +14,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   if a grandchild inherited it), instead of returning once the process exits
   like the other backends do
   (`#1174 <https://github.com/agronholm/anyio/issues/1174>`_; PR by @tapetersen)
+- Fixed ``Process.aclose()`` deadlocking on the asyncio backend when the subprocess is
+  blocked on writing to a stdout or stderr pipe whose buffer is full; closing the
+  process's standard streams now also closes the underlying pipe transports
+  (`#1166 <https://github.com/agronholm/anyio/issues/1166>`_; PR by @tapetersen)
 
 
 **4.14.0**

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,6 +10,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   when an async test raise an outcome exception (e.g., ``pytest.skip()``, ``pytest.xfail()``,
   or ``pytest.fail()``)
   (`#1179 <https://github.com/agronholm/anyio/issues/1179>`_; PR by @EmmanuelNiyonshuti)
+- Fixed ``Process.wait()`` on asyncio waiting for stdout/stderr kept open (e.g.
+  if a grandchild inherited it), instead of returning once the process exits
+  like the other backends do
+  (`#1174 <https://github.com/agronholm/anyio/issues/1174>`_; PR by @tapetersen)
+
 
 **4.14.0**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2422,7 +2422,7 @@ class _ProcessStreamProtocol(asyncio.subprocess.SubprocessStreamProtocol):
     """
 
     def __init__(self) -> None:
-        """Match standard factory for asyncio.create_process"""
+        # Match the standard factory for asyncio.create_process
         super().__init__(limit=2**16, loop=asyncio.get_running_loop())
         self.exited = asyncio.Event()
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1117,22 +1117,32 @@ class Process(abc.Process):
     _stdout: StreamReaderWrapper | None
     _stderr: StreamReaderWrapper | None
     _exited: asyncio.Event
+    _transport: asyncio.SubprocessTransport
 
     async def aclose(self) -> None:
         with CancelScope(shield=True) as scope:
+            # We need to close the underlying pipe_transports as well to allow a
+            # process blocking on full buffers to receive SIGPIPE and exit.
             if self._stdin:
                 await self._stdin.aclose()
+                if pipe := self._transport.get_pipe_transport(0):
+                    pipe.close()
             if self._stdout:
                 await self._stdout.aclose()
+                if pipe := self._transport.get_pipe_transport(1):
+                    pipe.close()
             if self._stderr:
                 await self._stderr.aclose()
+                if pipe := self._transport.get_pipe_transport(2):
+                    pipe.close()
 
             scope.shield = False
             try:
                 await self.wait()
             except BaseException:
                 scope.shield = True
-                self.kill()
+                # Closing the transport on asyncio also handles sending kill
+                self._transport.close()
                 await self.wait()
                 raise
 
@@ -2732,7 +2742,12 @@ class AsyncIOBackend(AsyncBackend):
         stdout_stream = StreamReaderWrapper(process.stdout) if process.stdout else None
         stderr_stream = StreamReaderWrapper(process.stderr) if process.stderr else None
         return Process(
-            process, stdin_stream, stdout_stream, stderr_stream, protocol.exited
+            process,
+            stdin_stream,
+            stdout_stream,
+            stderr_stream,
+            protocol.exited,
+            transport,
         )
 
     @classmethod

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1116,6 +1116,7 @@ class Process(abc.Process):
     _stdin: StreamWriterWrapper | None
     _stdout: StreamReaderWrapper | None
     _stderr: StreamReaderWrapper | None
+    _exited: asyncio.Event
 
     async def aclose(self) -> None:
         with CancelScope(shield=True) as scope:
@@ -1136,7 +1137,9 @@ class Process(abc.Process):
                 raise
 
     async def wait(self) -> int:
-        return await self._process.wait()
+        await self._exited.wait()
+        assert self._process.returncode is not None
+        return self._process.returncode
 
     def terminate(self) -> None:
         self._process.terminate()
@@ -2400,6 +2403,24 @@ class TestRunner(abc.TestRunner):
         self._raise_async_exceptions()
 
 
+class _ProcessStreamProtocol(asyncio.subprocess.SubprocessStreamProtocol):
+    """
+    A subprocess protocol that allows us to be notified of ``process_exited``
+
+    asyncio's own ``Process.wait()`` only resolves once every pipe transport has
+    disconnected so to get same semantics as on trio and uvloop we need this.
+    """
+
+    def __init__(self) -> None:
+        """Match standard factory for asyncio.create_process"""
+        super().__init__(limit=2**16, loop=asyncio.get_running_loop())
+        self.exited = asyncio.Event()
+
+    def process_exited(self) -> None:
+        super().process_exited()
+        self.exited.set()
+
+
 class AsyncIOBackend(AsyncBackend):
     @classmethod
     def run(
@@ -2683,8 +2704,13 @@ class AsyncIOBackend(AsyncBackend):
         if isinstance(command, PathLike):
             command = os.fspath(command)
 
+        # Use loop.subprocess_shell()/subprocess_exec() rather than their
+        # asyncio.create_subprocess_*() counterparts to get access to
+        # transport/protocol.
+        loop = asyncio.get_running_loop()
         if isinstance(command, (str, bytes)):
-            process = await asyncio.create_subprocess_shell(
+            transport, protocol = await loop.subprocess_shell(
+                _ProcessStreamProtocol,
                 command,
                 stdin=stdin,
                 stdout=stdout,
@@ -2692,7 +2718,8 @@ class AsyncIOBackend(AsyncBackend):
                 **kwargs,
             )
         else:
-            process = await asyncio.create_subprocess_exec(
+            transport, protocol = await loop.subprocess_exec(
+                _ProcessStreamProtocol,
                 *command,
                 stdin=stdin,
                 stdout=stdout,
@@ -2700,10 +2727,13 @@ class AsyncIOBackend(AsyncBackend):
                 **kwargs,
             )
 
+        process = asyncio.subprocess.Process(transport, protocol, loop)
         stdin_stream = StreamWriterWrapper(process.stdin) if process.stdin else None
         stdout_stream = StreamReaderWrapper(process.stdout) if process.stdout else None
         stderr_stream = StreamReaderWrapper(process.stderr) if process.stderr else None
-        return Process(process, stdin_stream, stdout_stream, stderr_stream)
+        return Process(
+            process, stdin_stream, stdout_stream, stderr_stream, protocol.exited
+        )
 
     @classmethod
     def setup_process_pool_exit_at_shutdown(cls, workers: set[abc.Process]) -> None:

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -17,6 +17,7 @@ from anyio import (
     ClosedResourceError,
     EndOfStream,
     create_task_group,
+    fail_after,
     open_process,
     run_process,
 )
@@ -391,3 +392,35 @@ async def test_close_while_reading() -> None:
             await process.stdout.receive()
 
         process.terminate()
+
+
+async def test_wait_returns_on_process_exit_with_open_stdout() -> None:
+    """
+    wait() should return once the process exits, rather than waiting for the piped
+    stdout/stderr to close. Easiest triggered by a grandchild that inherits the
+    stdout pipe and keeps it open after the immediate child has exited.
+    """
+    code = dedent("""\
+    import subprocess, sys
+
+    subprocess.Popen(
+        [sys.executable, "-c", "import select, sys; select.select([sys.stdin], [], [], 10)"]
+    )
+    """)
+
+    process = await open_process([sys.executable, "-c", code])
+    assert process.stdin is not None
+    assert process.stdout is not None
+    assert process.stderr is not None
+
+    # Closing stdin unblocks the grandchild
+    async with process.stdin:
+        with fail_after(5):
+            assert await process.wait() == 0
+
+    # Wait for grandchild to exit to avoid ResourceWarnings
+    with fail_after(3, shield=True):
+        async for _ in process.stdout:
+            pass
+        async for _ in process.stderr:
+            pass

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -424,3 +424,25 @@ async def test_wait_returns_on_process_exit_with_open_stdout() -> None:
             pass
         async for _ in process.stderr:
             pass
+
+
+async def test_close_with_stdout_blocked_subprocess(anyio_backend_name: str) -> None:
+    """
+    Regression test for #1166.
+
+    Test that closing a process unblocks a subprocess blocked on writing to stdout
+    (because the pipe buffer is full and nobody is reading), instead of deadlocking
+    while waiting for it to exit.
+    """
+
+    process = await open_process(
+        [sys.executable, "-c", "import sys;sys.stdout.write('x' * 1024 * 1024)"]
+    )
+    try:
+        with fail_after(5):
+            await process.aclose()
+    except TimeoutError:
+        if anyio_backend_name == "asyncio":
+            process._process._transport.close()  # type: ignore[attr-defined]
+
+        pytest.fail("Process.aclose() deadlocked")

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -422,6 +422,7 @@ async def test_wait_returns_on_process_exit_with_open_stdout() -> None:
     with fail_after(3, shield=True):
         async for _ in process.stdout:
             pass
+
         async for _ in process.stderr:
             pass
 


### PR DESCRIPTION


## Changes

Normalizes `Process.aclose()` and `Process.wait()` to same behavior as trio and asyncio+uvloop

Fixes #1174. and Fixes #1166.
Adds an explicit event resolved on `process_exit` that can be used to wait on only process for .wait()
For `aclose` it closes the underlying process's pipe_transports for stdin/stdout/stderr which the stream_wrappers don't do by default.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

