### PR TITLE
Ensure byte stream receive() requires max_bytes to be >= 1

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when
+  ``max_bytes`` is not a positive integer
+  (`#1191 <https://github.com/agronholm/anyio/pull/1191>`_)
 - Fixed ``CapacityLimiter.total_tokens`` rejecting ``float("inf")`` when the limiter was
   instantiated outside of an event loop. The adapter setter checked for infinity by
   identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1068,6 +1068,9 @@ class StreamReaderWrapper(abc.ByteReceiveStream):
     _stream: asyncio.StreamReader
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         data = await self._stream.read(max_bytes)
         if data:
             return data
@@ -1304,6 +1307,9 @@ class SocketStream(abc.SocketStream):
         return self._transport.get_extra_info("socket")
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         with self._receive_guard:
             if (
                 not self._protocol.read_event.is_set()
@@ -1428,6 +1434,9 @@ class UNIXSocketStream(_RawSocketMixin, abc.UNIXSocketStream):
             self._raw_socket.shutdown(socket.SHUT_WR)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         loop = get_running_loop()
         await AsyncIOBackend.checkpoint()
         with self._receive_guard:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -322,6 +322,9 @@ class ReceiveStreamWrapper(abc.ByteReceiveStream):
     _stream: trio.abc.ReceiveStream
 
     async def receive(self, max_bytes: int | None = None) -> bytes:
+        if max_bytes is not None and max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         try:
             data = await self._stream.receive_some(max_bytes)
         except trio.ClosedResourceError as exc:
@@ -477,6 +480,9 @@ class SocketStream(_TrioSocketMixin, abc.SocketStream):
         self._send_guard = ResourceGuard("writing to")
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         with self._receive_guard:
             try:
                 data = await self._trio_socket.recv(max_bytes)

--- a/src/anyio/abc/_streams.py
+++ b/src/anyio/abc/_streams.py
@@ -140,8 +140,10 @@ class ByteReceiveStream(AsyncResource, TypedAttributeProvider):
         .. note:: Implementers of this interface should not return an empty
             :class:`bytes` object, and users should ignore them.
 
-        :param max_bytes: maximum number of bytes to receive
+        :param max_bytes: maximum number of bytes to receive (must be a positive
+            integer)
         :return: the received bytes
+        :raises ValueError: if ``max_bytes`` is less than 1
         :raises ~anyio.EndOfStream: if this stream has been closed from the other end
         """
 

--- a/src/anyio/streams/buffered.py
+++ b/src/anyio/streams/buffered.py
@@ -65,6 +65,9 @@ class BufferedByteReceiveStream(ByteReceiveStream):
         self._buffer.extend(data)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         if self._closed:
             raise ClosedResourceError
 

--- a/src/anyio/streams/file.py
+++ b/src/anyio/streams/file.py
@@ -79,6 +79,9 @@ class FileReadStream(_BaseFileStream, ByteReceiveStream):
         return cls(file)
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         try:
             data = await to_thread.run_sync(self._file.read, max_bytes)
         except ValueError:

--- a/src/anyio/streams/stapled.py
+++ b/src/anyio/streams/stapled.py
@@ -41,6 +41,9 @@ class StapledByteStream(ByteStream):
     receive_stream: ByteReceiveStream
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         return await self.receive_stream.receive(max_bytes)
 
     async def send(self, item: bytes) -> None:

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -236,6 +236,9 @@ class TLSStream(ByteStream):
         await self.transport_stream.aclose()
 
     async def receive(self, max_bytes: int = 65536) -> bytes:
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be a positive integer")
+
         data = await self._call_sslobject_method(self._ssl_object.read, max_bytes)
         if not data:
             raise EndOfStream

--- a/tests/streams/test_buffered.py
+++ b/tests/streams/test_buffered.py
@@ -109,6 +109,29 @@ async def test_buffered_connectable() -> None:
         assert await stream.receive_exactly(2) == b"cd"
 
 
+@pytest.mark.parametrize("max_bytes", [0, -1])
+async def test_receive_invalid_max_bytes(max_bytes: int) -> None:
+    send_stream, receive_stream = create_memory_object_stream[bytes](1)
+    buffered_stream = BufferedByteReceiveStream(receive_stream)
+    with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+        await buffered_stream.receive(max_bytes)
+
+    send_stream.close()
+    receive_stream.close()
+
+
+@pytest.mark.parametrize("max_bytes", [0, -1])
+async def test_buffered_stream_receive_invalid_max_bytes(max_bytes: int) -> None:
+    send_stream, receive_stream = create_memory_object_stream[bytes](1)
+    buffered_stream = BufferedByteStream(
+        StapledObjectStream(send_stream, receive_stream)
+    )
+    with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+        await buffered_stream.receive(max_bytes)
+
+    await buffered_stream.aclose()
+
+
 async def test_feed_data() -> None:
     send_stream, receive_stream = create_memory_object_stream[bytes](1)
     buffered_stream = BufferedByteStream(

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -45,6 +45,16 @@ class TestFileReadStream:
         with pytest.raises(ClosedResourceError):
             await stream.receive()
 
+    @pytest.mark.parametrize("max_bytes", [0, -1])
+    async def test_receive_invalid_max_bytes(
+        self, file_path: Path, max_bytes: int
+    ) -> None:
+        async with await FileReadStream.from_path(file_path) as stream:
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
+                await stream.receive(max_bytes)
+
     async def test_seek(self, file_path: Path) -> None:
         with file_path.open("rb") as file:
             async with FileReadStream(file) as stream:

--- a/tests/streams/test_stapled.py
+++ b/tests/streams/test_stapled.py
@@ -95,6 +95,13 @@ class TestStapledByteStream:
         with pytest.raises(ClosedResourceError):
             await stapled.send(b"")
 
+    @pytest.mark.parametrize("max_bytes", [0, -1])
+    async def test_receive_invalid_max_bytes(
+        self, stapled: StapledByteStream, max_bytes: int
+    ) -> None:
+        with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+            await stapled.receive(max_bytes)
+
 
 T_Item = TypeVar("T_Item")
 

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -62,6 +62,51 @@ class TestTLSStream:
         server_sock.close()
         assert response == b"olleh"
 
+    @pytest.mark.parametrize("max_bytes", [0, -1])
+    async def test_receive_invalid_max_bytes(
+        self,
+        server_context: ssl.SSLContext,
+        client_context: ssl.SSLContext,
+        max_bytes: int,
+    ) -> None:
+        server_exc = None
+
+        def serve_sync() -> None:
+            nonlocal server_exc
+            conn, addr = server_sock.accept()
+            try:
+                conn.settimeout(1)
+            except BaseException as exc:
+                server_exc = exc
+            finally:
+                conn.close()
+
+        server_sock = server_context.wrap_socket(
+            socket.socket(), server_side=True, suppress_ragged_eofs=True
+        )
+        server_sock.settimeout(1)
+        server_sock.bind(("127.0.0.1", 0))
+        server_sock.listen()
+        server_thread = Thread(target=serve_sync, daemon=True)
+        server_thread.start()
+        try:
+            async with await connect_tcp(*server_sock.getsockname()) as stream:
+                wrapper = await TLSStream.wrap(
+                    stream,
+                    hostname="localhost",
+                    ssl_context=client_context,
+                    standard_compatible=False,
+                )
+                with pytest.raises(
+                    ValueError, match="max_bytes must be a positive integer"
+                ):
+                    await wrapper.receive(max_bytes)
+        finally:
+            server_thread.join()
+            server_sock.close()
+
+        assert server_exc is None
+
     async def test_extra_attributes(
         self,
         request: pytest.FixtureRequest,

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -282,6 +282,16 @@ class TestTCPStream:
 
         assert response == b"halb"
 
+    @pytest.mark.parametrize("max_bytes", [0, -1])
+    async def test_receive_invalid_max_bytes(
+        self, server_addr: tuple[str, int], max_bytes: int
+    ) -> None:
+        async with await connect_tcp(*server_addr) as stream:
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
+                await stream.receive(max_bytes)
+
     async def test_send_large_buffer(
         self, server_sock: socket.socket, server_addr: tuple[str, int]
     ) -> None:
@@ -1205,6 +1215,16 @@ class TestUNIXStream:
             client.close()
 
         assert response == b"halb"
+
+    @pytest.mark.parametrize("max_bytes", [0, -1])
+    async def test_receive_invalid_max_bytes(
+        self, server_sock: socket.socket, socket_path: Path, max_bytes: int
+    ) -> None:
+        async with await connect_unix(socket_path) as stream:
+            with pytest.raises(
+                ValueError, match="max_bytes must be a positive integer"
+            ):
+                await stream.receive(max_bytes)
 
     async def test_receive_large_buffer(
         self, server_sock: socket.socket, socket_path: Path

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -97,6 +97,18 @@ async def test_terminate(tmp_path: Path) -> None:
         assert await process.wait() == 2
 
 
+@pytest.mark.parametrize("max_bytes", [0, -1])
+async def test_process_receive_invalid_max_bytes(max_bytes: int) -> None:
+    async with await open_process(
+        [sys.executable, "-c", "import sys; sys.stdout.write('x')"]
+    ) as process:
+        assert process.stdout is not None
+        with pytest.raises(ValueError, match="max_bytes must be a positive integer"):
+            await process.stdout.receive(max_bytes)
+
+        await process.wait()
+
+
 async def test_process_cwd(tmp_path: Path) -> None:
     """Test that `cwd` is successfully passed to the subprocess implementation"""
     cmd = [sys.executable, "-c", "import os; print(os.getcwd())"]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Adds validation for the value of `max_bytes` in `ByteReceiveStream.receive()` implementations.

Fixes #1081. <!-- Provide issue number if exists -->
Closes #1139. Closes #1144.
<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
