### PR TITLE
Include the module name in `create_task` task names in more situations

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,15 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Changed the default name for a task spawned with ``TaskGroup.create_task(func())`` to
+  match the default task name for the analogous task spawned with
+  ``TaskGroup.start_soon(func)`` or ``TaskGroup.start(func)`` in more situations.
+  Previously, the default name of a ``TaskGroup.create_task`` task never included the
+  module name. (The default name for a task spawned with ``TaskGroup.start_soon`` or
+  ``TaskGroup.start`` typically includes the module name.) (PR by @gschaffner)
+
 **4.14.2**
 
 - Changed ``ByteReceiveStream.receive()`` implementations to raise a ``ValueError`` when

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -101,7 +101,7 @@ from ..abc import (
     UNIXDatagramPacketType,
 )
 from ..abc._eventloop import StrOrBytesPath
-from ..abc._tasks import call_for_coroutine, get_callable_name
+from ..abc._tasks import call_for_coroutine, get_callable_name, get_coro_name
 from ..lowlevel import RunVar
 from ..streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
@@ -926,10 +926,12 @@ class TaskGroup(abc.TaskGroup):
                 "This task group is not active; no new tasks can be started."
             )
 
+        final_name = get_coro_name(coro, name)
+
         if context is not None:
-            return context.run(self._spawn, coro, name=name)
+            return context.run(self._spawn, coro, name=final_name)
         else:
-            return self._spawn(coro, name=name)
+            return self._spawn(coro, name=final_name)
 
     async def start(
         self,

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -84,7 +84,7 @@ from .._core._tasks import CancelScope as BaseCancelScope
 from .._core._tasks import TaskHandle
 from ..abc import IPSockAddrType, UDPPacketType, UNIXDatagramPacketType
 from ..abc._eventloop import AsyncBackend, StrOrBytesPath
-from ..abc._tasks import T_contra, call_for_coroutine, get_callable_name
+from ..abc._tasks import T_contra, call_for_coroutine, get_callable_name, get_coro_name
 from ..streams.memory import MemoryObjectSendStream
 
 if TYPE_CHECKING:
@@ -267,7 +267,8 @@ class TaskGroup(abc.TaskGroup):
             raise TypeError(f"expected a coroutine, got {coro.__class__.__qualname__}")
 
         self._check_active(coro)
-        handle = TaskHandle(coro, name)
+        final_name = get_coro_name(coro, name)
+        handle = TaskHandle(coro, final_name)
         if context is not None:
             context.run(
                 partial(self._nursery.start_soon, handle._run_coro, name=handle.name)

--- a/src/anyio/abc/_tasks.py
+++ b/src/anyio/abc/_tasks.py
@@ -25,6 +25,20 @@ T_contra = TypeVar("T_contra", contravariant=True, default=None)
 PosArgsT = TypeVarTuple("PosArgsT")
 
 
+def get_coro_name(coro: Coroutine[Any, Any, object], override: object = None) -> str:
+    if override is not None:
+        return str(override)
+
+    try:
+        cr_frame = coro.cr_frame  # type: ignore[attr-defined]
+        module = cr_frame.f_globals["__name__"]
+    except (AttributeError, KeyError):
+        module = None
+
+    qualname = getattr(coro, "__qualname__", None)
+    return ".".join([x for x in (module, qualname) if x])
+
+
 def get_callable_name(func: Callable, override: object = None) -> str:
     if override is not None:
         return str(override)

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -2145,14 +2145,14 @@ class TestCreateTask:
 
             assert re.match(
                 r"<TaskHandle pending "
-                r"name='TestCreateTask.test_return_value.<locals>.taskfunc' "
+                r"name='tests.test_taskgroups.TestCreateTask.test_return_value.<locals>.taskfunc' "
                 r"coro=<coroutine object(.+)>>",
                 repr(handle),
             )
             assert await handle == 6
             assert re.match(
                 r"<TaskHandle finished "
-                r"name='TestCreateTask.test_return_value.<locals>.taskfunc' "
+                r"name='tests.test_taskgroups.TestCreateTask.test_return_value.<locals>.taskfunc' "
                 r"coro=<coroutine object(.+)>>",
                 repr(handle),
             )
@@ -2179,7 +2179,7 @@ class TestCreateTask:
 
         assert re.match(
             r"<TaskHandle failed "
-            r"name='TestCreateTask.test_exception.<locals>.taskfunc' "
+            r"name='tests.test_taskgroups.TestCreateTask.test_exception.<locals>.taskfunc' "
             r"coro=<coroutine object(.+)>",
             repr(handle),
         )
@@ -2202,7 +2202,7 @@ class TestCreateTask:
                 assert handle.status is TaskHandle.Status.FAILED
                 assert re.match(
                     r"<TaskHandle failed "
-                    r"name='TestCreateTask.test_base_exception.<locals>.taskfunc' "
+                    r"name='tests.test_taskgroups.TestCreateTask.test_base_exception.<locals>.taskfunc' "
                     r"coro=<coroutine object(.+)>",
                     repr(handle),
                 )
@@ -2237,7 +2237,7 @@ class TestCreateTask:
             assert handle.status is TaskHandle.Status.CANCELLING
             assert re.match(
                 r"<TaskHandle cancelling "
-                r"name='TestCreateTask.test_cancel.<locals>.taskfunc' "
+                r"name='tests.test_taskgroups.TestCreateTask.test_cancel.<locals>.taskfunc' "
                 r"coro=<coroutine object(.+)>>",
                 repr(handle),
             )
@@ -2259,7 +2259,7 @@ class TestCreateTask:
         assert task_started
         assert re.match(
             r"<TaskHandle cancelled "
-            r"name='TestCreateTask.test_cancel.<locals>.taskfunc' "
+            r"name='tests.test_taskgroups.TestCreateTask.test_cancel.<locals>.taskfunc' "
             r"coro=<coroutine object(.+)>>",
             repr(handle),
         )
@@ -2284,13 +2284,16 @@ class TestCreateTask:
             handle = tg.create_task(taskfunc())
             assert re.match(
                 r"<TaskHandle pending "
-                r"name='TestCreateTask.test_task_name_default.<locals>.taskfunc' "
+                r"name='tests.test_taskgroups.TestCreateTask.test_task_name_default.<locals>.taskfunc' "
                 r"coro=<coroutine object(.+)>>",
                 repr(handle),
             )
             assert await handle == handle.name
 
-        assert handle.name == "TestCreateTask.test_task_name_default.<locals>.taskfunc"
+        assert (
+            handle.name
+            == "tests.test_taskgroups.TestCreateTask.test_task_name_default.<locals>.taskfunc"
+        )
 
     async def test_task_name_custom_name(self) -> None:
         async def taskfunc() -> None:
@@ -2326,11 +2329,7 @@ async def test_task_from_asyncgen_asend(create_task: bool) -> None:
 
     async with create_task_group() as tg:
         async with aclosing(genfunc(3, 5)) as g:
-            if create_task:
-                handle = tg.create_task(g.asend(None))
-                assert handle.name.startswith("<async_generator_asend object at ")
-            else:
-                handle = tg.start_soon(g.asend, None)
-                assert handle.name == "async_generator.asend"
+            handle = tg.start_soon(g.asend, None)
+            assert handle.name == "async_generator.asend"
 
             assert await handle == 8


### PR DESCRIPTION
## Changes

This is an idea/proposal for how we could make `TaskGroup.create_task(func())`

*   give default task names that are more accurate (i.e. better for debugging).

*   give default task names that (typically) match the default task name for the analogous `TaskGroup.start_soon(func)`/`TaskGroup.start(func)` task.

The main problem that I know of is that this would technically be a backward-incompatible change.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.