### PR TITLE
Add a ``dev`` dependency group to get test  dependencies installed by default.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,13 @@ trio = ["trio >= 0.32.0"]
 pytest11 = {anyio = "anyio.pytest_plugin"}
 
 [dependency-groups]
+dev = [
+    "trio>=0.32.0",
+    "tox >= 4.22",
+    "pre-commit>=4.6.0",
+    {include-group = "test"},
+    {include-group = "doc"},
+]
 test = [
     "blockbuster >= 1.5.23; python_version < '3.15'",
     "coverage[toml] >= 7",


### PR DESCRIPTION
## Changes

``uv`` and some other tools install the dependency-group ``dev`` by default when working locally on the package. This allows running ``uv run pytest`` or and ``tox`` or ``pre-commit`` by  default without externally adding them.

This adds a dependency-group named `dev` to `pyproject.toml` which includes the `test` and `doc` group as well as `tox` and `pre-commit` to get these installed by default when checking out to work on the project.

This shouldn't impact downstream users but mainly make it more convenient for developers to get started running necessary tests.

## Checklist

I'm a bit unsure which docs if any I should update or if developer only changes should be included in changelog.

- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

### Updating the changelog

