### PR TITLE
Fix `TaskHandle.name` for `TaskGroup.start` on Trio

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,12 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed the default ``TaskHandle.name`` missing part of the task name for tasks started
+  with ``TaskGroup.start`` on Trio (`#1231
+  <https://github.com/agronholm/anyio/issues/1231>`_; PR by @gschaffner)
+
 **4.14.2**
 
 - Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -297,7 +297,7 @@ class TaskGroup(abc.TaskGroup):
             else:
                 wrapper_task_status.real_task_status = task_status
 
-            handle = TaskHandle(coro, name)
+            handle = TaskHandle(coro, final_name)
             await handle._run_coro()
 
         self._check_active()

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -2344,37 +2344,6 @@ class TestCreateTask:
         async with create_task_group() as tg:
             assert await tg.create_task(taskfunc(), context=ctx) == 42
 
-    async def test_task_name_default(self) -> None:
-        async def taskfunc() -> str | None:
-            return get_current_task().name
-
-        async with create_task_group() as tg:
-            handle = tg.create_task(taskfunc())
-            assert re.match(
-                r"<TaskHandle pending "
-                r"name='tests.test_taskgroups.TestCreateTask.test_task_name_default.<locals>.taskfunc' "
-                r"coro=<coroutine object(.+)>>",
-                repr(handle),
-            )
-            assert await handle == handle.name
-
-        assert (
-            handle.name
-            == "tests.test_taskgroups.TestCreateTask.test_task_name_default.<locals>.taskfunc"
-        )
-
-    async def test_task_name_custom_name(self) -> None:
-        async def taskfunc() -> None:
-            assert get_current_task().name == "custom name"
-
-        async with create_task_group() as tg:
-            handle = tg.create_task(taskfunc(), name="custom name")
-            assert handle.name == "custom name"
-            assert re.match(
-                r"<TaskHandle pending name='custom name' coro=<coroutine object(.+)>>",
-                repr(handle),
-            )
-
     async def test_wait(self) -> None:
         async def taskfunc() -> None:
             raise RuntimeError("dummy error")
@@ -2390,28 +2359,65 @@ class TestCreateTask:
         await handle.wait()
 
 
-async def test_start_name_default() -> None:
-    """
-    This is similar to ``TestCreateTask.test_task_name_default``, but for ``start``
-    instead of ``create_task``.
-    """
-
-    async def taskfunc(*, task_status: TaskStatus[None]) -> str | None:
+@pytest.mark.parametrize("spawner", ["create_task", "start_soon", "start"])
+async def test_task_name_default(spawner: str) -> None:
+    async def taskfunc(
+        *, task_status: TaskStatus[None] = TASK_STATUS_IGNORED
+    ) -> str | None:
         task_status.started()
         return get_current_task().name
 
     async with create_task_group() as tg:
-        handle = await tg.start(taskfunc, return_handle=True)
+        match spawner:
+            case "create_task":
+                handle = tg.create_task(taskfunc())
+            case "start_soon":
+                handle = tg.start_soon(taskfunc)
+            case "start":
+                handle = await tg.start(taskfunc, return_handle=True)
+            case _:
+                raise NotImplementedError()
+
+        assert (
+            await handle
+            == handle.name
+            == "tests.test_taskgroups.test_task_name_default.<locals>.taskfunc"
+        )
         assert re.match(
-            r"<TaskHandle finished name='tests.test_taskgroups.test_start_name_default.<locals>.taskfunc' "
-            r"coro=<coroutine object test_start_name_default.<locals>.taskfunc at 0x[0-9a-fA-F]+>>",
+            r"<TaskHandle finished "
+            r"name='tests.test_taskgroups.test_task_name_default.<locals>.taskfunc' "
+            r"coro=<coroutine object test_task_name_default.<locals>.taskfunc at 0x[0-9a-fA-F]+>>",
             repr(handle),
         )
-        assert await handle == handle.name
 
-    assert (
-        handle.name == "tests.test_taskgroups.test_start_name_default.<locals>.taskfunc"
-    )
+
+@pytest.mark.parametrize("spawner", ["create_task", "start_soon", "start"])
+async def test_task_name_custom_name(spawner: str) -> None:
+    async def taskfunc(
+        *, task_status: TaskStatus[None] = TASK_STATUS_IGNORED
+    ) -> str | None:
+        task_status.started()
+        return get_current_task().name
+
+    async with create_task_group() as tg:
+        match spawner:
+            case "create_task":
+                handle = tg.create_task(taskfunc(), name="custom name")
+            case "start_soon":
+                handle = tg.start_soon(taskfunc, name="custom name")
+            case "start":
+                handle = await tg.start(
+                    taskfunc, return_handle=True, name="custom name"
+                )
+            case _:
+                raise NotImplementedError()
+
+        assert await handle == handle.name == "custom name"
+        assert re.match(
+            r"<TaskHandle finished name='custom name' "
+            r"coro=<coroutine object test_task_name_custom_name.<locals>.taskfunc at 0x[0-9a-fA-F]+>>",
+            repr(handle),
+        )
 
 
 @pytest.mark.parametrize("create_task", [False, True])

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -2376,7 +2376,7 @@ async def test_task_name_default(spawner: str) -> None:
             case "start":
                 handle = await tg.start(taskfunc, return_handle=True)
             case _:
-                raise NotImplementedError()
+                raise ValueError
 
         assert (
             await handle
@@ -2410,7 +2410,7 @@ async def test_task_name_custom_name(spawner: str) -> None:
                     taskfunc, return_handle=True, name="custom name"
                 )
             case _:
-                raise NotImplementedError()
+                raise ValueError
 
         assert await handle == handle.name == "custom name"
         assert re.match(

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -2319,6 +2319,30 @@ class TestCreateTask:
         await handle.wait()
 
 
+async def test_start_name_default() -> None:
+    """
+    This is similar to ``TestCreateTask.test_task_name_default``, but for ``start``
+    instead of ``create_task``.
+    """
+
+    async def taskfunc(*, task_status: TaskStatus[None]) -> str | None:
+        task_status.started()
+        return get_current_task().name
+
+    async with create_task_group() as tg:
+        handle = await tg.start(taskfunc, return_handle=True)
+        assert re.match(
+            r"<TaskHandle finished name='tests.test_taskgroups.test_start_name_default.<locals>.taskfunc' "
+            r"coro=<coroutine object test_start_name_default.<locals>.taskfunc at 0x[0-9a-fA-F]+>>",
+            repr(handle),
+        )
+        assert await handle == handle.name
+
+    assert (
+        handle.name == "tests.test_taskgroups.test_start_name_default.<locals>.taskfunc"
+    )
+
+
 @pytest.mark.parametrize("create_task", [False, True])
 async def test_task_from_asyncgen_asend(create_task: bool) -> None:
     async def genfunc(x: int, y: int) -> AsyncGenerator[int, None]:


### PR DESCRIPTION
## Changes

Fixes #1231.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.