### PR TITLE
Add missing await to open_file() in file I/O concurrency example

### DIFF
--- a/docs/fileio.rst
+++ b/docs/fileio.rst
@@ -102,7 +102,7 @@ methods)::
 
     async def main():
         limiter = CapacityLimiter(5)
-        async with open_file('/foo/bar', limiter=limiter) as fp:
+        async with await open_file('/foo/bar', limiter=limiter) as fp:
             contents = await fp.read()
 
     run(main)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,9 +10,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   when an async test raise an outcome exception (e.g., ``pytest.skip()``, ``pytest.xfail()``,
   or ``pytest.fail()``)
   (`#1179 <https://github.com/agronholm/anyio/issues/1179>`_; PR by @EmmanuelNiyonshuti)
-- Fixed the "Limiting concurrency" example in the file I/O documentation missing the
-  ``await`` on the asynchronous ``open_file()`` call, so it failed when run as written
-  (PR by @patrickwehbe)
 
 **4.14.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,6 +10,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   when an async test raise an outcome exception (e.g., ``pytest.skip()``, ``pytest.xfail()``,
   or ``pytest.fail()``)
   (`#1179 <https://github.com/agronholm/anyio/issues/1179>`_; PR by @EmmanuelNiyonshuti)
+- Fixed the "Limiting concurrency" example in the file I/O documentation missing the
+  ``await`` on the asynchronous ``open_file()`` call, so it failed when run as written
+  (PR by @patrickwehbe)
 
 **4.14.0**
 


### PR DESCRIPTION
## Changes

The "Limiting concurrency" example in `docs/fileio.rst` uses `async with open_file('/foo/bar', limiter=limiter) as fp:`. Since `open_file()` is a coroutine function, this raises `TypeError: 'coroutine' object does not support the asynchronous context manager protocol` when run as written.

Added the missing `await` so the example actually runs. It now matches the other two `open_file()` examples in the same file, which already use `async with await open_file(...)`.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.
