### PR TITLE
Fixed TLSStream.wrap() using IDNA 2003 to encode host names

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -13,6 +13,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,
   while every backend setter (using ``math.isinf()``) accepts any positive infinity
   (`#1189 <https://github.com/agronholm/anyio/pull/1189>`_; PR by @greymoth-jp).
+- Fixed ``anyio.open_process()`` (and ``run_process()``) ignoring the ``extra_groups``
+  argument, as it mistakenly passed the value of the ``group`` argument instead
 
 **4.14.1**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -15,6 +15,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#1189 <https://github.com/agronholm/anyio/pull/1189>`_; PR by @greymoth-jp).
 - Fixed ``anyio.open_process()`` (and ``run_process()``) ignoring the ``extra_groups``
   argument, as it mistakenly passed the value of the ``group`` argument instead
+  (`#1193 <https://github.com/agronholm/anyio/pull/1193>`_)
+- Fixed ``TLSStream.wrap()`` matching an internationalized (unicode) host name against
+  the peer certificate using IDNA 2003 (via the standard library) instead of IDNA 2008,
+  which could cause the host name to be matched against the wrong certificate
+  (`#1194 <https://github.com/agronholm/anyio/pull/1194>`_)
 
 **4.14.1**
 

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -59,6 +59,15 @@ AnyIPAddressFamily = Literal[
 IPAddressFamily = Literal[AddressFamily.AF_INET, AddressFamily.AF_INET6]
 
 
+def idna2008_resolve(host: str) -> bytes:
+    try:
+        return host.encode("ascii")
+    except UnicodeEncodeError:
+        import idna
+
+        return idna.encode(host, uts46=True)
+
+
 # tls_hostname given
 @overload
 async def connect_tcp(
@@ -644,16 +653,7 @@ async def getaddrinfo(
 
     """
     # Handle unicode hostnames
-    if isinstance(host, str):
-        try:
-            encoded_host: bytes | None = host.encode("ascii")
-        except UnicodeEncodeError:
-            import idna
-
-            encoded_host = idna.encode(host, uts46=True)
-    else:
-        encoded_host = host
-
+    encoded_host = idna2008_resolve(host) if isinstance(host, str) else host
     gai_res = await get_async_backend().getaddrinfo(
         encoded_host, port, family=family, type=type, proto=proto, flags=flags
     )

--- a/src/anyio/_core/_subprocesses.py
+++ b/src/anyio/_core/_subprocesses.py
@@ -176,7 +176,7 @@ async def open_process(
         kwargs["group"] = group
 
     if extra_groups is not None:
-        kwargs["extra_groups"] = group
+        kwargs["extra_groups"] = extra_groups
 
     if umask >= 0:
         kwargs["umask"] = umask

--- a/src/anyio/streams/tls.py
+++ b/src/anyio/streams/tls.py
@@ -141,11 +141,23 @@ class TLSStream(ByteStream):
         bio_in = ssl.MemoryBIO()
         bio_out = ssl.MemoryBIO()
 
+        # Resolve international host names using IDNA 2008.
+        # Otherwise wrap_bio() would resolve them with IDNA 2003.
+        if hostname is not None:
+            from .._core._sockets import idna2008_resolve
+
+            server_hostname: bytes | None = idna2008_resolve(hostname)
+        else:
+            server_hostname = None
+
         # External SSLContext implementations may do blocking I/O in wrap_bio(),
         # but the standard library implementation won't
         if type(ssl_context) is ssl.SSLContext:
             ssl_object = ssl_context.wrap_bio(
-                bio_in, bio_out, server_side=server_side, server_hostname=hostname
+                bio_in,
+                bio_out,
+                server_side=server_side,
+                server_hostname=server_hostname,
             )
         else:
             ssl_object = await to_thread.run_sync(
@@ -153,7 +165,7 @@ class TLSStream(ByteStream):
                 bio_in,
                 bio_out,
                 server_side,
-                hostname,
+                server_hostname,
                 None,
             )
 

--- a/tests/streams/test_tls.py
+++ b/tests/streams/test_tls.py
@@ -60,6 +60,47 @@ class TestTLSStream:
         server_sock.close()
         assert response == b"olleh"
 
+    async def test_unicode_hostname_idna2008(
+        self, ca: CA, client_context: ssl.SSLContext
+    ) -> None:
+        """
+        Test that a unicode host name is encoded to ASCII using IDNA 2008 rather
+        than the standard library's IDNA 2003 before being matched against the
+        peer certificate.
+
+        """
+        # "faß.de" encodes to "xn--fa-hia.de" under IDNA 2008, but to the
+        # entirely different (and wrong) "fass.de" under IDNA 2003
+        server_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        if hasattr(ssl, "OP_IGNORE_UNEXPECTED_EOF"):
+            server_context.options &= ~ssl.OP_IGNORE_UNEXPECTED_EOF
+
+        ca.issue_cert("xn--fa-hia.de").configure_cert(server_context)
+
+        server_send, server_receive = create_memory_object_stream[bytes](1)
+        client_send, client_receive = create_memory_object_stream[bytes](1)
+        client_stream = StapledObjectStream(client_send, server_receive)
+        server_stream = StapledObjectStream(server_send, client_receive)
+
+        async def serve() -> None:
+            async with await TLSStream.wrap(
+                server_stream, server_side=True, ssl_context=server_context
+            ) as tls_stream:
+                data = await tls_stream.receive()
+                await tls_stream.send(data[::-1])
+
+        async with create_task_group() as tg:
+            tg.start_soon(serve)
+            # This would raise an SSLCertVerificationError if the host name were
+            # encoded using IDNA 2003 (yielding "fass.de")
+            async with await TLSStream.wrap(
+                client_stream, hostname="faß.de", ssl_context=client_context
+            ) as wrapper:
+                await wrapper.send(b"hello")
+                response = await wrapper.receive()
+
+        assert response == b"olleh"
+
     @pytest.mark.parametrize("max_bytes", [0, -1])
     async def test_receive_invalid_max_bytes(
         self,

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -66,6 +66,7 @@ from anyio import (
 )
 from anyio._core._eventloop import get_async_backend
 from anyio.abc import (
+    AnyByteStream,
     ConnectedUDPSocket,
     ConnectedUNIXDatagramSocket,
     IPSockAddrType,
@@ -80,7 +81,7 @@ from anyio.abc import (
 from anyio.lowlevel import checkpoint
 from anyio.pytest_plugin import FreePortFactory
 from anyio.streams.stapled import MultiListener
-from anyio.streams.tls import TLSConnectable
+from anyio.streams.tls import TLSConnectable, TLSStream
 
 from .conftest import asyncio_params, no_other_refs
 
@@ -678,6 +679,34 @@ class TestTCPStream:
 
         thread.join()
         assert thread_exception is None
+
+    async def test_connect_tcp_with_tls_unicode_hostname(
+        self,
+        server_sock: socket.socket,
+        server_addr: tuple[str, int],
+        family: AnyIPAddressFamily,
+        mocker: MockerFixture,
+    ) -> None:
+        """
+        Test that connect_tcp() forwards the target host name to ``TLSStream.wrap()``
+        as-is, deferring the matching against the peer certificate (and any IDNA
+        encoding required for that) to it.
+
+        """
+        gai_result = socket.getaddrinfo(
+            server_addr[0], server_addr[1], family, socket.SOCK_STREAM
+        )
+        mocker.patch.object(get_async_backend(), "getaddrinfo", return_value=gai_result)
+
+        async def fake_wrap(
+            transport_stream: AnyByteStream, **kwargs: Any
+        ) -> AnyByteStream:
+            await transport_stream.aclose()
+            return transport_stream
+
+        wrap = mocker.patch.object(TLSStream, "wrap", side_effect=fake_wrap)
+        await connect_tcp("faß.de", server_addr[1], tls=True)
+        assert wrap.call_args.kwargs["hostname"] == "faß.de"
 
     @pytest.mark.parametrize("anyio_backend", asyncio_params)
     async def test_unretrieved_future_exception_server_crash(

--- a/tests/test_subprocesses.py
+++ b/tests/test_subprocesses.py
@@ -5,11 +5,12 @@ import platform
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from subprocess import CalledProcessError
+from subprocess import DEVNULL, CalledProcessError
 from textwrap import dedent
 from typing import Any
 
 import pytest
+from pytest_mock.plugin import MockerFixture
 
 from anyio import (
     BrokenResourceError,
@@ -21,6 +22,7 @@ from anyio import (
     open_process,
     run_process,
 )
+from anyio._core._eventloop import get_async_backend
 from anyio.streams.buffered import BufferedByteReceiveStream
 
 
@@ -348,11 +350,10 @@ async def test_exceptions_after_subprocess_closes_standard_streams() -> None:
                 )
             ],
         ),
-        pytest.param("extra_groups", list, id="extra_groups"),
         pytest.param("umask", lambda: 0, id="umask"),
     ],
 )
-async def test_py39_arguments(
+async def test_user_group_arguments(
     argname: str,
     argvalue_factory: Callable[[], Any],
     event_loop_implementation_name: str | None,
@@ -373,6 +374,33 @@ async def test_py39_arguments(
             )
 
         raise
+
+
+async def test_arguments_passed_through(mocker: MockerFixture) -> None:
+    """
+    Regression test that ensures that all the arguments accepted by ``open_process()``
+    are passed through to the backend's ``open_process()``.
+    """
+
+    command = [sys.executable, "-c", "pass"]
+    kwargs: dict[str, Any] = {
+        "stdin": DEVNULL,
+        "stdout": DEVNULL,
+        "stderr": DEVNULL,
+        "cwd": "/tmp",
+        "env": {"FOO": "bar"},
+        "startupinfo": object(),
+        "creationflags": 4,
+        "start_new_session": True,
+        "pass_fds": (5, 6),
+        "user": "myuser",
+        "group": "mygroup",
+        "extra_groups": [1, 2, "foo"],
+        "umask": 123,
+    }
+    mock_open_process = mocker.patch.object(get_async_backend(), "open_process")
+    await open_process(command, **kwargs)
+    mock_open_process.assert_called_once_with(command, **kwargs)
 
 
 async def test_close_early() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Changes `TLSStream.wrap()` to use IDNA 2008 instead of IDNA 2003 to encode internationalized domain names, matching `connect_tcp()`.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
