### PR TITLE
fix: use monotonic task IDs instead of object IDs

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,13 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed ``TaskInfo`` objects from separate event loop runs comparing equal due to
+  reused object IDs. Each task is now assigned a process-monotonic ID cached in a
+  ``WeakKeyDictionary``, so ``TaskInfo`` identity is stable and unique per task
+  (`#324 <https://github.com/agronholm/anyio/issues/324>`_; PR by @pctablet505)
+
 **4.14.2**
 
 - Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -893,9 +893,13 @@ class TaskGroup(abc.TaskGroup):
                 )
 
         if task_status_future:
-            parent_id = _get_task_id(current_task())
+            parent = current_task()
+            assert parent is not None
+            parent_id = _get_task_id(parent)
         else:
-            parent_id = _get_task_id(self.cancel_scope._host_task)
+            host_task = self.cancel_scope._host_task
+            assert host_task is not None
+            parent_id = _get_task_id(host_task)
 
         handle = TaskHandle(coro, name)
         loop = asyncio.get_running_loop()
@@ -957,9 +961,9 @@ class TaskGroup(abc.TaskGroup):
 
         future: asyncio.Future = asyncio.Future()
         final_name = get_callable_name(func, name)
-        task_status = _AsyncioTaskStatus(
-            future, _get_task_id(self.cancel_scope._host_task)
-        )
+        host_task = self.cancel_scope._host_task
+        assert host_task is not None
+        task_status = _AsyncioTaskStatus(future, _get_task_id(host_task))
         coro = call_for_coroutine(func, args, task_status=task_status)
         handle = self._spawn(coro, final_name, future)
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -957,7 +957,9 @@ class TaskGroup(abc.TaskGroup):
 
         future: asyncio.Future = asyncio.Future()
         final_name = get_callable_name(func, name)
-        task_status = _AsyncioTaskStatus(future, _get_task_id(self.cancel_scope._host_task))
+        task_status = _AsyncioTaskStatus(
+            future, _get_task_id(self.cancel_scope._host_task)
+        )
         coro = call_for_coroutine(func, args, task_status=task_status)
         handle = self._spawn(coro, final_name, future)
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -4,6 +4,7 @@ import array
 import asyncio
 import concurrent.futures
 import contextvars
+import itertools
 import math
 import os
 import socket
@@ -717,6 +718,17 @@ class TaskState:
 
 
 _task_states: WeakKeyDictionary[asyncio.Task, TaskState] = WeakKeyDictionary()
+_task_id_counter = itertools.count(1)
+_task_ids: WeakKeyDictionary[asyncio.Task, int] = WeakKeyDictionary()
+
+
+def _get_task_id(task: asyncio.Task) -> int:
+    try:
+        return _task_ids[task]
+    except KeyError:
+        task_id = next(_task_id_counter)
+        _task_ids[task] = task_id
+        return task_id
 
 
 #
@@ -881,9 +893,9 @@ class TaskGroup(abc.TaskGroup):
                 )
 
         if task_status_future:
-            parent_id = id(current_task())
+            parent_id = _get_task_id(current_task())
         else:
-            parent_id = id(self.cancel_scope._host_task)
+            parent_id = _get_task_id(self.cancel_scope._host_task)
 
         handle = TaskHandle(coro, name)
         loop = asyncio.get_running_loop()
@@ -945,7 +957,7 @@ class TaskGroup(abc.TaskGroup):
 
         future: asyncio.Future = asyncio.Future()
         final_name = get_callable_name(func, name)
-        task_status = _AsyncioTaskStatus(future, id(self.cancel_scope._host_task))
+        task_status = _AsyncioTaskStatus(future, _get_task_id(self.cancel_scope._host_task))
         coro = call_for_coroutine(func, args, task_status=task_status)
         handle = self._spawn(coro, final_name, future)
 
@@ -2227,7 +2239,7 @@ class AsyncIOTaskInfo(TaskInfo):
 
         coro = task.get_coro()
         assert coro is not None, "created TaskInfo from a completed Task"
-        super().__init__(id(task), parent_id, task.get_name(), coro)
+        super().__init__(_get_task_id(task), parent_id, task.get_name(), coro)
         self._task = weakref.ref(task)
 
     def has_pending_cancellation(self) -> bool:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import array
+import itertools
 import math
 import os
 import socket
@@ -38,6 +39,7 @@ from typing import (
     cast,
     overload,
 )
+from weakref import WeakKeyDictionary
 
 import trio.from_thread
 import trio.lowlevel
@@ -1056,13 +1058,26 @@ class TestRunner(abc.TestRunner):
         self._call_in_runner_task(test_func, **kwargs)
 
 
+_task_id_counter = itertools.count(1)
+_task_ids: WeakKeyDictionary[trio.lowlevel.Task, int] = WeakKeyDictionary()
+
+
+def _get_task_id(task: trio.lowlevel.Task) -> int:
+    try:
+        return _task_ids[task]
+    except KeyError:
+        task_id = next(_task_id_counter)
+        _task_ids[task] = task_id
+        return task_id
+
+
 class TrioTaskInfo(TaskInfo):
     def __init__(self, task: trio.lowlevel.Task):
         parent_id = None
         if task.parent_nursery and task.parent_nursery.parent_task:
-            parent_id = id(task.parent_nursery.parent_task)
+            parent_id = _get_task_id(task.parent_nursery.parent_task)
 
-        super().__init__(id(task), parent_id, task.name, task.coro)
+        super().__init__(_get_task_id(task), parent_id, task.name, task.coro)
         self._task = weakref.proxy(task)
 
     def has_pending_cancellation(self) -> bool:

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -99,6 +99,16 @@ async def test_get_running_tasks() -> None:
         assert repr(task).endswith(f"TaskInfo(id={task.id}, name={expected_name!r})")
 
 
+def test_task_info_ids_unique_across_runs() -> None:
+    async def current_task() -> TaskInfo:
+        return get_current_task()
+
+    t = anyio.run(current_task)
+    u = anyio.run(current_task)
+    assert t != u
+    assert t.id != u.id
+
+
 @pytest.mark.skipif(
     sys.version_info >= (3, 11),
     reason="Generator based coroutines have been removed in Python 3.11",

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import sys
 from collections.abc import AsyncGenerator, Generator
 from types import CoroutineType, GeneratorType
@@ -107,6 +108,32 @@ def test_task_info_ids_unique_across_runs() -> None:
     u = anyio.run(current_task)
     assert t != u
     assert t.id != u.id
+
+
+def test_task_info_ids_not_reused_after_gc() -> None:
+    # Regression test for #324: task IDs used to be derived from id(task), which
+    # CPython can (and does) hand out again once a task object is garbage
+    # collected, causing unrelated tasks to alias the same TaskInfo.id and
+    # compare/hash as equal. Using a WeakKeyDictionary-memoized counter instead
+    # means an id is only ever handed out once, regardless of GC/reuse timing.
+    seen: dict[TaskInfo, list[int]] = {}
+
+    async def leaf(n: int) -> None:
+        seen.setdefault(get_current_task(), []).append(n)
+
+    async def main() -> None:
+        for i in range(40):
+            async with create_task_group() as tg:
+                tg.start_soon(leaf, i)
+
+            gc.collect()
+
+    anyio.run(main)
+
+    # 40 distinct tasks were spawned; each must have gotten its own unique
+    # TaskInfo (and thus its own dict key), never aliasing a prior task's id.
+    assert len(seen) == 40
+    assert all(len(runs) == 1 for runs in seen.values())
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Fixes #324

TaskInfo previously used Python's `id()` of the underlying task object, which is reused by the allocator (especially for the first asyncio.Task in each run). This caused TaskInfo objects from different runs to compare equal and share IDs.

This change assigns each task a monotonic counter-based ID, cached in a WeakKeyDictionary so the same task object always receives the same ID. The parent_id references are updated to use the same IDs.