### PR TITLE
Fixed OutcomeException canceling the runner task in run_test()

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,15 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed ``TestRunner.run_test()`` incorrectly treating pytest ``OutcomeException``
+  (raised by ``pytest.skip()``, ``pytest.xfail()``, etc.) as a forced event-loop
+  interruption, which canceled the runner task and caused higher-scoped async fixtures
+  holding a cancel scope to fail at teardown with ``RuntimeError: Attempted to exit
+  cancel scope in a different task``
+  (`#1179 <https://github.com/agronholm/anyio/issues/1179>`_; PR by @gaoflow)
+
 **4.14.0**
 
 - Added support for Python 3.15

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -2373,12 +2373,16 @@ class TestRunner(abc.TestRunner):
     def run_test(
         self, test_func: Callable[..., Coroutine[Any, Any, Any]], kwargs: dict[str, Any]
     ) -> None:
+        from _pytest.outcomes import OutcomeException
+
         try:
             self.get_loop().run_until_complete(
                 self._call_in_runner_task(test_func, **kwargs)
             )
         except Exception as exc:
             self._exceptions.append(exc)
+        except OutcomeException:
+            raise
         except BaseException:
             # A BaseException (e.g. KeyboardInterrupt, SystemExit) interrupted the event loop before
             # the test completed. Cancel _runner_task so it does not resume when the event

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -793,3 +793,43 @@ def test_func_as_parametrize_param_name(testdir: Pytester) -> None:
 
     result = testdir.runpytest(*pytest_args)
     result.assert_outcomes(passed=len(get_available_backends()))
+
+
+def test_outcome_exception_does_not_break_async_fixture_teardown(
+    testdir: Pytester,
+) -> None:
+    """Regression test for #1179: pytest OutcomeException (skip/xfail) must not
+    cancel the runner task, which would break teardown of higher-scoped async
+    fixtures holding a cancel scope open across their yield."""
+    testdir.makepyfile(
+        """
+        import anyio
+        import pytest
+
+
+        @pytest.fixture(scope="module")
+        def anyio_backend() -> str:
+            return "asyncio"
+
+
+        @pytest.fixture(scope="module")
+        async def background_resource():
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(anyio.sleep_forever)
+                yield "resource"
+                tg.cancel_scope.cancel()
+
+
+        @pytest.mark.anyio
+        async def test_uses_the_resource(background_resource: str) -> None:
+            assert background_resource == "resource"
+
+
+        @pytest.mark.anyio
+        async def test_that_skips() -> None:
+            pytest.skip("deliberate skip")
+        """
+    )
+
+    result = testdir.runpytest(*pytest_args)
+    result.assert_outcomes(passed=1, skipped=1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Changes

Fixes #1179.

pytest signals skip/xfail/failed assertions by raising `OutcomeException`, which subclasses `BaseException` but not `Exception`. The `KeyboardInterrupt` handler in `TestRunner.run_test()` (added in #1121) catches `BaseException` and tears down the runner task. But `OutcomeException` is a deliberate test signal — not a forced event-loop interruption — so it should not trigger that path. When it does, the new runner task spawned by the next test cannot exit the cancel scope a higher-scoped fixture entered in the old task, producing `RuntimeError: Attempted to exit cancel scope in a different task` at teardown.

The fix mirrors the existing handling in `_run_tests_and_fixtures()`, which already treats `OutcomeException` the same as `Exception` — letting it propagate without resetting runner state.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).