### PR TITLE
Remove seemingly unused _current_task_handle ContextVar in _tasks

### DIFF
--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -9,7 +9,6 @@ from collections.abc import (
 from contextlib import (
     contextmanager,
 )
-from contextvars import ContextVar
 from enum import Enum, auto
 from inspect import iscoroutine
 from types import TracebackType
@@ -33,8 +32,6 @@ T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
 T_startval = TypeVar("T_startval", covariant=True, default=Never)
 PosArgsT = TypeVarTuple("PosArgsT")
-
-_current_task_handle: ContextVar[TaskHandle] = ContextVar("_current_task_handle")
 
 
 class _IgnoredTaskStatus(TaskStatus[object]):


### PR DESCRIPTION
## Changes

`anyio._core._tasks._current_task_handle` was initialised in the module but I can't find anything referencing it at all.
A PR was easier to demonstrate and ensure the tests pass than an issue.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

Testing for unused code feels a bit too much
- [ ] You've added tests (in `tests/`) which would fail without your patch

- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If this is correctly confirmed dead code and not a missunderstanding by me I'll add a changelog as well.