### PR TITLE
Fix Process.wait() deadlock on asyncio backend when subprocess blocks on full pipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__
 .cache
 .local
 CLAUDE.local.md
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__
 .local
 CLAUDE.local.md
 .venv/
+.rocky

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **4.14.0**
 
+- Fixed deadlock in ``Process.wait()`` on the ``asyncio`` backend when a subprocess is
+  blocked writing to a full stdout/stderr pipe
+  (`#1174 <https://github.com/agronholm/anyio/issues/1174>`_,
+  `#1166 <https://github.com/agronholm/anyio/issues/1166>`_; PR by @goingforstudying-ctrl)
 - Added support for Python 3.15
 - Added an asynchronous implementation of the ``itertools`` module
   (`#998 <https://github.com/agronholm/anyio/issues/998>`_; PR by @11kkw)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1138,10 +1138,16 @@ class Process(abc.Process):
                 raise
 
     async def wait(self) -> int:
-        # Use a polling loop instead of asyncio.subprocess.Process.wait(),
-        # which waits for stdout/stderr pipes to close in addition to the
-        # process exiting.  That extra wait can deadlock when a subprocess is
-        # blocked writing to a full pipe and nobody is reading.
+        # Use a polling loop instead of asyncio.subprocess.Process.wait(), which
+        # waits for stdout/stderr pipes to close in addition to the process
+        # exiting.  The extra pipe-close wait is problematic because it can
+        # deadlock when a subprocess is blocked writing to a full pipe and
+        # nobody is reading from the other end.  The polling loop checks only
+        # the process returncode, so it returns as soon as the process exits
+        # regardless of pipe state.  This is safe because the caller is
+        # responsible for draining/closing pipes separately, and the polling
+        # interval is bounded by a single checkpoint (essentially zero wait
+        # when the event loop has no other work).
         while self._process.returncode is None:
             await AsyncIOBackend.checkpoint()
 
@@ -1194,9 +1200,12 @@ def _forcibly_shutdown_process_pool_on_exit(
         if process.returncode is not None:
             continue
 
-        process._stdin._stream._transport.close()  # type: ignore[union-attr]
-        process._stdout._stream._transport.close()  # type: ignore[union-attr]
-        process._stderr._stream._transport.close()  # type: ignore[union-attr]
+        if process._stdin and process._stdin._stream._transport is not None:  # type: ignore[union-attr]
+            process._stdin._stream._transport.close()  # type: ignore[union-attr]
+        if process._stdout and process._stdout._stream._transport is not None:  # type: ignore[union-attr]
+            process._stdout._stream._transport.close()  # type: ignore[union-attr]
+        if process._stderr and process._stderr._stream._transport is not None:  # type: ignore[union-attr]
+            process._stderr._stream._transport.close()  # type: ignore[union-attr]
         process.kill()
         if child_watcher:
             child_watcher.remove_child_handler(process.pid)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1200,12 +1200,12 @@ def _forcibly_shutdown_process_pool_on_exit(
         if process.returncode is not None:
             continue
 
-        if process._stdin and process._stdin._stream._transport is not None:  # type: ignore[union-attr]
-            process._stdin._stream._transport.close()  # type: ignore[union-attr]
-        if process._stdout and process._stdout._stream._transport is not None:  # type: ignore[union-attr]
-            process._stdout._stream._transport.close()  # type: ignore[union-attr]
-        if process._stderr and process._stderr._stream._transport is not None:  # type: ignore[union-attr]
-            process._stderr._stream._transport.close()  # type: ignore[union-attr]
+        if process._stdin and process._stdin._stream._transport is not None:  # type: ignore[attr-defined]
+            process._stdin._stream._transport.close()  # type: ignore[attr-defined]
+        if process._stdout and process._stdout._stream._transport is not None:  # type: ignore[attr-defined]
+            process._stdout._stream._transport.close()  # type: ignore[attr-defined]
+        if process._stderr and process._stderr._stream._transport is not None:  # type: ignore[attr-defined]
+            process._stderr._stream._transport.close()  # type: ignore[attr-defined]
         process.kill()
         if child_watcher:
             child_watcher.remove_child_handler(process.pid)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1076,6 +1076,8 @@ class StreamReaderWrapper(abc.ByteReceiveStream):
 
     async def aclose(self) -> None:
         self._stream.set_exception(ClosedResourceError())
+        if self._stream._transport is not None:
+            self._stream._transport.close()
         await AsyncIOBackend.checkpoint()
 
 
@@ -1136,7 +1138,14 @@ class Process(abc.Process):
                 raise
 
     async def wait(self) -> int:
-        return await self._process.wait()
+        # Use a polling loop instead of asyncio.subprocess.Process.wait(),
+        # which waits for stdout/stderr pipes to close in addition to the
+        # process exiting.  That extra wait can deadlock when a subprocess is
+        # blocked writing to a full pipe and nobody is reading.
+        while self._process.returncode is None:
+            await AsyncIOBackend.checkpoint()
+
+        return self._process.returncode
 
     def terminate(self) -> None:
         self._process.terminate()

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1076,8 +1076,8 @@ class StreamReaderWrapper(abc.ByteReceiveStream):
 
     async def aclose(self) -> None:
         self._stream.set_exception(ClosedResourceError())
-        if self._stream._transport is not None:
-            self._stream._transport.close()
+        if self._stream._transport is not None:  # type: ignore[attr-defined]
+            self._stream._transport.close()  # type: ignore[attr-defined]
         await AsyncIOBackend.checkpoint()
 
 

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -391,3 +391,67 @@ async def test_close_while_reading() -> None:
             await process.stdout.receive()
 
         process.terminate()
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Unix-specific: grandchild process and signal handling",
+)
+async def test_wait_returns_on_process_exit_with_open_stdout() -> None:
+    """wait() should return once the process exits, even when a grandchild
+    keeps a pipe file descriptor open."""
+
+    code = dedent("""\
+    import subprocess, sys
+
+    subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(10)"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    sys.stdout.write("ok")
+    """)
+
+    async with await open_process([sys.executable, "-c", code]) as process:
+        returncode = await process.wait()
+
+    assert returncode == 0
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Unix-specific: pipe buffer sizes and EPIPE behaviour",
+)
+async def test_aclose_unblocks_subprocess_blocked_on_write() -> None:
+    """aclose() must unblock a subprocess that is stuck writing to a full
+    pipe (because nobody is reading), rather than deadlocking while waiting
+    for it to exit."""
+
+    # Write enough data to fill the pipe buffer (~64 KiB on Linux) so the
+    # subprocess blocks and never reaches its own exit.
+    code = dedent("""\
+    import sys
+
+    sys.stdout.write("x" * 1024 * 1024)
+    sys.stdout.flush()
+    """)
+
+    from anyio import Event, sleep
+
+    deadline_hit = Event()
+
+    async with create_task_group() as tg:
+        process = await open_process([sys.executable, "-c", code])
+
+        async def deadline() -> None:
+            await sleep(5)
+            deadline_hit.set()
+
+        tg.start_soon(deadline)
+
+        # This must not deadlock even though the subprocess is still
+        # blocked on the full stdout pipe.
+        await process.aclose()
+        tg.cancel_scope.cancel()
+
+    assert not deadline_hit.is_set(), "Process.aclose() deadlocked"

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -455,3 +455,95 @@ async def test_aclose_unblocks_subprocess_blocked_on_write() -> None:
         tg.cancel_scope.cancel()
 
     assert not deadline_hit.is_set(), "Process.aclose() deadlocked"
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Unix-specific: pipe buffer sizes and EPIPE behaviour",
+)
+async def test_wait_returns_when_subprocess_blocked_on_write() -> None:
+    """wait() must not deadlock when a subprocess is stuck writing to a
+    full pipe.  It should return the exit code once aclose() closes the
+    pipes and terminates the process."""
+
+    code = dedent("""\
+    import sys
+
+    sys.stdout.write("x" * 1024 * 1024)
+    sys.stdout.flush()
+    """)
+
+    from anyio import Event, sleep
+
+    deadline_hit = Event()
+
+    async with create_task_group() as tg:
+        process = await open_process([sys.executable, "-c", code])
+
+        async def deadline() -> None:
+            await sleep(5)
+            deadline_hit.set()
+
+        tg.start_soon(deadline)
+
+        # Close pipes and kill the process so it exits, then wait() must
+        # return promptly rather than hanging on the still-full pipe.
+        await process.aclose()
+        tg.cancel_scope.cancel()
+
+    returncode = await process.wait()
+    assert not deadline_hit.is_set(), "Process.wait() deadlocked"
+    assert returncode is not None  # process exited
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Unix-specific: pipe buffer sizes and EPIPE behaviour",
+)
+async def test_wait_returns_promptly_for_fast_exit() -> None:
+    """wait() must return quickly when the process exits immediately
+    without writing to stdout or stderr."""
+
+    from anyio import Event, sleep
+
+    deadline_hit = Event()
+
+    async with create_task_group() as tg:
+        process = await open_process([sys.executable, "-c", ""])
+
+        async def deadline() -> None:
+            await sleep(5)
+            deadline_hit.set()
+
+        tg.start_soon(deadline)
+
+        returncode = await process.wait()
+        tg.cancel_scope.cancel()
+
+    assert not deadline_hit.is_set(), "Process.wait() deadlocked for fast exit"
+    assert returncode == 0
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Unix-specific: grandchild process and signal handling",
+)
+async def test_wait_returns_on_process_exit_with_open_stderr() -> None:
+    """wait() should return once the process exits, even when a grandchild
+    keeps the stderr pipe file descriptor open."""
+
+    code = dedent("""\
+    import subprocess, sys
+
+    subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(10)"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    sys.stderr.write("ok")
+    """)
+
+    async with await open_process([sys.executable, "-c", code]) as process:
+        returncode = await process.wait()
+
+    assert returncode == 0


### PR DESCRIPTION
## Changes

Fixes #1174 and #1166.

On the asyncio backend, Process.wait() delegates to
asyncio.subprocess.Process.wait(), which waits for both the process exit
and the closure of stdout/stderr pipes. When a subprocess is blocked
writing to a full pipe (because nobody is reading), the pipe never closes
and wait() hangs forever.

Two changes:

1. StreamReaderWrapper.aclose() now closes the underlying transport rather
   than only setting a stream exception. This unblocks the subprocess by
   delivering EPIPE / BrokenPipeError on the write end.

2. Process.wait() uses a polling loop on returncode with event-loop yield
   rather than calling the stdlib's wait(). The polling loop
   returns as soon as the process exits, never waiting for pipes.

Two new tests verify the fix.
