### PR TITLE
pin setup-uv to a commit sha across downstream jobs

### DIFF
--- a/.github/workflows/test-downstream.yml
+++ b/.github/workflows/test-downstream.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.4"
+          version: "0.11.18"
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml

--- a/.github/workflows/test-downstream.yml
+++ b/.github/workflows/test-downstream.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           repository: Kludex/starlette
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -70,7 +70,7 @@ jobs:
         with:
           python-version: "${{ matrix.python-version }}"
       - name: Setup uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.11.4"
           enable-cache: true
@@ -102,7 +102,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.8.8"
           enable-cache: true
@@ -126,7 +126,7 @@ jobs:
         with:
           repository: modelcontextprotocol/python-sdk
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
           version: "0.9.5"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #. <!-- Provide issue number if exists -->

Downstream jobs that use astral-sh/setup-uv, only one (FastAPI) was pinned to a commit sha, the others used a floating tag. I'm pinning all four to the same commit hash. Minor thing, but keep consistency across these jobs.  ([more about setup-uv immutable releases and secure tags](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0)). 
They're all now on the exact same version too!

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
