### PR TITLE
Fix asyncio backend leaking the event loop via cached root task (#1203)

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed the asyncio backend leaking the event loop (and the run's result) on every
+  ``anyio.run()`` that used ``to_thread.run_sync()``. ``find_root_task()`` cached the
+  root task in a per-loop run-var, and the cached task strong-referenced its loop (the
+  weak *key* of the run-vars mapping), so the entry could never be evicted. The cache
+  entry is now cleared via a task done-callback
+  (`#1203 <https://github.com/agronholm/anyio/issues/1203>`_)
 - Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when
   ``max_bytes`` is not a positive integer
   (`#1191 <https://github.com/agronholm/anyio/pull/1191>`_)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -308,6 +308,19 @@ P = ParamSpec("P")
 _root_task: RunVar[asyncio.Task | None] = RunVar("_root_task")
 
 
+def _clear_root_task(_task: object) -> None:
+    # Drop the cached root task once it is done so the event loop it strong-refs
+    # can be garbage-collected. Without this, the cached Task keeps its loop alive
+    # as a strong value in the per-loop run-vars mapping, which is the weak *key*
+    # of ``lowlevel._run_vars``, so the loop (and everything it references, incl.
+    # the run's result) can never be evicted. See
+    # https://github.com/agronholm/anyio/issues/1203.
+    from ..lowlevel import _run_vars as _lowlevel_run_vars
+
+    for run_vars in _lowlevel_run_vars.values():
+        run_vars.pop(_root_task, None)
+
+
 def find_root_task() -> asyncio.Task:
     root_task = _root_task.get(None)
     if root_task is not None and not root_task.done():
@@ -323,6 +336,10 @@ def find_root_task() -> asyncio.Task:
                     or getattr(cb, "__module__", None) == "uvloop.loop"
                 ):
                     _root_task.set(task)
+                    # Register with a fresh context so the callback does not
+                    # capture (and thus retain) the current contextvars snapshot;
+                    # see test_run_sync_worker_cyclic_references.
+                    task.add_done_callback(_clear_root_task, context=Context())
                     return task
 
     # Look up the topmost task in the AnyIO task tree, if possible

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import math
+import sys
 import time
+import weakref
 from asyncio import get_running_loop
 from collections.abc import Generator
 from typing import Any
@@ -12,7 +15,7 @@ from unittest.mock import AsyncMock
 import pytest
 from pytest import MonkeyPatch
 
-from anyio import current_time, run, sleep, sleep_forever, sleep_until
+from anyio import current_time, run, sleep, sleep_forever, sleep_until, to_thread
 
 from .conftest import return_non_coro_awaitable
 
@@ -78,6 +81,39 @@ def test_run_unknown_backend() -> None:
 
     with pytest.raises(LookupError, match="No such backend: somebackend"):
         run(main, backend="somebackend")
+
+
+@pytest.mark.skipif(
+    sys.implementation.name != "cpython",
+    reason="garbage collection semantics differ on non-CPython implementations",
+)
+def test_asyncio_run_does_not_leak_event_loop() -> None:
+    """
+    Regression test for #1203.
+
+    ``find_root_task()`` caches the root task in a per-loop run-var. Because the
+    cached task strong-references its event loop (the weak *key* of the run-vars
+    mapping), the loop -- and the run's result -- could never be garbage-collected,
+    leaking on every ``anyio.run()`` that used ``to_thread.run_sync()``.
+    """
+
+    def thread_worker() -> None:
+        pass
+
+    loop_refs: list[weakref.ref[asyncio.AbstractEventLoop]] = []
+
+    async def main() -> None:
+        # Exercising to_thread.run_sync() triggers find_root_task(), which caches
+        # the root task (and thus the loop) in the run-vars mapping.
+        await to_thread.run_sync(thread_worker)
+        loop_refs.append(weakref.ref(get_running_loop()))
+
+    for _ in range(3):
+        run(main, backend="asyncio")
+
+    gc.collect()
+    alive = [ref for ref in loop_refs if ref() is not None]
+    assert not alive, f"{len(alive)} event loop(s) leaked"
 
 
 def test_run_known_but_uninstalled_backend(monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #1203.

## The leak

`find_root_task()` caches the root task in the per-loop `_root_task` `RunVar`. That cached `Task` strong-references its event loop — and the loop is the **weak *key*** of `lowlevel._run_vars` (`WeakKeyDictionary`). Because a live value (the task, reachable via the mapping) keeps the weak key alive, the entry can never be evicted.

Net effect: every `anyio.run()` on the asyncio backend that calls `to_thread.run_sync()` (which goes through `find_root_task()`) permanently leaks the event loop, its root task, **and the run's result**. Called in a loop, RSS grows without bound → OOM. `gc.collect()` does not reclaim it.

## The fix

When caching the root task, attach a done-callback that removes `_root_task` from the run-vars mapping once the root task finishes. This breaks the strong reference, so the `WeakKeyDictionary` entry becomes collectable.

This follows the direction @tapetersen [suggested on the issue](https://github.com/agronholm/anyio/issues/1203#issuecomment-4904743496):

> The correct fix is probably to add a done callback that unsets the specific RunVar when it exits. Anyio can be used in a library that manages the loop with asyncio.run or trio.run directly so clearing in a finally there as suggested by Fable won't work reliably.

The callback is registered with a fresh `contextvars.Context()` so it does not capture/retain the current context snapshot (otherwise `test_run_sync_worker_cyclic_references` regresses, since the captured context would keep the worker's context values alive).

## Test

Added `test_asyncio_run_does_not_leak_event_loop`: runs `anyio.run(main)` (where `main` awaits `to_thread.run_sync(...)`) a few times, holds a `weakref` to each loop, and asserts all loops are collected after `gc.collect()`.

- **Before this change:** fails — `3 event loop(s) leaked`.
- **After this change:** passes.

Full local run of `test_eventloop.py`, `test_to_thread.py`, `test_lowlevel.py`, `test_from_thread.py`, `test_taskgroups.py` is green (402 passed, uvloop-gated tests skipped locally). Added a `versionhistory.rst` entry.

## CI note

The one red job — `test (ubuntu-latest, 3.14, [trio])` — fails only on `test_sockets.py::TestTCPListener::test_tcp_listener_same_port`, which is unrelated to this change (it touches only `find_root_task()` / event-loop teardown, no sockets). That failing parametrization binds a hardcoded port (`54321`) / relies on dual-stack listener counts; it reproduces **identically on a clean `master` checkout without this patch**, so it's a pre-existing environment/port flake, not a regression here. Every other matrix job (macOS + Windows across 3.10–3.14, `pyright`, `docs`, `pre-commit.ci`) is green, including the new regression test. A re-run of that single job should clear it.
