### PR TITLE
Allow 0 tokens in a CapacityLimiter instantiated outside an event loop

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -13,7 +13,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``CapacityLimiter.total_tokens`` rejecting a value of ``0`` when the limiter was
   instantiated outside of an event loop, contradicting the documented behavior of
   allowing 0 total tokens
-  (`#1184 <https://github.com/agronholm/anyio/pull/1184>`_; PR by @nyxst4ck)
+  (`#1183 <https://github.com/agronholm/anyio/pull/1183>`_; PR by @nyxst4ck)
 
 **4.14.0**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,6 +10,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   when an async test raise an outcome exception (e.g., ``pytest.skip()``, ``pytest.xfail()``,
   or ``pytest.fail()``)
   (`#1179 <https://github.com/agronholm/anyio/issues/1179>`_; PR by @EmmanuelNiyonshuti)
+- Fixed ``CapacityLimiter.total_tokens`` rejecting a value of ``0`` when the limiter was
+  instantiated outside of an event loop, contradicting the documented behavior of
+  allowing 0 total tokens
+  (`#1184 <https://github.com/agronholm/anyio/pull/1184>`_; PR by @nyxst4ck)
 
 **4.14.0**
 

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -684,8 +684,8 @@ class CapacityLimiterAdapter(CapacityLimiter):
     def total_tokens(self, value: float) -> None:
         if not isinstance(value, int) and value is not math.inf:
             raise TypeError("total_tokens must be an int or math.inf")
-        elif value < 1:
-            raise ValueError("total_tokens must be >= 1")
+        elif value < 0:
+            raise ValueError("total_tokens must be >= 0")
 
         if self._internal_limiter is None:
             self._total_tokens = value

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -920,6 +920,14 @@ class TestCapacityLimiter:
             backend_options=anyio_backend_options,
         )
 
+    def test_zero_tokens_outside_event_loop(self) -> None:
+        # Regression test for the CapacityLimiterAdapter setter rejecting 0,
+        # which contradicted the 4.12 behavior of allowing 0 total tokens
+        limiter = CapacityLimiter(1)
+        limiter.total_tokens = 0
+        assert limiter.total_tokens == 0
+        assert CapacityLimiter(0).total_tokens == 0
+
     async def test_total_tokens_as_kwarg(self) -> None:
         # Regression test for #515
         limiter = CapacityLimiter(total_tokens=1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Changes

Fixes #. <!-- No linked issue -->

PR #1019 (released in 4.12) allowed setting a `CapacityLimiter`'s total tokens to `0`, updating the docstring, the changelog and the asyncio backend setter (`value < 1` → `value < 0`).

However, the `CapacityLimiterAdapter.total_tokens` setter in `src/anyio/_core/_synchronization.py` was missed and still enforced `value < 1`. This adapter is used whenever a `CapacityLimiter` is instantiated **outside of a running event loop**, so the documented 4.12 behavior was not honored on that path:

```python
import anyio

anyio.CapacityLimiter(0)             # ValueError: total_tokens must be >= 1
limiter = anyio.CapacityLimiter(1)
limiter.total_tokens = 0             # ValueError: total_tokens must be >= 1
```

This aligns the adapter setter with the asyncio backend setter (`value < 0`, message `"total_tokens must be >= 0"`) and adds a regression test for the outside-event-loop path.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.