### PR TITLE
Fix per-run event loop leak in _run_vars on asyncio

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -23,6 +23,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``anyio.open_process()`` (and ``run_process()``) ignoring the ``extra_groups``
   argument, as it mistakenly passed the value of the ``group`` argument instead
   (`#1209 <https://github.com/agronholm/anyio/pull/1209>`_)
+- Fixed a memory leak on asyncio where each ``anyio.run()`` call permanently retained
+  its event loop, root task and result. ``find_root_task()`` caches the root task in a
+  run variable, and since that task strongly references its loop (the weak key of the
+  ``_run_vars`` entry), the entry could never be evicted. ``anyio.run()`` now clears the
+  loop's run variables on teardown
+  (`#1203 <https://github.com/agronholm/anyio/issues/1203>`_; PR by @vidigoat)
 
 **4.14.1**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -65,6 +65,7 @@ from .. import (
     LockStatistics,
     TaskInfo,
     abc,
+    lowlevel,
 )
 from .._core._eventloop import (
     claim_worker_thread,
@@ -342,8 +343,6 @@ def find_root_task() -> asyncio.Task:
 #
 # Event loop
 #
-
-_run_vars: WeakKeyDictionary[asyncio.AbstractEventLoop, Any] = WeakKeyDictionary()
 
 
 def _task_started(task: asyncio.Task) -> bool:
@@ -2473,7 +2472,16 @@ class AsyncIOBackend(AsyncBackend):
                 loop_factory = winloop.new_event_loop
 
         with Runner(debug=debug, loop_factory=loop_factory) as runner:
-            return runner.run(wrapper())
+            try:
+                return runner.run(wrapper())
+            finally:
+                # Drop this loop's run variables. Some of them (notably the
+                # cached root task; see find_root_task()) hold a strong reference
+                # to the loop, which is the weak key of the _run_vars entry. That
+                # self-reference would otherwise keep the loop, the root task and
+                # its result alive forever, leaking memory across successive
+                # anyio.run() calls (#1203).
+                lowlevel._run_vars.pop(runner.get_loop(), None)
 
     @classmethod
     def current_token(cls) -> object:

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -277,6 +277,29 @@ def test_asyncio_no_recycle_stopping_worker(
     asyncio_event_loop.run_until_complete(asyncio.gather(task1, task2))
 
 
+def test_asyncio_run_sync_no_run_var_leak() -> None:
+    """
+    Regression test for #1203.
+
+    Ensures that repeated ``anyio.run()`` calls that use ``to_thread.run_sync()``
+    do not leak an entry in ``_run_vars`` per run. ``find_root_task()`` caches the
+    root task in a ``RunVar``, and that task holds a strong reference to its event
+    loop, which is the weak key of the ``_run_vars`` entry. Without cleanup, that
+    self-reference keeps every loop (and its cached result) alive forever.
+    """
+    from anyio.lowlevel import _run_vars
+
+    async def main() -> None:
+        await anyio.to_thread.run_sync(time.sleep, 0)
+
+    _run_vars.clear()
+    for _ in range(3):
+        anyio.run(main)
+        gc.collect()
+
+    assert len(_run_vars) == 0
+
+
 async def test_stopiteration() -> None:
     """
     Test that raising StopIteration in a worker thread raises a RuntimeError on the


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Changes

Fixes #1203.

On the **asyncio** backend, every `anyio.run()` call permanently leaks its
event loop, root task and result. Calling `anyio.run()` in a loop grows memory
without bound and `gc.collect()` does not reclaim it.

### Root cause

`find_root_task()` caches the root task in the `_root_task` run variable:

```python
_root_task.set(task)
```

Run variables live in `anyio.lowlevel._run_vars`, a `WeakKeyDictionary` keyed by
the event loop. The cached `Task` strongly references its loop (via
`task.get_loop()`), so the entry's **value** holds a strong reference back to its
own **weak key**. A `WeakKeyDictionary` entry whose value keeps its key alive can
never be evicted, so the loop, the root task and the task's result survive for
the lifetime of the process.

The Trio backend is unaffected, and `Semaphore`/`Lock`-style hand-offs are not
involved — this is purely the weak-key self-reference.

### Fix

`AsyncIOBackend.run()` now drops the loop's `_run_vars` entry in a `finally`
block once the run finishes (whether it returns or raises), breaking the cycle so
the loop and its result can be garbage-collected.

While here, this also removes an **unused, shadowing** module-level `_run_vars`
definition in `_asyncio.py`. It was dead code (never read or written anywhere)
and shadowed the real `anyio.lowlevel._run_vars`, making it easy to reference the
wrong dictionary.

### Reproduction (before the fix)

```python
import gc
import anyio, anyio.lowlevel, anyio.to_thread

async def main() -> bytes:
    return await anyio.to_thread.run_sync(lambda: b"x" * 50_000_000)

for i in range(6):
    anyio.run(main)
    gc.collect()
    print(i, "entries", len(anyio.lowlevel._run_vars))
# entries: 1, 2, 3, 4, 5, 6  (RSS climbs ~48 MB per iteration)
```

With the fix, `_run_vars` stays empty and RSS is flat.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

The new test `test_asyncio_run_sync_no_run_var_leak` fails on `master`
(`assert 3 == 0`) and passes with this patch. Full test suite: 3690 passed,
0 failed. `ruff check`, `ruff format` and `mypy` all pass on the changed files.
