### PR TITLE
Fix flaky test_tcp_listener_same_port using a hardcoded port

### DIFF
--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1015,7 +1015,7 @@ class TestTCPListener:
                 None,
                 AddressFamily.AF_UNSPEC,
                 1 if socket.has_dualstack_ipv6() else 2,
-                54321,
+                None,
             ),
             ("localhost", AddressFamily.AF_UNSPEC, 2, None),
             ("localhost", AddressFamily.AF_INET, 1, None),


### PR DESCRIPTION
## Changes

Fixes #1205.

One parametrization of `test_tcp_listener_same_port` still binds the hardcoded port `54321`, so the test fails intermittently in CI (and blocks parallel `tox` runs) whenever that port is already in use on the runner. This has been surfacing as red `3.14` jobs on `master` and on unrelated PRs.

d0482f9 converted the sibling `("localhost", …, 54321)` cases to the `free_tcp_port_factory` fixture but missed the adjacent `(None, AF_UNSPEC, …, 54321)` case. This change points that case at the factory too — it already handles `family=None` by finding a port free on both IPv4 and IPv6, so no fixed port is needed.

## Checklist

This is a trivial, test-only change (a single hardcoded port swapped for the existing free-port fixture), so per the template's note the user-facing checklist below doesn't strictly apply. Recording the status honestly anyway:

- [ ] You've added tests (in `tests/`) which would fail without your patch — N/A: this fixes an existing flaky test rather than adding coverage.
- [ ] You've updated the documentation (in `docs/`) — N/A: no behavior or API change.
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`) — N/A: test-only, following the same no-changelog convention as the sibling fix d0482f9.

---

> [!NOTE]
> #1205 also documents a second, environment-dependent failure mode in the same test (the `("localhost", AF_UNSPEC, 2, …)` cases assume `localhost` resolves dual-stack). That's left untouched here since it passes on GitHub's runners and is arguably a separate change — happy to follow up if you'd like the test made resolution-agnostic.
