### PR TITLE
Fixed 100% CPU spin on cancel scope misuse

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -23,6 +23,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``anyio.open_process()`` (and ``run_process()``) ignoring the ``extra_groups``
   argument, as it mistakenly passed the value of the ``group`` argument instead
   (`#1209 <https://github.com/agronholm/anyio/pull/1209>`_)
+- Fixed unnecessary CPU spin when delivering cancellation from ``CancelScope`` on
+  asyncio under certain conditions, including improper cancel scope nesting
+  (`#1111 <https://github.com/agronholm/anyio/issues/1111>`_)
 
 **4.14.1**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -592,6 +592,10 @@ class CancelScope(BaseCancelScope):
         should_retry = False
         current = current_task()
         for task in self._tasks:
+            # Always skip tasks that are already done (see issue #1111)
+            if task.done():
+                continue
+
             should_retry = True
             if task._must_cancel:  # type: ignore[attr-defined]
                 continue

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -15,6 +15,7 @@ from unittest import mock
 
 import pytest
 from pytest import FixtureRequest, MonkeyPatch
+from pytest_mock import MockerFixture
 
 import anyio
 from anyio import (
@@ -358,6 +359,51 @@ async def test_cancel_with_nested_task_groups() -> None:
                 tg.cancel_scope.cancel()
 
     assert len(outer_cancel_spy.call_args_list) < 10
+
+
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
+async def test_no_spin_on_done_task_in_cancel_scope(mocker: MockerFixture) -> None:
+    """Regression test for #1111.
+
+    When a task group is entered but never exited (e.g. it is abandoned because
+    the task owning it finishes without unwinding it), its cancel scope is left
+    with the now-finished host task still in its set of contained tasks.
+    Cancelling such a scope used to make ``_deliver_cancellation`` treat that
+    finished task as still cancellable and reschedule itself via ``call_soon``
+    forever, pinning the event loop at 100% CPU.
+    """
+    from anyio._backends import _asyncio
+
+    class EditableCancelScope(_asyncio.CancelScope):
+        pass
+
+    holder: list[TaskGroup] = []
+
+    async def owner() -> None:
+        tg = create_task_group()
+        await tg.__aenter__()  # entered but deliberately never exited
+        holder.append(tg)
+
+    # Let the owner task run to completion, abandoning the task group. Its
+    # cancel scope now holds the finished host task and nothing else.
+    with mock.patch.object(_asyncio, "CancelScope", EditableCancelScope):
+        await asyncio.create_task(owner())
+        scope = cast(_asyncio.CancelScope, holder[0].cancel_scope)
+        spy = mocker.spy(scope, "_deliver_cancellation")
+        assert scope._host_task is not None and scope._host_task.done()
+        assert scope._host_task in scope._tasks
+
+    scope.cancel()
+
+    # Give any rescheduled _deliver_cancellation callbacks the chance to fire.
+    # With the bug present this reschedules forever (the test timeout would
+    # trip); the fix leaves no pending cancellation callback since the only
+    # remaining task is done.
+    for _ in range(5):
+        await checkpoint()
+
+    assert scope._cancel_handle is None
+    spy.assert_called_once()
 
 
 @pytest.mark.parametrize("return_handle", [False, True])

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -391,8 +391,6 @@ async def test_no_spin_on_done_task_in_cancel_scope(mocker: MockerFixture) -> No
 
     scope = cast(_asyncio.CancelScope, holder[0].cancel_scope)
     spy = mocker.spy(scope, "_deliver_cancellation")
-    assert scope._host_task is not None and scope._host_task.done()
-    assert scope._host_task in scope._tasks
 
     scope.cancel()
 

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -374,24 +374,15 @@ async def test_no_spin_on_done_task_in_cancel_scope(mocker: MockerFixture) -> No
     """
     from anyio._backends import _asyncio
 
+    # To allow the mocker to override a @final class
     class EditableCancelScope(_asyncio.CancelScope):
         pass
 
-    holder: list[TaskGroup] = []
+    async def owner() -> EditableCancelScope:
+        return cast(EditableCancelScope, EditableCancelScope().__enter__())
 
-    async def owner() -> None:
-        tg = create_task_group()
-        await tg.__aenter__()  # entered but deliberately never exited
-        holder.append(tg)
-
-    # Let the owner task run to completion, abandoning the task group. Its
-    # cancel scope now holds the finished host task and nothing else.
-    with mock.patch.object(_asyncio, "CancelScope", EditableCancelScope):
-        await asyncio.create_task(owner())
-
-    scope = cast(_asyncio.CancelScope, holder[0].cancel_scope)
+    scope = await asyncio.create_task(owner())
     spy = mocker.spy(scope, "_deliver_cancellation")
-
     scope.cancel()
 
     # Give any rescheduled _deliver_cancellation callbacks the chance to fire.

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -388,10 +388,11 @@ async def test_no_spin_on_done_task_in_cancel_scope(mocker: MockerFixture) -> No
     # cancel scope now holds the finished host task and nothing else.
     with mock.patch.object(_asyncio, "CancelScope", EditableCancelScope):
         await asyncio.create_task(owner())
-        scope = cast(_asyncio.CancelScope, holder[0].cancel_scope)
-        spy = mocker.spy(scope, "_deliver_cancellation")
-        assert scope._host_task is not None and scope._host_task.done()
-        assert scope._host_task in scope._tasks
+
+    scope = cast(_asyncio.CancelScope, holder[0].cancel_scope)
+    spy = mocker.spy(scope, "_deliver_cancellation")
+    assert scope._host_task is not None and scope._host_task.done()
+    assert scope._host_task in scope._tasks
 
     scope.cancel()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Mitigates the CPU-spin effects of cancel scope misnesting.

Fixes #1111.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
