### PR TITLE
Docs communicates `anyio_backend` is function scoped, but it's actually module scoped

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -59,7 +59,7 @@ Specifying the backends to run on
 ---------------------------------
 
 The ``anyio_backend`` fixture determines the backends and their options that tests and
-fixtures are run with. The AnyIO pytest plugin comes with a function scoped fixture with
+fixtures are run with. The AnyIO pytest plugin comes with a module scoped fixture with
 this name which runs everything on all supported backends.
 
 If you change the backends/options for the entire project, then put something like this
@@ -143,16 +143,16 @@ For ``autouse=True`` fixtures, you may need to use the other approach::
 Using async fixtures with higher scopes
 ---------------------------------------
 
-For async fixtures with scopes other than ``function``, you will need to define your own
-``anyio_backend`` fixture because the default ``anyio_backend`` fixture is function
+For async fixtures with scopes other than ``module``, you will need to define your own
+``anyio_backend`` fixture because the default ``anyio_backend`` fixture is module
 scoped::
 
-    @pytest.fixture(scope='module')
+    @pytest.fixture(scope='session')
     def anyio_backend():
         return 'asyncio'
 
 
-    @pytest.fixture(scope='module')
+    @pytest.fixture(scope='session')
     async def server(anyio_backend):
         server = await setup_server()
         yield


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Related to #https://github.com/agronholm/anyio/discussions/1156

I got a little hesitant here because reverting `anyio_backend` back to function scoped
doesn't break anyio's own test suite. I suspected this was because the 3.x backport
https://github.com/agronholm/anyio/pull/437 (backporting the async-generator-fixture
change from #435) explicitly added `anyio_backend` as module scoped directly inside
`test_pytest_plugin.test_module_scoped_task_group_fixture`:
https://github.com/agronholm/anyio/blob/85b8b6eb2e213c0fc7cbc1c29f71e3d487393bab/tests/test_pytest_plugin.py#L273-L275

What I took this to imply was that anyio_backend had stayed function scoped, except it was already updated to module scoped in [#435](https://github.com/agronholm/anyio/pull/435) , hence redeclaring it as module scoped explicitly in that one test doesn't seem to change anything.

Best I can tell, having anyio_backend module scoped by default reduces the boilerplate for higher-scoped async/async-generator fixtures.

Another tiny confusion was that, there are two fixtures that depend on
`anyio_backend` for convenience,
https://anyio.readthedocs.io/en/stable/testing.html#:~:text=Because%20the%20anyio_backend,run%20the%20backend
https://github.com/agronholm/anyio/blob/85b8b6eb2e213c0fc7cbc1c29f71e3d487393bab/src/anyio/pytest_plugin.py#L281-L282
https://github.com/agronholm/anyio/blob/85b8b6eb2e213c0fc7cbc1c29f71e3d487393bab/src/anyio/pytest_plugin.py#L289-L290
and these were left function scoped. **But**, I don't think this a problem?. These fixtures aren't auto-injected into async fixtures like anyio_backend is; they're only pulled in when someone deliberately requests them.

And updating the docs seemed to make more sense to me than reverting `anyio_backend` back to
function scoped, unless I'm proven wrong.


<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
