### PR TITLE
Fix event loop memory leak from cached root task (#1203)

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **4.14.2**
 
+- Fixed a memory leak on the asyncio backend where every ``anyio.run()`` call that used
+  ``to_thread.run_sync()`` (via ``find_root_task()``) permanently leaked its event loop,
+  root task and result. The root task was cached with a strong reference in the
+  loop-keyed ``_run_vars`` dict, so the loop (the weak key) was kept alive by its own
+  value; the cached task is now held via a weak reference
+  (`#1203 <https://github.com/agronholm/anyio/issues/1203>`_)
 - Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when
   ``max_bytes`` is not a positive integer
   (`#1191 <https://github.com/agronholm/anyio/pull/1191>`_)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -305,13 +305,19 @@ T_contra = TypeVar("T_contra", contravariant=True)
 PosArgsT = TypeVarTuple("PosArgsT")
 P = ParamSpec("P")
 
-_root_task: RunVar[asyncio.Task | None] = RunVar("_root_task")
+# A weak reference is used so that the cached root task does not keep the event
+# loop (which is the weak key of the ``_run_vars`` dict holding this RunVar)
+# alive, which would leak the loop, the root task and its result on every
+# ``anyio.run()`` call (issue #1203).
+_root_task: RunVar[weakref.ref[asyncio.Task] | None] = RunVar("_root_task")
 
 
 def find_root_task() -> asyncio.Task:
-    root_task = _root_task.get(None)
-    if root_task is not None and not root_task.done():
-        return root_task
+    root_task_ref = _root_task.get(None)
+    if root_task_ref is not None:
+        root_task = root_task_ref()
+        if root_task is not None and not root_task.done():
+            return root_task
 
     # Look for a task that has been started via run_until_complete()
     for task in all_tasks():
@@ -322,7 +328,7 @@ def find_root_task() -> asyncio.Task:
                     cb is _run_until_complete_cb
                     or getattr(cb, "__module__", None) == "uvloop.loop"
                 ):
-                    _root_task.set(task)
+                    _root_task.set(weakref.ref(task))
                     return task
 
     # Look up the topmost task in the AnyIO task tree, if possible

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -402,9 +402,7 @@ def test_anyio_run_does_not_leak_event_loop() -> None:
     def live_loops() -> int:
         gc.collect()
         return sum(
-            1
-            for obj in gc.get_objects()
-            if isinstance(obj, asyncio.AbstractEventLoop)
+            1 for obj in gc.get_objects() if isinstance(obj, asyncio.AbstractEventLoop)
         )
 
     before = live_loops()

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -386,3 +386,29 @@ async def test_run_sync_worker_cyclic_references() -> None:
     assert gc.get_referrers(contextval) == no_other_refs()
     assert gc.get_referrers(foo) == no_other_refs()
     assert gc.get_referrers(arg) == no_other_refs()
+
+
+def test_anyio_run_does_not_leak_event_loop() -> None:
+    # Each anyio.run() that uses to_thread.run_sync() (which calls
+    # find_root_task) must not leak its event loop: the root task was cached
+    # strongly in the loop-keyed _run_vars dict, keeping the loop (and its
+    # result) alive forever (issue #1203).
+    import anyio
+
+    async def main() -> int:
+        await to_thread.run_sync(lambda: None)
+        return 42
+
+    def live_loops() -> int:
+        gc.collect()
+        return sum(
+            1
+            for obj in gc.get_objects()
+            if isinstance(obj, asyncio.AbstractEventLoop)
+        )
+
+    before = live_loops()
+    for _ in range(3):
+        assert anyio.run(main) == 42
+
+    assert live_loops() == before


### PR DESCRIPTION
Fixes #1203

### Problem

`find_root_task()` (asyncio backend) caches the root task via
`_root_task.set(task)`. That RunVar lives in the per-loop dict of
`_run_vars`, which is a `WeakKeyDictionary` keyed by the event loop.

Because the cached `Task` holds a strong reference back to its loop, the loop
is kept alive by a value stored under its own weak key — so the weak key never
clears. Every `anyio.run()` that goes through `find_root_task()` (e.g. anything
using `to_thread.run_sync()`) permanently leaks its event loop, root task and
the coroutine's result. In a loop this grows memory without bound and
`gc.collect()` cannot reclaim it.

Reproduction:

```python
import gc, asyncio, anyio
from anyio import to_thread

async def main():
    await to_thread.run_sync(lambda: None)

def loops():
    gc.collect()
    return sum(1 for o in gc.get_objects() if isinstance(o, asyncio.AbstractEventLoop))

before = loops()
for _ in range(5):
    anyio.run(main)
print(loops() - before)   # 5 before this change, 0 after
```

### Fix

Cache a `weakref` to the root task instead of a strong reference, so the
cached value no longer pins the loop. While the loop is running the root task
is alive, so the weakref resolves; once the loop is done, the weakref clears
and everything is collected.

### Verification

- The reproduction above goes from 5 leaked loops to 0.
- Added `test_anyio_run_does_not_leak_event_loop` (uses `clear_cache`-free gc
  check), which fails on `master` and passes with this change.
- Full test suite passes (the only failures on my machine are pre-existing,
  unrelated Windows/`psutil` env issues that also fail on an unmodified tree).
- `ruff` clean; changelog updated.