### PR TITLE
Added the move_on_at() and fail_at() functions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,7 +32,9 @@ Timeouts and cancellation
 -------------------------
 
 .. autofunction:: anyio.move_on_after
+.. autofunction:: anyio.move_on_at
 .. autofunction:: anyio.fail_after
+.. autofunction:: anyio.fail_at
 .. autofunction:: anyio.current_effective_deadline
 
 .. autoclass:: anyio.CancelScope

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,11 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Added the ``move_on_at()`` and ``fail_at()`` functions to complement
+  ``move_on_after()`` and ``fail_after()``
+
 **4.14.2**
 
 - Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -74,7 +74,9 @@ from ._core._tasks import TaskHandle as TaskHandle
 from ._core._tasks import create_task_group as create_task_group
 from ._core._tasks import current_effective_deadline as current_effective_deadline
 from ._core._tasks import fail_after as fail_after
+from ._core._tasks import fail_at as fail_at
 from ._core._tasks import move_on_after as move_on_after
+from ._core._tasks import move_on_at as move_on_at
 from ._core._tempfile import NamedTemporaryFile as NamedTemporaryFile
 from ._core._tempfile import SpooledTemporaryFile as SpooledTemporaryFile
 from ._core._tempfile import TemporaryDirectory as TemporaryDirectory

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -146,7 +146,7 @@ def fail_at(
     current_time = get_async_backend().current_time
     effective_deadline = math.inf if deadline is None else deadline
     with get_async_backend().create_cancel_scope(
-        deadline=effective_deadline or math.inf, shield=shield
+        deadline=effective_deadline, shield=shield
     ) as cancel_scope:
         yield cancel_scope
 

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -6,7 +6,7 @@ from collections.abc import (
     Coroutine,
     Generator,
 )
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from enum import Enum, auto
 from inspect import iscoroutine
 from types import TracebackType
@@ -196,10 +196,9 @@ def move_on_at(deadline: float | None, shield: bool = False) -> CancelScope:
     )
 
 
-@contextmanager
 def move_on_after(
     delay: float | None, shield: bool = False
-) -> Generator[CancelScope, None, None]:
+) -> AbstractContextManager[CancelScope]:
     """
     Create a cancel scope with a deadline that expires after the given delay.
 
@@ -210,14 +209,14 @@ def move_on_after(
     :raises NoEventLoopError: if no supported asynchronous event loop is running in the
         current thread
 
+    .. note:: Unlike with :func:`fail_after`, the timer starts when this function is
+        called, not when the context manager is entered. This will be changed in v5.0.
+
     """
     deadline = (
         (get_async_backend().current_time() + delay) if delay is not None else math.inf
     )
-    with get_async_backend().create_cancel_scope(
-        deadline=deadline, shield=shield
-    ) as scope:
-        yield scope
+    return get_async_backend().create_cancel_scope(deadline=deadline, shield=shield)
 
 
 def current_effective_deadline() -> float:

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -6,7 +6,7 @@ from collections.abc import (
     Coroutine,
     Generator,
 )
-from contextlib import AbstractContextManager, contextmanager
+from contextlib import contextmanager
 from enum import Enum, auto
 from inspect import iscoroutine
 from types import TracebackType
@@ -154,9 +154,10 @@ def fail_at(
         raise TimeoutError
 
 
+@contextmanager
 def fail_after(
     delay: float | None, shield: bool = False
-) -> AbstractContextManager[CancelScope]:
+) -> Generator[CancelScope, None, None]:
     """
     Create a context manager which raises a :class:`TimeoutError` if the code in the
     enclosing context block does not finish in time.
@@ -172,7 +173,8 @@ def fail_after(
     """
     current_time = get_async_backend().current_time
     deadline = (current_time() + delay) if delay is not None else math.inf
-    return fail_at(deadline, shield=shield)
+    with fail_at(deadline, shield=shield) as scope:
+        yield scope
 
 
 def move_on_at(deadline: float | None, shield: bool = False) -> CancelScope:
@@ -194,7 +196,10 @@ def move_on_at(deadline: float | None, shield: bool = False) -> CancelScope:
     )
 
 
-def move_on_after(delay: float | None, shield: bool = False) -> CancelScope:
+@contextmanager
+def move_on_after(
+    delay: float | None, shield: bool = False
+) -> Generator[CancelScope, None, None]:
     """
     Create a cancel scope with a deadline that expires after the given delay.
 
@@ -209,7 +214,10 @@ def move_on_after(delay: float | None, shield: bool = False) -> CancelScope:
     deadline = (
         (get_async_backend().current_time() + delay) if delay is not None else math.inf
     )
-    return get_async_backend().create_cancel_scope(deadline=deadline, shield=shield)
+    with get_async_backend().create_cancel_scope(
+        deadline=deadline, shield=shield
+    ) as scope:
+        yield scope
 
 
 def current_effective_deadline() -> float:

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -6,9 +6,7 @@ from collections.abc import (
     Coroutine,
     Generator,
 )
-from contextlib import (
-    contextmanager,
-)
+from contextlib import AbstractContextManager, contextmanager
 from enum import Enum, auto
 from inspect import iscoroutine
 from types import TracebackType
@@ -127,12 +125,41 @@ class CancelScope:
 
 
 @contextmanager
-def fail_after(
-    delay: float | None, shield: bool = False
+def fail_at(
+    deadline: float | None, shield: bool = False
 ) -> Generator[CancelScope, None, None]:
     """
-    Create a context manager which raises a :class:`TimeoutError` if does not finish in
-    time.
+    Create a context manager which raises a :class:`TimeoutError` if the code in the
+    enclosing context does not finish by the given deadline.
+
+    :param deadline: the deadline before raising the exception, or
+        ``None`` to disable the timeout
+    :param shield: ``True`` to shield the cancel scope from external cancellation
+    :return: a context manager that yields a cancel scope
+    :rtype: :class:`~typing.ContextManager`\\[:class:`~anyio.CancelScope`\\]
+    :raises NoEventLoopError: if no supported asynchronous event loop is running in the
+        current thread
+
+    .. versionadded:: 4.15.0
+
+    """
+    current_time = get_async_backend().current_time
+    effective_deadline = math.inf if deadline is None else deadline
+    with get_async_backend().create_cancel_scope(
+        deadline=effective_deadline or math.inf, shield=shield
+    ) as cancel_scope:
+        yield cancel_scope
+
+    if cancel_scope.cancelled_caught and current_time() >= cancel_scope.deadline:
+        raise TimeoutError
+
+
+def fail_after(
+    delay: float | None, shield: bool = False
+) -> AbstractContextManager[CancelScope]:
+    """
+    Create a context manager which raises a :class:`TimeoutError` if the code in the
+    enclosing context block does not finish in time.
 
     :param delay: maximum allowed time (in seconds) before raising the exception, or
         ``None`` to disable the timeout
@@ -145,13 +172,26 @@ def fail_after(
     """
     current_time = get_async_backend().current_time
     deadline = (current_time() + delay) if delay is not None else math.inf
-    with get_async_backend().create_cancel_scope(
-        deadline=deadline, shield=shield
-    ) as cancel_scope:
-        yield cancel_scope
+    return fail_at(deadline, shield=shield)
 
-    if cancel_scope.cancelled_caught and current_time() >= cancel_scope.deadline:
-        raise TimeoutError
+
+def move_on_at(deadline: float | None, shield: bool = False) -> CancelScope:
+    """
+    Create a cancel scope with a deadline that expires after the given delay.
+
+    :param deadline: the deadline before exiting the context block, or
+        ``None`` to disable the timeout
+    :param shield: ``True`` to shield the cancel scope from external cancellation
+    :return: a cancel scope
+    :raises NoEventLoopError: if no supported asynchronous event loop is running in the
+        current thread
+
+    .. versionadded:: 4.15.0
+
+    """
+    return get_async_backend().create_cancel_scope(
+        deadline=deadline if deadline is not None else math.inf, shield=shield
+    )
 
 
 def move_on_after(delay: float | None, shield: bool = False) -> CancelScope:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -30,9 +30,11 @@ from anyio import (
     current_effective_deadline,
     current_time,
     fail_after,
+    fail_at,
     get_cancelled_exc_class,
     get_current_task,
     move_on_after,
+    move_on_at,
     sleep,
     sleep_forever,
     wait_all_tasks_blocked,
@@ -754,6 +756,54 @@ async def test_nested_move_on_after() -> None:
     assert outer_scope.cancelled_caught
     assert not inner_scope.cancel_called
     assert not inner_scope.cancelled_caught
+
+
+@pytest.mark.parametrize("delay", [0, 0.1], ids=["instant", "delayed"])
+async def test_fail_at(delay: float) -> None:
+    with pytest.raises(TimeoutError):
+        with fail_at(current_time() + delay) as scope:
+            try:
+                await sleep(1)
+            except get_cancelled_exc_class() as exc:
+                assert "deadline" in str(exc)
+                raise
+            else:
+                pytest.fail("sleep() should have raised a cancellation exception")
+
+    assert scope.cancel_called
+    assert scope.cancelled_caught
+
+
+async def test_fail_at_no_timeout() -> None:
+    with fail_at(None) as scope:
+        assert scope.deadline == float("inf")
+        await sleep(0.1)
+
+    assert not scope.cancel_called
+    assert not scope.cancelled_caught
+
+
+@pytest.mark.parametrize("delay", [0, 0.1], ids=["instant", "delayed"])
+async def test_move_on_at(delay: float) -> None:
+    result = False
+    with move_on_at(current_time() + delay) as scope:
+        await sleep(1)
+        result = True
+
+    assert not result
+    assert scope.cancel_called
+    assert scope.cancelled_caught
+
+
+async def test_move_on_at_no_timeout() -> None:
+    result = False
+    with move_on_at(None) as scope:
+        assert scope.deadline == float("inf")
+        await sleep(0.1)
+        result = True
+
+    assert result
+    assert not scope.cancel_called
 
 
 async def test_shielding() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Adds the `move_on_at()` and `fail_at()` function to match Trio and to complement the existing `move_after()` and `fail_after()` functions.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
