### PR TITLE
Fix the default TaskHandle name for start() on Trio

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,13 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed the default ``TaskHandle.name`` of a task started with ``TaskGroup.start()`` on
+  Trio being taken from the internal wrapper coroutine, so it lacked the module
+  qualifier and disagreed with the task's own name
+  (`#1231 <https://github.com/agronholm/anyio/issues/1231>`_)
+
 **4.14.2**
 
 - Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -286,6 +286,11 @@ class TaskGroup(abc.TaskGroup):
     ) -> Any:
         handle: TaskHandle[T_co]
 
+        # Derived from func, not from the wrapper coroutine the handle is built
+        # around, so that TaskHandle.name matches the task's own name (and the
+        # asyncio backend, which spawns with this same name).
+        final_name = get_callable_name(func, name)
+
         async def run_coro_with_task_status(
             *, task_status: trio.TaskStatus[Any]
         ) -> None:
@@ -297,11 +302,10 @@ class TaskGroup(abc.TaskGroup):
             else:
                 wrapper_task_status.real_task_status = task_status
 
-            handle = TaskHandle(coro, name)
+            handle = TaskHandle(coro, final_name)
             await handle._run_coro()
 
         self._check_active()
-        final_name = get_callable_name(func, name)
         start_value = await self._nursery.start(
             run_coro_with_task_status, name=final_name
         )

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1827,6 +1827,42 @@ async def test_start_return_handle_cancel() -> None:
         assert handle.start_value == 3
 
 
+async def test_start_name_default() -> None:
+    """Like ``TestCreateTask.test_task_name_default``, but for ``start()``.
+
+    The handle used to be named after the wrapper coroutine on Trio, which
+    dropped the module qualifier and disagreed with the task's own name.
+    """
+
+    async def taskfunc(*, task_status: TaskStatus[None]) -> str | None:
+        task_status.started()
+        return get_current_task().name
+
+    expected = f"{__name__}.test_start_name_default.<locals>.taskfunc"
+    async with create_task_group() as tg:
+        handle = await tg.start(taskfunc, return_handle=True)
+        assert re.match(
+            rf"<TaskHandle (pending|finished) name='{re.escape(expected)}' "
+            r"coro=<coroutine object(.+)>>",
+            repr(handle),
+        )
+        assert await handle == handle.name
+
+    assert handle.name == expected
+
+
+async def test_start_name_custom_name() -> None:
+    async def taskfunc(*, task_status: TaskStatus[None]) -> str | None:
+        task_status.started()
+        return get_current_task().name
+
+    async with create_task_group() as tg:
+        handle = await tg.start(taskfunc, name="custom name", return_handle=True)
+        assert await handle == "custom name"
+
+    assert handle.name == "custom name"
+
+
 @pytest.mark.skipif(
     sys.implementation.name == "pypy",
     reason=(


### PR DESCRIPTION
## Summary

Fixes #1231. On Trio, the default `TaskHandle.name` for a task started with `TaskGroup.start()` was missing the module qualifier and disagreed with the task's own `TaskInfo.name`.

`TaskGroup.start()` in the Trio backend computes `final_name = get_callable_name(func, name)` for the nursery, but builds the handle from the **raw** `name` argument, which is `None` by default:

```python
handle = TaskHandle(coro, name)          # raw name -> derived from the wrapper coro
...
final_name = get_callable_name(func, name)
start_value = await self._nursery.start(run_coro_with_task_status, name=final_name)
```

Since `coro` there is the internal `call_for_coroutine(...)` wrapper rather than `func`, the handle ended up named after the wrapper. The asyncio backend already spawns the handle with `final_name`, so the two disagreed:

| backend | `TaskHandle.name` | `TaskInfo.name` | match |
| --- | --- | --- | --- |
| asyncio | `'__main__.taskfunc'` | `'__main__.taskfunc'` | ✅ |
| trio (before) | `'taskfunc'` | `'__main__.taskfunc'` | ❌ |
| trio (after) | `'__main__.taskfunc'` | `'__main__.taskfunc'` | ✅ |

## Change

Compute `final_name` before the nested runner and build the handle from it, matching what the nursery is told and what asyncio already does. An explicit `name=` argument was already honoured and is unaffected — `get_callable_name(func, name)` returns it unchanged.

## Tests

`test_start_name_default` mirrors the existing `TestCreateTask.test_task_name_default`, but for `start()`: it checks `repr(handle)`, that the handle's name equals the name the task sees, and the final name after the group exits. Added `test_start_name_custom_name` alongside it, since the fix touches the same path and the explicit-name case should stay pinned.

The expected name is built from `__name__` rather than hardcoding `tests.test_taskgroups`, so it doesn't break if the module moves.

Reverting only `src/` fails **precisely one parametrization** — which is the right shape for a Trio-only bug:

```
FAILED tests/test_taskgroups.py::test_start_name_default[trio]
1 failed, 5 passed
```

## Verification

- `pytest tests/test_taskgroups.py` → **368 passed, 139 skipped, 3 xfailed** (the skips are `winloop not available` on Windows)
- `ruff check src tests` → all checks passed; `ruff format --check` → 73 files already formatted
- Added an `**UNRELEASED**` section to `docs/versionhistory.rst`, since 4.14.2 is now tagged and the previous unreleased header was renamed at that release
