### PR TITLE
Fixed `extra_groups` not being passed to backend `open_process()`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -15,6 +15,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#1189 <https://github.com/agronholm/anyio/pull/1189>`_; PR by @greymoth-jp).
 - Fixed ``anyio.open_process()`` (and ``run_process()``) ignoring the ``extra_groups``
   argument, as it mistakenly passed the value of the ``group`` argument instead
+  (`#1193 <https://github.com/agronholm/anyio/pull/1193>`_)
 
 **4.14.1**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -13,6 +13,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,
   while every backend setter (using ``math.isinf()``) accepts any positive infinity
   (`#1189 <https://github.com/agronholm/anyio/pull/1189>`_; PR by @greymoth-jp).
+- Fixed ``anyio.open_process()`` (and ``run_process()``) ignoring the ``extra_groups``
+  argument, as it mistakenly passed the value of the ``group`` argument instead
 
 **4.14.1**
 

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -176,7 +176,7 @@ async def open_process(
         kwargs["group"] = group
 
     if extra_groups is not None:
-        kwargs["extra_groups"] = group
+        kwargs["extra_groups"] = extra_groups
 
     if umask >= 0:
         kwargs["umask"] = umask

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -5,11 +5,12 @@ import platform
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from subprocess import CalledProcessError
+from subprocess import DEVNULL, CalledProcessError
 from textwrap import dedent
 from typing import Any
 
 import pytest
+from pytest_mock.plugin import MockerFixture
 
 from anyio import (
     BrokenResourceError,
@@ -21,6 +22,7 @@ from anyio import (
     open_process,
     run_process,
 )
+from anyio._core._eventloop import get_async_backend
 from anyio.streams.buffered import BufferedByteReceiveStream
 
 
@@ -348,11 +350,10 @@ async def test_exceptions_after_subprocess_closes_standard_streams() -> None:
                 )
             ],
         ),
-        pytest.param("extra_groups", list, id="extra_groups"),
         pytest.param("umask", lambda: 0, id="umask"),
     ],
 )
-async def test_py39_arguments(
+async def test_user_group_arguments(
     argname: str,
     argvalue_factory: Callable[[], Any],
     event_loop_implementation_name: str | None,
@@ -373,6 +374,33 @@ async def test_py39_arguments(
             )
 
         raise
+
+
+async def test_arguments_passed_through(mocker: MockerFixture) -> None:
+    """
+    Regression test that ensures that all the arguments accepted by ``open_process()``
+    are passed through to the backend's ``open_process()``.
+    """
+
+    command = [sys.executable, "-c", "pass"]
+    kwargs: dict[str, Any] = {
+        "stdin": DEVNULL,
+        "stdout": DEVNULL,
+        "stderr": DEVNULL,
+        "cwd": "/tmp",
+        "env": {"FOO": "bar"},
+        "startupinfo": object(),
+        "creationflags": 4,
+        "start_new_session": True,
+        "pass_fds": (5, 6),
+        "user": "myuser",
+        "group": "mygroup",
+        "extra_groups": [1, 2, "foo"],
+        "umask": 123,
+    }
+    mock_open_process = mocker.patch.object(get_async_backend(), "open_process")
+    await open_process(command, **kwargs)
+    mock_open_process.assert_called_once_with(command, **kwargs)
 
 
 async def test_close_early() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes the `extra_groups` option not being passed to the backend's `open_process()` call.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
