### PR TITLE
Added `StapledObjectStream.send_nowait` method

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added ``StapledObjectStream.send_nowait()`` that delegates to the underlying
   ``ObjectSendStream``, if it implements it
+  (`#1241 <https://github.com/agronholm/anyio/pull/1241>`_; PR by @davidbrochart)
 - Added the ``move_on_at()`` and ``fail_at()`` functions to complement
   ``move_on_after()`` and ``fail_after()``
 - Changed the default name for a task spawned with ``TaskGroup.create_task(func())`` to

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added ``StapledObjectStream.send_nowait()`` that delegates to the underlying
+  ``ObjectSendStream``, if it implements it
 - Added the ``move_on_at()`` and ``fail_at()`` functions to complement
   ``move_on_after()`` and ``fail_after()``
 - Changed the default name for a task spawned with ``TaskGroup.create_task(func())`` to

--- a/src/anyio/streams/stapled.py
+++ b/src/anyio/streams/stapled.py
@@ -85,6 +85,9 @@ class StapledObjectStream(Generic[T_Item], ObjectStream[T_Item]):
     async def send(self, item: T_Item) -> None:
         await self.send_stream.send(item)
 
+    def send_nowait(self, item: T_Item) -> None:
+        self.send_stream.send_nowait(item)  # type: ignore[attr-defined]
+
     async def send_eof(self) -> None:
         await self.send_stream.aclose()
 

--- a/src/anyio/streams/stapled.py
+++ b/src/anyio/streams/stapled.py
@@ -86,7 +86,12 @@ class StapledObjectStream(Generic[T_Item], ObjectStream[T_Item]):
         await self.send_stream.send(item)
 
     def send_nowait(self, item: T_Item) -> None:
-        self.send_stream.send_nowait(item)  # type: ignore[attr-defined]
+        try:
+            self.send_stream.send_nowait(item)  # type: ignore[attr-defined]
+        except AttributeError as exc:
+            raise NotImplementedError(
+                f"'send_nowait' method not implemented in {type(self.send_stream)}"
+            ) from exc
 
     async def send_eof(self) -> None:
         await self.send_stream.aclose()

--- a/tests/streams/test_stapled.py
+++ b/tests/streams/test_stapled.py
@@ -138,6 +138,12 @@ class DummyObjectSendStream(ObjectSendStream[T_Item]):
 
         self.buffer.append(item)
 
+    def send_nowait(self, item: T_Item) -> None:
+        if self._closed:
+            raise ClosedResourceError
+
+        self.buffer.append(item)
+
     async def aclose(self) -> None:
         self._closed = True
 
@@ -171,6 +177,12 @@ class TestStapledObjectStream:
         await stapled.send("today?")
         assert stapled.send_stream is send_stream
         assert send_stream.buffer == ["how are you ", "today?"]
+
+    def test_send_nowait(
+        self, stapled: StapledObjectStream[str], send_stream: DummyObjectSendStream[str]
+    ) -> None:
+        stapled.send_nowait("hello")
+        assert send_stream.buffer == ["hello"]
 
     async def test_send_eof(self, stapled: StapledObjectStream[str]) -> None:
         await stapled.send_eof()

--- a/tests/streams/test_stapled.py
+++ b/tests/streams/test_stapled.py
@@ -205,7 +205,8 @@ class TestStapledObjectStream:
     ) -> None:
         with pytest.raises(
             NotImplementedError,
-            match="'send_nowait' method not implemented in <class 'tests.streams.test_stapled.DummyObjectSendStream'>",
+            match="'send_nowait' method not implemented in "
+                  "<class 'tests.streams.test_stapled.DummyObjectSendStream'>",
         ):
             stapled.send_nowait("hello")
 

--- a/tests/streams/test_stapled.py
+++ b/tests/streams/test_stapled.py
@@ -138,14 +138,16 @@ class DummyObjectSendStream(ObjectSendStream[T_Item]):
 
         self.buffer.append(item)
 
+    async def aclose(self) -> None:
+        self._closed = True
+
+
+class DummyObjectSendStreamWithSendNowait(DummyObjectSendStream[T_Item]):
     def send_nowait(self, item: T_Item) -> None:
         if self._closed:
             raise ClosedResourceError
 
         self.buffer.append(item)
-
-    async def aclose(self) -> None:
-        self._closed = True
 
 
 class TestStapledObjectStream:
@@ -158,12 +160,24 @@ class TestStapledObjectStream:
         return DummyObjectSendStream[str]()
 
     @pytest.fixture
+    def send_stream_with_send_nowait(self) -> DummyObjectSendStreamWithSendNowait[str]:
+        return DummyObjectSendStreamWithSendNowait[str]()
+
+    @pytest.fixture
     def stapled(
         self,
         receive_stream: DummyObjectReceiveStream[str],
         send_stream: DummyObjectSendStream[str],
     ) -> StapledObjectStream[str]:
         return StapledObjectStream(send_stream, receive_stream)
+
+    @pytest.fixture
+    def stapled_with_send_nowait(
+        self,
+        receive_stream: DummyObjectReceiveStream[str],
+        send_stream_with_send_nowait: DummyObjectSendStreamWithSendNowait[str],
+    ) -> StapledObjectStream[str]:
+        return StapledObjectStream(send_stream_with_send_nowait, receive_stream)
 
     async def test_receive_send(
         self, stapled: StapledObjectStream[str], send_stream: DummyObjectSendStream[str]
@@ -178,11 +192,22 @@ class TestStapledObjectStream:
         assert stapled.send_stream is send_stream
         assert send_stream.buffer == ["how are you ", "today?"]
 
-    def test_send_nowait(
+    def test_send_nowait_implemented(
+        self,
+        stapled_with_send_nowait: StapledObjectStream[str],
+        send_stream_with_send_nowait: DummyObjectSendStream[str],
+    ) -> None:
+        stapled_with_send_nowait.send_nowait("hello")
+        assert send_stream_with_send_nowait.buffer == ["hello"]
+
+    def test_send_nowait_not_implemented(
         self, stapled: StapledObjectStream[str], send_stream: DummyObjectSendStream[str]
     ) -> None:
-        stapled.send_nowait("hello")
-        assert send_stream.buffer == ["hello"]
+        with pytest.raises(
+            NotImplementedError,
+            match="'send_nowait' method not implemented in <class 'tests.streams.test_stapled.DummyObjectSendStream'>",
+        ):
+            stapled.send_nowait("hello")
 
     async def test_send_eof(self, stapled: StapledObjectStream[str]) -> None:
         await stapled.send_eof()

--- a/tests/streams/test_stapled.py
+++ b/tests/streams/test_stapled.py
@@ -206,7 +206,7 @@ class TestStapledObjectStream:
         with pytest.raises(
             NotImplementedError,
             match="'send_nowait' method not implemented in "
-                  "<class 'tests.streams.test_stapled.DummyObjectSendStream'>",
+            "<class 'tests.streams.test_stapled.DummyObjectSendStream'>",
         ):
             stapled.send_nowait("hello")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

This PR adds the `send_nowait` method to `StapledObjectStream`, delegating to the underlying send stream's `send_nowait` if it implements it.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
