### PR TITLE
support free-threaded python3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy3.11-v7.3.23"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "pypy3.11-v7.3.23"]
         extras: ["[trio]"]
         lowest-bound: [false]
         include:

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,22 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Added the free-threaded build of Python 3.14t to the test matrix
+  (`#1224 <https://github.com/agronholm/anyio/pull/1224>`_; PR by @EmmanuelNiyonshuti)
+  As a result:
+
+  - Fixed ``start_blocking_portal()`` portal thread inheriting the calling thread's
+    ``contextvars.Context`` on Python 3.14+ free-threaded builds, previously was
+    leading to a ``RuntimeError: Already running <backend> in this thread``
+    raised in ``TestBlockingPortal::test_from_async``.
+    (`#1220 <https://github.com/agronholm/anyio/issues/1220>`_; PR by @EmmanuelNiyonshuti)
+  - Fixed ``to_thread.run_sync()``'s worker thread pool on asyncio backend retaining a
+    reference to the calling task's ``contextvars.Context`` for the lifetime of the
+    pooled worker thread on Python 3.14+ free-threaded builds. Same reason as above.
+    previously was breaking this test ``test_run_sync_worker_cyclic_references``.
+
 **4.14.2**
 
 - Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,7 +5,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-  (`#1224 <https://github.com/agronholm/anyio/pull/1224>`_; PR by @EmmanuelNiyonshuti)
 - Changed the default name for a task spawned with ``TaskGroup.create_task(func())`` to
   match the default task name for the analogous task spawned with
   ``TaskGroup.start_soon(func)`` or ``TaskGroup.start(func)`` in more situations.
@@ -16,6 +15,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   free-threading builds, newly created threads inherit the current context by default,
   causing AnyIO to behave erroneously in relation to ``start_blocking_portal()`` and
   ``anyio.to_thread.run_sync()``
+  (`#1224 <https://github.com/agronholm/anyio/pull/1224>`_; PR by @EmmanuelNiyonshuti)
 
 **4.14.2**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,16 +5,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Added the free-threaded build of Python 3.14t to the test matrix
+- Fixed free-threading compatibility issues arising from the fact that on Python 3.14
+  free-threading builds, newly created threads inherit the current context by default,
+  causing AnyIO to behave erroneously in relation to ``start_blocking_portal()`` and
+  ``anyio.to_thread.run_sync()``
   (`#1224 <https://github.com/agronholm/anyio/pull/1224>`_; PR by @EmmanuelNiyonshuti)
-  As a result:
-
-  - Fixed ``start_blocking_portal()`` portal thread inheriting the calling thread's
-    ``contextvars.Context`` on Python 3.14+ free-threaded build.
-    (`#1220 <https://github.com/agronholm/anyio/issues/1220>`_; PR by @EmmanuelNiyonshuti)
-  - Fixed ``to_thread.run_sync()``'s worker thread pool on asyncio backend retaining a
-    reference to the calling task's ``contextvars.Context`` for the lifetime of the
-    pooled worker thread on Python 3.14+ free-threaded build.
 
 **4.14.2**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,14 +10,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   As a result:
 
   - Fixed ``start_blocking_portal()`` portal thread inheriting the calling thread's
-    ``contextvars.Context`` on Python 3.14+ free-threaded builds, previously was
-    leading to a ``RuntimeError: Already running <backend> in this thread``
-    raised in ``TestBlockingPortal::test_from_async``.
+    ``contextvars.Context`` on Python 3.14+ free-threaded build.
     (`#1220 <https://github.com/agronholm/anyio/issues/1220>`_; PR by @EmmanuelNiyonshuti)
   - Fixed ``to_thread.run_sync()``'s worker thread pool on asyncio backend retaining a
     reference to the calling task's ``contextvars.Context`` for the lifetime of the
-    pooled worker thread on Python 3.14+ free-threaded builds. Same reason as above.
-    previously was breaking this test ``test_run_sync_worker_cyclic_references``.
+    pooled worker thread on Python 3.14+ free-threaded build.
 
 **4.14.2**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3.15",
+    "Programming Language :: Python :: Free Threading :: 2 - Beta",
 ]
 requires-python = ">= 3.10"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ exclude_also = [
 ]
 
 [tool.tox]
-env_list = ["pre-commit", "py310", "py311", "py312", "py313", "py314", "py315", "pypy3", "only_asyncio"]
+env_list = ["pre-commit", "py310", "py311", "py312", "py313", "py314", "py314t", "py315", "pypy3", "only_asyncio"]
 skip_missing_interpreters = true
 requires = ["tox >= 4.22"]
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -991,7 +991,7 @@ class WorkerThread(Thread):
     ):
         kwargs: dict[str, Any] = {}
         if sys.version_info >= (3, 14):
-            kwargs["context"] = False
+            kwargs["context"] = Context()
 
         super().__init__(name="AnyIO worker thread", **kwargs)
         self.root_task = root_task

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -989,7 +989,7 @@ class WorkerThread(Thread):
     ):
         kwargs: dict[str, Any] = {}
         if sys.version_info >= (3, 14):
-            kwargs["context"] = Context()
+            kwargs["context"] = False
 
         super().__init__(name="AnyIO worker thread", **kwargs)
         self.root_task = root_task

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -987,7 +987,10 @@ class WorkerThread(Thread):
         workers: set[WorkerThread],
         idle_workers: deque[WorkerThread],
     ):
-        super().__init__(name="AnyIO worker thread")
+        kwargs: dict[str, Any] = {}
+        if sys.version_info >= (3, 14):
+            kwargs["context"] = Context()
+        super().__init__(name="AnyIO worker thread", **kwargs)
         self.root_task = root_task
         self.workers = workers
         self.idle_workers = idle_workers

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -990,6 +990,7 @@ class WorkerThread(Thread):
         kwargs: dict[str, Any] = {}
         if sys.version_info >= (3, 14):
             kwargs["context"] = Context()
+
         super().__init__(name="AnyIO worker thread", **kwargs)
         self.root_task = root_task
         self.workers = workers

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -545,6 +545,7 @@ def start_blocking_portal(
     kwargs: dict[str, Any] = {}
     if sys.version_info >= (3, 14):
         kwargs["context"] = Context()
+
     thread = Thread(target=run_blocking_portal, daemon=True, name=name, **kwargs)
     thread.start()
     try:

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -9,7 +9,6 @@ __all__ = (
     "start_blocking_portal",
 )
 
-import contextvars
 import sys
 from collections.abc import Awaitable, Callable, Coroutine, Generator
 from concurrent.futures import Future
@@ -18,6 +17,7 @@ from contextlib import (
     AbstractContextManager,
     contextmanager,
 )
+from contextvars import Context
 from dataclasses import dataclass, field
 from functools import partial
 from inspect import isawaitable
@@ -542,15 +542,10 @@ def start_blocking_portal(
                     future.set_exception(exc)
 
     future: Future[BlockingPortal] = Future()
+    kwargs: dict[str, Any] = {}
     if sys.version_info >= (3, 14):
-        thread = Thread(
-            target=run_blocking_portal,
-            daemon=True,
-            name=name,
-            context=contextvars.Context(),
-        )
-    else:
-        thread = Thread(target=run_blocking_portal, daemon=True, name=name)
+        kwargs["context"] = Context()
+    thread = Thread(target=run_blocking_portal, daemon=True, name=name, **kwargs)
     thread.start()
     try:
         cancel_remaining_tasks = False

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -17,6 +17,7 @@ from contextlib import (
     AbstractContextManager,
     contextmanager,
 )
+from contextvars import Context
 from dataclasses import dataclass, field
 from functools import partial
 from inspect import isawaitable
@@ -543,8 +544,7 @@ def start_blocking_portal(
     future: Future[BlockingPortal] = Future()
     kwargs: dict[str, Any] = {}
     if sys.version_info >= (3, 14):
-        kwargs["context"] = False
-
+        kwargs["context"] = Context()
     thread = Thread(target=run_blocking_portal, daemon=True, name=name, **kwargs)
     thread.start()
     try:

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -9,6 +9,7 @@ __all__ = (
     "start_blocking_portal",
 )
 
+import contextvars
 import sys
 from collections.abc import Awaitable, Callable, Coroutine, Generator
 from concurrent.futures import Future
@@ -541,7 +542,15 @@ def start_blocking_portal(
                     future.set_exception(exc)
 
     future: Future[BlockingPortal] = Future()
-    thread = Thread(target=run_blocking_portal, daemon=True, name=name)
+    if sys.version_info >= (3, 14):
+        thread = Thread(
+            target=run_blocking_portal,
+            daemon=True,
+            name=name,
+            context=contextvars.Context(),
+        )
+    else:
+        thread = Thread(target=run_blocking_portal, daemon=True, name=name)
     thread.start()
     try:
         cancel_remaining_tasks = False

--- a/src/anyio/from_thread.py
+++ b/src/anyio/from_thread.py
@@ -17,7 +17,6 @@ from contextlib import (
     AbstractContextManager,
     contextmanager,
 )
-from contextvars import Context
 from dataclasses import dataclass, field
 from functools import partial
 from inspect import isawaitable
@@ -544,7 +543,8 @@ def start_blocking_portal(
     future: Future[BlockingPortal] = Future()
     kwargs: dict[str, Any] = {}
     if sys.version_info >= (3, 14):
-        kwargs["context"] = Context()
+        kwargs["context"] = False
+
     thread = Thread(target=run_blocking_portal, daemon=True, name=name, **kwargs)
     thread.start()
     try:

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -24,6 +24,7 @@ from anyio import (
 )
 from anyio._core._eventloop import current_async_library
 from anyio.from_thread import BlockingPortalProvider
+from anyio.lowlevel import checkpoint
 
 from .conftest import asyncio_params, no_other_refs
 
@@ -382,6 +383,11 @@ async def test_run_sync_worker_cyclic_references() -> None:
     await to_thread.run_sync(foo, arg)
     cvar.set(Foo())
     gc.collect()
+    # This checkpoint only exist to give the worker thread a moment to finish releasing its own
+    # references before we check. on free threaded python builds, this can
+    # otherwise race and intermittently show a leftover reference.
+    # See: https://github.com/agronholm/anyio/pull/1224
+    await checkpoint()
 
     assert gc.get_referrers(contextval) == no_other_refs()
     assert gc.get_referrers(foo) == no_other_refs()

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -383,10 +383,6 @@ async def test_run_sync_worker_cyclic_references() -> None:
     await to_thread.run_sync(foo, arg)
     cvar.set(Foo())
     gc.collect()
-    # This checkpoint only exist to give the worker thread a moment to finish releasing its own
-    # references before we check. on free threaded python builds, this can
-    # otherwise race and intermittently show a leftover reference.
-    # See: https://github.com/agronholm/anyio/pull/1224
     await checkpoint()
 
     assert gc.get_referrers(contextval) == no_other_refs()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1220

Add `Python 3.14t `to the test matrix so the test suite is also exercised on the free-threaded build. This also fixes the referenced issue as a side effect.
I am leaving 3.15t out of the matrix for now, since the current released test dependencies do not install successfully on that interpreter yet. Specifically, the failure happens while building cryptography against CPython 3.15t.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
