### PR TITLE
Guard typing-only imports behind `if TYPE_CHECKING:`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ local_scheme = "dirty-tag"
 src = ["src"]
 
 [tool.ruff.lint]
+future-annotations = true
 extend-select = [
     "ASYNC",        # flake8-async
     "B",            # flake8-bugbear
@@ -92,13 +93,12 @@ extend-select = [
     "PGH",          # pygrep-hooks
     "RUF100",       # unused noqa (yesqa)
     "T201",         # print
+    "TC001",        # typing-only-first-party-import
     "UP",           # pyupgrade
     "W",            # pycodestyle warnings
 ]
 ignore = ["B009", "PERF203"]
-
-[tool.ruff.lint.isort]
-"required-imports" = ["from __future__ import annotations"]
+extend-safe-fixes = ["TC001"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/test_tempfile.py" = ["ASYNC230"]

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -100,15 +100,14 @@ from ..abc import (
     UDPPacketType,
     UNIXDatagramPacketType,
 )
-from ..abc._eventloop import StrOrBytesPath
 from ..abc._tasks import call_for_coroutine, get_callable_name
 from ..lowlevel import RunVar
-from ..streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
 if TYPE_CHECKING:
     from _typeshed import FileDescriptorLike
-else:
-    FileDescriptorLike = object
+
+    from ..abc._eventloop import StrOrBytesPath
+    from ..streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
 if sys.version_info >= (3, 11):
     from asyncio import Runner

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -85,10 +85,11 @@ from .._core._tasks import TaskHandle
 from ..abc import IPSockAddrType, UDPPacketType, UNIXDatagramPacketType
 from ..abc._eventloop import AsyncBackend, StrOrBytesPath
 from ..abc._tasks import T_contra, call_for_coroutine, get_callable_name
-from ..streams.memory import MemoryObjectSendStream
 
 if TYPE_CHECKING:
     from _typeshed import FileDescriptorLike
+
+    from ..streams.memory import MemoryObjectSendStream
 
 if sys.version_info >= (3, 11):
     from typing import TypeVarTuple, Unpack

--- a/src/anyio/_core/_resources.py
+++ b/src/anyio/_core/_resources.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-from ..abc import AsyncResource
+from typing import TYPE_CHECKING
+
 from ._tasks import CancelScope
+
+if TYPE_CHECKING:
+    from ..abc import AsyncResource
 
 
 async def aclose_forcefully(resource: AsyncResource) -> None:

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -4,11 +4,13 @@ from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from io import BytesIO
 from os import PathLike
 from subprocess import PIPE, CalledProcessError, CompletedProcess
-from typing import IO, Any, TypeAlias, cast
+from typing import IO, TYPE_CHECKING, Any, TypeAlias, cast
 
-from ..abc import Process
 from ._eventloop import get_async_backend
 from ._tasks import create_task_group
+
+if TYPE_CHECKING:
+    from ..abc import Process
 
 StrOrBytesPath: TypeAlias = str | bytes | PathLike[str] | PathLike[bytes]
 

--- a/src/anyio/abc/_sockets.py
+++ b/src/anyio/abc/_sockets.py
@@ -8,7 +8,7 @@ from contextlib import AsyncExitStack
 from io import IOBase
 from ipaddress import IPv4Address, IPv6Address
 from socket import AddressFamily
-from typing import Any, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
 
 from .._core._eventloop import get_async_backend
 from .._core._typedattr import (
@@ -17,7 +17,9 @@ from .._core._typedattr import (
     typed_attribute,
 )
 from ._streams import ByteStream, Listener, UnreliableObjectStream
-from ._tasks import TaskGroup
+
+if TYPE_CHECKING:
+    from ._tasks import TaskGroup
 
 IPAddressType: TypeAlias = str | IPv4Address | IPv6Address
 IPSockAddrType: TypeAlias = tuple[str, int]

--- a/src/anyio/abc/_streams.py
+++ b/src/anyio/abc/_streams.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable
-from typing import Any, Generic, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar
 
 from .._core._exceptions import EndOfStream
 from .._core._typedattr import TypedAttributeProvider
 from ._resources import AsyncResource
-from ._tasks import TaskGroup
+
+if TYPE_CHECKING:
+    from ._tasks import TaskGroup
 
 T_Item = TypeVar("T_Item")
 T_co = TypeVar("T_co", covariant=True)

--- a/src/anyio/abc/_subprocesses.py
+++ b/src/anyio/abc/_subprocesses.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from signal import Signals
+from typing import TYPE_CHECKING
 
 from ._resources import AsyncResource
-from ._streams import ByteReceiveStream, ByteSendStream
+
+if TYPE_CHECKING:
+    from ._streams import ByteReceiveStream, ByteSendStream
 
 
 class Process(AsyncResource):

--- a/src/anyio/lowlevel.py
+++ b/src/anyio/lowlevel.py
@@ -13,11 +13,13 @@ __all__ = (
 import enum
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Any, Generic, Literal, TypeVar, final, overload
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, final, overload
 from weakref import WeakKeyDictionary
 
 from ._core._eventloop import get_async_backend
-from .abc import AsyncBackend
+
+if TYPE_CHECKING:
+    from .abc import AsyncBackend
 
 T = TypeVar("T")
 D = TypeVar("D")

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack, contextmanager
 from inspect import isasyncgenfunction, iscoroutinefunction, ismethod
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from _pytest.fixtures import FuncFixtureInfo, SubRequest
@@ -22,7 +22,9 @@ from ._core._eventloop import (
     set_current_async_library,
 )
 from ._core._exceptions import iterate_exceptions
-from .abc import TestRunner
+
+if TYPE_CHECKING:
+    from .abc import TestRunner
 
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup

--- a/src/anyio/to_thread.py
+++ b/src/anyio/to_thread.py
@@ -7,11 +7,13 @@ __all__ = (
 
 import sys
 from collections.abc import Callable
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 from warnings import warn
 
 from ._core._eventloop import get_async_backend
-from .abc import CapacityLimiter
+
+if TYPE_CHECKING:
+    from .abc import CapacityLimiter
 
 if sys.version_info >= (3, 11):
     from typing import TypeVarTuple, Unpack

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from _pytest.fixtures import SubRequest
 from _pytest.tmpdir import TempPathFactory
 
 from anyio import ClosedResourceError, EndOfStream
-from anyio.abc import ByteReceiveStream
 from anyio.streams.file import FileReadStream, FileStreamAttribute, FileWriteStream
+
+if TYPE_CHECKING:
+    from anyio.abc import ByteReceiveStream
 
 
 class TestFileReadStream:

--- a/tests/streams/test_memory.py
+++ b/tests/streams/test_memory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import gc
 import sys
-from typing import NoReturn
+from typing import TYPE_CHECKING, NoReturn
 
 import pytest
 
@@ -17,7 +17,6 @@ from anyio import (
     fail_after,
     wait_all_tasks_blocked,
 )
-from anyio.abc import ObjectReceiveStream, ObjectSendStream, TaskStatus
 from anyio.streams.memory import (
     MemoryObjectReceiveStream,
     MemoryObjectSendStream,
@@ -25,6 +24,9 @@ from anyio.streams.memory import (
 )
 
 from ..conftest import asyncio_params
+
+if TYPE_CHECKING:
+    from anyio.abc import ObjectReceiveStream, ObjectSendStream, TaskStatus
 
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -4,7 +4,7 @@ import asyncio
 import sys
 from collections.abc import AsyncGenerator, Generator
 from types import CoroutineType, GeneratorType
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -18,9 +18,11 @@ from anyio import (
     move_on_after,
     wait_all_tasks_blocked,
 )
-from anyio.abc import TaskStatus
 
 from .conftest import asyncio_params
+
+if TYPE_CHECKING:
+    from anyio.abc import TaskStatus
 
 get_coro = asyncio.Task.get_coro
 

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -9,7 +9,7 @@ from concurrent import futures
 from concurrent.futures import CancelledError, Future, ThreadPoolExecutor
 from contextlib import asynccontextmanager, suppress
 from contextvars import ContextVar
-from typing import Any, Literal, NoReturn, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeVar
 
 import pytest
 from pytest import LogCaptureFixture
@@ -30,11 +30,13 @@ from anyio import (
     to_thread,
     wait_all_tasks_blocked,
 )
-from anyio.abc import TaskStatus
 from anyio.from_thread import BlockingPortal, start_blocking_portal
 from anyio.lowlevel import EventLoopToken, checkpoint, current_token
 
 from .conftest import asyncio_params, return_non_coro_awaitable
+
+if TYPE_CHECKING:
+    from anyio.abc import TaskStatus
 
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import socket
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import pytest
 from _pytest.logging import LogCaptureFixture
 from _pytest.pytester import Pytester
 
 from anyio import get_available_backends
-from anyio.pytest_plugin import FreePortFactory
+
+if TYPE_CHECKING:
+    from anyio.pytest_plugin import FreePortFactory
 
 pytestmark = [
     pytest.mark.filterwarnings(

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -10,7 +10,7 @@ from asyncio import CancelledError
 from collections.abc import AsyncGenerator, Coroutine, Generator
 from contextlib import aclosing
 from contextvars import ContextVar, copy_context
-from typing import Any, NoReturn, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 from unittest import mock
 
 import pytest
@@ -36,10 +36,12 @@ from anyio import (
     sleep_forever,
     wait_all_tasks_blocked,
 )
-from anyio.abc import TaskGroup, TaskStatus
 from anyio.lowlevel import checkpoint
 
 from .conftest import asyncio_params, no_other_refs
+
+if TYPE_CHECKING:
+    from anyio.abc import TaskGroup, TaskStatus
 
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

This moves imports only needed for type annotations under `if TYPE_CHECKING:`.
It enables a Ruff rule for doing so automatically.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
