### PR TITLE
add reason parameter to explain timeouts in fail_after

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -23,6 +23,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   rollover, so the destination buffer was overwritten by the second read and the file
   position advanced twice, silently losing data
   (`#1215 <https://github.com/agronholm/anyio/pull/1215>`_; PR by @c-tonneslan)
+- Added a ``reason`` parameter to ``fail_after`` (and the new ``fail_at``) allowing for
+  added exception context when raising ``TimeoutError``
+  (`#1227 <https://github.com/agronholm/anyio/pull/1227>`_; PR by @Graeme22)
 
 **4.14.2**
 

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -128,7 +128,7 @@ class CancelScope:
 
 @contextmanager
 def fail_after(
-    delay: float | None, shield: bool = False
+    delay: float | None, shield: bool = False, reason: str | None = None
 ) -> Generator[CancelScope, None, None]:
     """
     Create a context manager which raises a :class:`TimeoutError` if does not finish in
@@ -137,6 +137,7 @@ def fail_after(
     :param delay: maximum allowed time (in seconds) before raising the exception, or
         ``None`` to disable the timeout
     :param shield: ``True`` to shield the cancel scope from external cancellation
+    :param reason: explanation for timeout to add to the message of a raised `TimeoutError`
     :return: a context manager that yields a cancel scope
     :rtype: :class:`~typing.ContextManager`\\[:class:`~anyio.CancelScope`\\]
     :raises NoEventLoopError: if no supported asynchronous event loop is running in the
@@ -151,7 +152,7 @@ def fail_after(
         yield cancel_scope
 
     if cancel_scope.cancelled_caught and current_time() >= cancel_scope.deadline:
-        raise TimeoutError
+        raise TimeoutError(reason or "")
 
 
 def move_on_after(delay: float | None, shield: bool = False) -> CancelScope:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -792,6 +792,15 @@ async def test_fail_at_no_timeout() -> None:
     assert not scope.cancelled_caught
 
 
+async def test_fail_at_reason() -> None:
+    with pytest.raises(TimeoutError, match="oopsies"):
+        with fail_at(current_time(), reason="oopsies") as scope:
+            await sleep(1)
+
+    assert scope.cancel_called
+    assert scope.cancelled_caught
+
+
 @pytest.mark.parametrize("delay", [0, 0.1], ids=["instant", "delayed"])
 async def test_move_on_at(delay: float) -> None:
     result = False

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -714,6 +714,15 @@ async def test_fail_after_scope_cancelled_before_timeout() -> None:
         await checkpoint()
 
 
+async def test_fail_after_reason() -> None:
+    with pytest.raises(TimeoutError, match="oopsies"):
+        with fail_after(0, reason="oopsies") as scope:
+            await sleep(1)
+
+    assert scope.cancel_called
+    assert scope.cancelled_caught
+
+
 @pytest.mark.parametrize("delay", [0, 0.1], ids=["instant", "delayed"])
 async def test_move_on_after(delay: float) -> None:
     result = False


### PR DESCRIPTION
## Changes

Adds an optional `reason` parameter to `fail_after`. This allows users to specify context around timeout failures without needing to look at source code.

Motivation: I've often found myself using `move_on_after` where I'd rather use `fail_after` just to be able to add context to the raised `TimeoutError`:

```python
with move_on_after(1) as scope:
    ...
if scope.cancelled_caught:
    raise TimeoutError("Server didn't respond in time!")
```

With this change you can just do:
```python
with fail_after(1, reason="Server didn't respond in time!"):
    ...
```

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
