### PR TITLE
Fix SpooledTemporaryFile.readinto/readinto1 reading twice before rollover

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,7 +11,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``SpooledTemporaryFile.readinto()`` and ``readinto1()`` reading twice before
   rollover, so the destination buffer was overwritten by the second read and the file
   position advanced twice, silently losing data
-  (`#1215 <https://github.com/agronholm/anyio/pull/1215>`_); PR by @c-tonneslan 
+  (`#1215 <https://github.com/agronholm/anyio/pull/1215>`_); PR by @c-tonneslan
 - Fixed ``CapacityLimiter.total_tokens`` rejecting ``float("inf")`` when the limiter was
   instantiated outside of an event loop. The adapter setter checked for infinity by
   identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,6 +8,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when
   ``max_bytes`` is not a positive integer
   (`#1191 <https://github.com/agronholm/anyio/pull/1191>`_)
+- Fixed ``SpooledTemporaryFile.readinto()`` and ``readinto1()`` reading twice before
+  rollover, so the destination buffer was overwritten by the second read and the file
+  position advanced twice, silently losing data
+  (`#1215 <https://github.com/agronholm/anyio/pull/1215>`_)
 - Fixed ``CapacityLimiter.total_tokens`` rejecting ``float("inf")`` when the limiter was
   instantiated outside of an event loop. The adapter setter checked for infinity by
   identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,7 +11,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``SpooledTemporaryFile.readinto()`` and ``readinto1()`` reading twice before
   rollover, so the destination buffer was overwritten by the second read and the file
   position advanced twice, silently losing data
-  (`#1215 <https://github.com/agronholm/anyio/pull/1215>`_)
+  (`#1215 <https://github.com/agronholm/anyio/pull/1215>`_); PR by @c-tonneslan 
 - Fixed ``CapacityLimiter.total_tokens`` rejecting ``float("inf")`` when the limiter was
   instantiated outside of an event loop. The adapter setter checked for infinity by
   identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,7 +11,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``SpooledTemporaryFile.readinto()`` and ``readinto1()`` reading twice before
   rollover, so the destination buffer was overwritten by the second read and the file
   position advanced twice, silently losing data
-  (`#1215 <https://github.com/agronholm/anyio/pull/1215>`_); PR by @c-tonneslan
+  (`#1215 <https://github.com/agronholm/anyio/pull/1215>`_; PR by @c-tonneslan)
 - Fixed ``CapacityLimiter.total_tokens`` rejecting ``float("inf")`` when the limiter was
   instantiated outside of an event loop. The adapter setter checked for infinity by
   identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,15 +3,18 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed ``SpooledTemporaryFile.readinto()`` and ``readinto1()`` reading twice before
+  rollover, so the destination buffer was overwritten by the second read and the file
+  position advanced twice, silently losing data
+  (`#1215 <https://github.com/agronholm/anyio/pull/1215>`_; PR by @c-tonneslan)
+
 **4.14.2**
 
 - Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when
   ``max_bytes`` is not a positive integer
   (`#1191 <https://github.com/agronholm/anyio/pull/1191>`_)
-- Fixed ``SpooledTemporaryFile.readinto()`` and ``readinto1()`` reading twice before
-  rollover, so the destination buffer was overwritten by the second read and the file
-  position advanced twice, silently losing data
-  (`#1215 <https://github.com/agronholm/anyio/pull/1215>`_; PR by @c-tonneslan)
 - Fixed ``CapacityLimiter.total_tokens`` rejecting ``float("inf")`` when the limiter was
   instantiated outside of an event loop. The adapter setter checked for infinity by
   identity (``value is math.inf``), so only the exact ``math.inf`` singleton was accepted,

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -365,14 +365,14 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
     async def readinto(self: SpooledTemporaryFile[bytes], b: WriteableBuffer) -> int:
         if not self._rolled:
             await checkpoint_if_cancelled()
-            self._fp.readinto(b)
+            return self._fp.readinto(b)
 
         return await super().readinto(b)
 
     async def readinto1(self: SpooledTemporaryFile[bytes], b: WriteableBuffer) -> int:
         if not self._rolled:
             await checkpoint_if_cancelled()
-            self._fp.readinto(b)
+            return self._fp.readinto1(b)
 
         return await super().readinto1(b)
 

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -108,6 +108,32 @@ class TestSpooledTemporaryFile:
             await stf.write(b"x")
             assert stf._rolled
 
+    @pytest.mark.parametrize("rolled", [False, True])
+    async def test_readinto(self, rolled: bool) -> None:
+        async with SpooledTemporaryFile(max_size=1024, mode="w+b") as stf:
+            await stf.write(b"hello world")
+            if rolled:
+                await stf.rollover()
+            assert stf._rolled is rolled
+            await stf.seek(0)
+            buf = bytearray(5)
+            assert await stf.readinto(buf) == 5
+            assert bytes(buf) == b"hello"
+            assert await stf.tell() == 5
+
+    @pytest.mark.parametrize("rolled", [False, True])
+    async def test_readinto1(self, rolled: bool) -> None:
+        async with SpooledTemporaryFile(max_size=1024, mode="w+b") as stf:
+            await stf.write(b"hello world")
+            if rolled:
+                await stf.rollover()
+            assert stf._rolled is rolled
+            await stf.seek(0)
+            buf = bytearray(5)
+            assert await stf.readinto1(buf) == 5
+            assert bytes(buf) == b"hello"
+            assert await stf.tell() == 5
+
 
 class TestTemporaryDirectory:
     async def test_context_manager(self) -> None:

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -108,31 +108,21 @@ class TestSpooledTemporaryFile:
             await stf.write(b"x")
             assert stf._rolled
 
-    @pytest.mark.parametrize("rolled", [False, True])
-    async def test_readinto(self, rolled: bool) -> None:
+    async def test_readinto(self) -> None:
         async with SpooledTemporaryFile(max_size=1024, mode="w+b") as stf:
             await stf.write(b"hello world")
-            if rolled:
-                await stf.rollover()
-            assert stf._rolled is rolled
             await stf.seek(0)
             buf = bytearray(5)
             assert await stf.readinto(buf) == 5
             assert bytes(buf) == b"hello"
-            assert await stf.tell() == 5
 
-    @pytest.mark.parametrize("rolled", [False, True])
-    async def test_readinto1(self, rolled: bool) -> None:
+    async def test_readinto1(self) -> None:
         async with SpooledTemporaryFile(max_size=1024, mode="w+b") as stf:
             await stf.write(b"hello world")
-            if rolled:
-                await stf.rollover()
-            assert stf._rolled is rolled
             await stf.seek(0)
             buf = bytearray(5)
             assert await stf.readinto1(buf) == 5
             assert bytes(buf) == b"hello"
-            assert await stf.tell() == 5
 
 
 class TestTemporaryDirectory:


### PR DESCRIPTION
## Changes

Before rollover, `SpooledTemporaryFile.readinto` and `readinto1` read from the underlying file object but discard the result and fall through to `super().readinto(b)`, which reads a *second* time. The buffer is overwritten by the second read and the file position advances twice, so the caller silently loses the first chunk of data. `readinto1` additionally called `self._fp.readinto` instead of `self._fp.readinto1`.

Every other read method on the class (`read`, `read1`, `readline`, `readlines`) already `return` from the non-rolled branch; these two were missing the `return`.

```python
async with SpooledTemporaryFile(max_size=1024, mode="w+b") as f:
    await f.write(b"hello world")
    await f.seek(0)
    buf = bytearray(5)
    await f.readinto(buf)
    # before: buf == b" worl", f.tell() == 10
    # after:  buf == b"hello", f.tell() == 5
```

Only triggers before rollover (while the spooled data is still in memory), which is why it went unnoticed.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).