### PR TITLE
Fixed CapacityLimiter raising trio.WouldBlock instead of anyio.WouldBlock

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -23,6 +23,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``anyio.open_process()`` (and ``run_process()``) ignoring the ``extra_groups``
   argument, as it mistakenly passed the value of the ``group`` argument instead
   (`#1209 <https://github.com/agronholm/anyio/pull/1209>`_)
+- Fixed ``CapacityLimiter.acquire_nowait()`` and
+  ``CapacityLimiter.acquire_nowait_on_behalf_of()`` raising ``trio.WouldBlock`` instead
+  of ``anyio.WouldBlock`` on the ``trio`` backend when there are no tokens available
+  (`#1218 <https://github.com/agronholm/anyio/pull/1218>`_)
 
 **4.14.1**
 

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -888,10 +888,16 @@ class CapacityLimiter(BaseCapacityLimiter):
         return self.__original.available_tokens
 
     def acquire_nowait(self) -> None:
-        self.__original.acquire_nowait()
+        try:
+            self.__original.acquire_nowait()
+        except trio.WouldBlock:
+            raise WouldBlock from None
 
     def acquire_on_behalf_of_nowait(self, borrower: object) -> None:
-        self.__original.acquire_on_behalf_of_nowait(borrower)
+        try:
+            self.__original.acquire_on_behalf_of_nowait(borrower)
+        except trio.WouldBlock:
+            raise WouldBlock from None
 
     async def acquire(self) -> None:
         await self.__original.acquire()

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -976,3 +976,20 @@ class TestCapacityLimiter:
             tg.cancel_scope.cancel()
 
         pytest.fail("The second borrower failed to acquire the limiter")
+
+    async def test_acquire_nowait(self) -> None:
+        async def borrower() -> None:
+            limiter.acquire_nowait()
+
+        limiter = CapacityLimiter(1)
+        limiter.acquire_nowait()
+        with pytest.RaisesGroup(pytest.RaisesExc(WouldBlock)):
+            async with create_task_group() as tg:
+                tg.start_soon(borrower)
+
+    async def test_acquire_on_behalf_of_nowait(self) -> None:
+        borrower1, borrower2 = object(), object()
+        limiter = CapacityLimiter(1)
+        limiter.acquire_on_behalf_of_nowait(borrower1)
+        with pytest.raises(WouldBlock):
+            limiter.acquire_on_behalf_of_nowait(borrower2)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Converts ``trio.WouldBlock`` into ``anyio.WouldBlock`` in the Trio implementation of `CapacityLimiter`, like we do with all other synchronization primitives.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
