### PR TITLE
Break ref-cycle between loop and root_task via RunVar

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -13,6 +13,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,
   while every backend setter (using ``math.isinf()``) accepts any positive infinity
   (`#1189 <https://github.com/agronholm/anyio/pull/1189>`_; PR by @greymoth-jp).
+- Fixed ``anyio.run`` leaking, or at least, delaying collection of loop and root_task
+  due to the root task being cached in a ``RunVar``.
+  (`#1203 <https://github.com/agronholm/anyio/issues/1203>`_; PR by @tapetersen)
 
 **4.14.1**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -102,7 +102,7 @@ from ..abc import (
 )
 from ..abc._eventloop import StrOrBytesPath
 from ..abc._tasks import call_for_coroutine, get_callable_name
-from ..lowlevel import RunVar, _run_vars, current_token
+from ..lowlevel import RunVar, _run_vars
 from ..streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
 if TYPE_CHECKING:
@@ -321,13 +321,10 @@ def find_root_task() -> asyncio.Task:
                     cb is _run_until_complete_cb
                     or getattr(cb, "__module__", None) == "uvloop.loop"
                 ):
-                    tok = current_token()
                     _root_task.set(task)
 
-                    def _unset(
-                        t: asyncio.Task[Any], native_tok: object = tok.native_token
-                    ) -> None:
-                        if vars := _run_vars.get(native_tok):
+                    def _unset(t: asyncio.Task[Any]) -> None:
+                        if vars := _run_vars.get(t.get_loop()):
                             vars.pop(_root_task, None)
 
                     # Register a callback to break the task -> loop -> _run_var[loop][_root_task] -> task cycle

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -102,7 +102,7 @@ from ..abc import (
 )
 from ..abc._eventloop import StrOrBytesPath
 from ..abc._tasks import call_for_coroutine, get_callable_name
-from ..lowlevel import RunVar
+from ..lowlevel import RunVar, _run_vars, current_token
 from ..streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
 if TYPE_CHECKING:
@@ -305,7 +305,7 @@ T_contra = TypeVar("T_contra", contravariant=True)
 PosArgsT = TypeVarTuple("PosArgsT")
 P = ParamSpec("P")
 
-_root_task: RunVar[asyncio.Task | None] = RunVar("_root_task")
+_root_task: RunVar[asyncio.Task[Any] | None] = RunVar("_root_task")
 
 
 def find_root_task() -> asyncio.Task:
@@ -316,13 +316,25 @@ def find_root_task() -> asyncio.Task:
     # Look for a task that has been started via run_until_complete()
     for task in all_tasks():
         if task._callbacks and not task.done():
-            callbacks = [cb for cb, context in task._callbacks]
-            for cb in callbacks:
+            for cb, context in task._callbacks:
                 if (
                     cb is _run_until_complete_cb
                     or getattr(cb, "__module__", None) == "uvloop.loop"
                 ):
+                    tok = current_token()
                     _root_task.set(task)
+
+                    def _unset(
+                        t: asyncio.Task[Any], native_tok: object = tok.native_token
+                    ) -> None:
+                        if vars := _run_vars.get(native_tok):
+                            vars.pop(_root_task, None)
+
+                    # Register a callback to break the task -> loop -> _run_var[loop][_root_task] -> task cycle
+                    # Also run it in its own context to not create another reference.
+                    # We can't use RunVar.reset() here since these are called synchronously
+                    # and thus lowlevel.current_token() (which RunVar.reset() depends on) fails.
+                    task.add_done_callback(_unset, context=context)
                     return task
 
     # Look up the topmost task in the AnyIO task tree, if possible
@@ -337,13 +349,6 @@ def find_root_task() -> asyncio.Task:
             return cast(asyncio.Task, cancel_scope._host_task)
 
     return task
-
-
-#
-# Event loop
-#
-
-_run_vars: WeakKeyDictionary[asyncio.AbstractEventLoop, Any] = WeakKeyDictionary()
 
 
 def _task_started(task: asyncio.Task) -> bool:

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -5,6 +5,7 @@ import gc
 import sys
 import threading
 import time
+import weakref
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextvars import ContextVar
 from functools import partial
@@ -361,13 +362,16 @@ class TestBlockingPortalProvider:
         assert len(threads) == 1
 
 
-@pytest.mark.skipif(
+skipif_pypy_mark = pytest.mark.skipif(
     sys.implementation.name == "pypy",
     reason=(
         "gc.get_referrers is broken on PyPy (see "
         "https://github.com/pypy/pypy/issues/5075)"
     ),
 )
+
+
+@skipif_pypy_mark
 async def test_run_sync_worker_cyclic_references() -> None:
     class Foo:
         pass
@@ -386,3 +390,33 @@ async def test_run_sync_worker_cyclic_references() -> None:
     assert gc.get_referrers(contextval) == no_other_refs()
     assert gc.get_referrers(foo) == no_other_refs()
     assert gc.get_referrers(arg) == no_other_refs()
+
+
+@skipif_pypy_mark
+def test_asyncio_run_does_not_leak_event_loop() -> None:
+    """
+    Regression test for #1203.
+
+    Ensure we don't leak the root task and event loop in when caching it in a RunVar.
+    """
+
+    def thread_worker() -> None:
+        pass
+
+    async def main() -> None:
+        # Exercising to_thread.run_sync() triggers find_root_task(), which caches
+        # the root task (and thus the loop) in the run-vars mapping.
+        await to_thread.run_sync(thread_worker)
+        f.set_running_or_notify_cancel()
+        f.set_result(weakref.ref(asyncio.get_running_loop()))
+
+    f = Future[weakref.ref[object]]()
+    t = threading.Thread(
+        group=None, target=anyio.run, args=(main,), kwargs={"backend": "asyncio"}
+    )
+    t.start()
+    loop_ref = f.result(timeout=2.0)
+    t.join()
+
+    gc.collect()
+    assert loop_ref() is None

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -403,20 +403,13 @@ def test_asyncio_run_does_not_leak_event_loop() -> None:
     def thread_worker() -> None:
         pass
 
-    async def main() -> None:
+    async def main() -> weakref.ref[object]:
         # Exercising to_thread.run_sync() triggers find_root_task(), which caches
         # the root task (and thus the loop) in the run-vars mapping.
         await to_thread.run_sync(thread_worker)
-        f.set_running_or_notify_cancel()
-        f.set_result(weakref.ref(asyncio.get_running_loop()))
+        return weakref.ref(asyncio.get_running_loop())
 
-    f = Future[weakref.ref[object]]()
-    t = threading.Thread(
-        group=None, target=anyio.run, args=(main,), kwargs={"backend": "asyncio"}
-    )
-    t.start()
-    loop_ref = f.result(timeout=2.0)
-    t.join()
+    loop_ref = anyio.run(main)
 
     gc.collect()
     assert loop_ref() is None


### PR DESCRIPTION
## Changes

Fixes #1203 

Breaks the reference-cycle by unsetting the `_root_task` RunVar in a completed callback.
Since those run as sync callbacks we can't use the RunVar's  builtin reset mechanism as it
fails on `current_token()` since we're not in a running loop.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

