### PR TITLE
Fix asyncio UDP transport error delivery

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -39,6 +39,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``Path(".txt")``) instead of raising ``ValueError`` when given an empty stem on a
   path with a non-empty suffix, unlike :meth:`pathlib.PurePath.with_stem`
   (`#1200 <https://github.com/agronholm/anyio/pull/1200>`_; PR by @Sanjays2402)
+- Fixed UDP receives on the asyncio backend failing to wake up when the transport
+  reports an error, and preserved the transport error as the cause of the resulting
+  ``BrokenResourceError``
+  (`#1239 <https://github.com/agronholm/anyio/issues/1239>`_; PR by @deepakganesh78)
 
 **4.14.2**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -40,8 +40,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   path with a non-empty suffix, unlike :meth:`pathlib.PurePath.with_stem`
   (`#1200 <https://github.com/agronholm/anyio/pull/1200>`_; PR by @Sanjays2402)
 - Fixed UDP receives on the asyncio backend failing to wake up when the transport
-  reports an error, and preserved the transport error as the cause of the resulting
-  ``BrokenResourceError``
+  reports an error, preserved the transport error as the cause of the resulting
+  ``BrokenResourceError``, and kept the Windows Proactor receive loop running after
+  nonfatal errors
   (`#1239 <https://github.com/agronholm/anyio/issues/1239>`_; PR by @deepakganesh78)
 
 **4.14.2**

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1286,7 +1286,7 @@ class StreamProtocol(asyncio.Protocol):
 
 
 class DatagramProtocol(asyncio.DatagramProtocol):
-    read_queue: deque[tuple[bytes, IPSockAddrType]]
+    read_queue: deque[tuple[bytes, IPSockAddrType] | Exception]
     read_event: asyncio.Event
     write_event: asyncio.Event
     closed_event: asyncio.Event
@@ -1311,6 +1311,8 @@ class DatagramProtocol(asyncio.DatagramProtocol):
 
     def error_received(self, exc: Exception) -> None:
         self.exception = exc
+        self.read_queue.append(exc)
+        self.read_event.set()
 
     def pause_writing(self) -> None:
         self.write_event.clear()
@@ -1700,12 +1702,17 @@ class UDPSocket(abc.UDPSocket):
                 await self._protocol.read_event.wait()
 
             try:
-                return self._protocol.read_queue.popleft()
+                packet = self._protocol.read_queue.popleft()
             except IndexError:
                 if self._closed:
                     raise ClosedResourceError from None
                 else:
                     raise BrokenResourceError from None
+
+            if isinstance(packet, Exception):
+                raise BrokenResourceError from packet
+
+            return packet
 
     async def send(self, item: UDPPacketType) -> None:
         with self._send_guard:
@@ -1756,6 +1763,9 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
                     raise ClosedResourceError from None
                 else:
                     raise BrokenResourceError from None
+
+            if isinstance(packet, Exception):
+                raise BrokenResourceError from packet
 
             return packet[0]
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1321,6 +1321,19 @@ class DatagramProtocol(asyncio.DatagramProtocol):
         self.write_event.set()
 
 
+def _rearm_proactor_udp_transport(transport: asyncio.DatagramTransport) -> None:
+    # CPython's Proactor transport leaves _read_fut unset after a receive error.
+    transport_type = type(transport)
+    if (
+        sys.platform == "win32"
+        and transport_type.__module__ == "asyncio.proactor_events"
+        and transport_type.__name__ == "_ProactorDatagramTransport"
+        and not transport.is_closing()
+        and getattr(transport, "_read_fut", None) is None
+    ):
+        cast(Any, transport)._loop_reading()
+
+
 class SocketStream(abc.SocketStream):
     def __init__(self, transport: asyncio.Transport, protocol: StreamProtocol):
         self._transport = transport
@@ -1710,6 +1723,7 @@ class UDPSocket(abc.UDPSocket):
                     raise BrokenResourceError from None
 
             if isinstance(packet, Exception):
+                _rearm_proactor_udp_transport(self._transport)
                 raise BrokenResourceError from packet
 
             return packet
@@ -1765,6 +1779,7 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
                     raise BrokenResourceError from None
 
             if isinstance(packet, Exception):
+                _rearm_proactor_udp_transport(self._transport)
                 raise BrokenResourceError from packet
 
             return packet[0]

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1710,6 +1710,31 @@ async def test_multi_listener(tmp_path_factory: TempPathFactory) -> None:
 @pytest.mark.network
 @pytest.mark.usefixtures("check_asyncio_bug")
 class TestUDPSocket:
+    async def test_receive_transport_error(self, anyio_backend_name: str) -> None:
+        if anyio_backend_name != "asyncio":
+            pytest.skip("asyncio-specific transport behavior")
+
+        async with await create_udp_socket(
+            family=AddressFamily.AF_INET, local_host="127.0.0.1"
+        ) as udp:
+            protocol = cast(Any, udp)._protocol
+            transport_error = ConnectionResetError("ICMP port unreachable")
+
+            async def report_error() -> None:
+                await wait_all_tasks_blocked()
+                protocol.error_received(transport_error)
+
+            async with create_task_group() as task_group:
+                task_group.start_soon(report_error)
+                with pytest.raises(BrokenResourceError) as exc_info:
+                    await udp.receive()
+
+            assert exc_info.value.__cause__ is transport_error
+
+            host, port = cast(tuple[str, int], udp.extra(SocketAttribute.local_address))
+            await udp.sendto(b"still usable", host, port)
+            assert await udp.receive() == (b"still usable", (host, port))
+
     async def test_aclose_waits_for_fd_release(
         self, family: AnyIPAddressFamily, free_udp_port: int
     ) -> None:
@@ -1891,6 +1916,42 @@ class TestUDPSocket:
 @pytest.mark.network
 @pytest.mark.usefixtures("check_asyncio_bug")
 class TestConnectedUDPSocket:
+    async def test_receive_transport_error(self, anyio_backend_name: str) -> None:
+        if anyio_backend_name != "asyncio":
+            pytest.skip("asyncio-specific transport behavior")
+
+        async with await create_udp_socket(
+            family=AddressFamily.AF_INET, local_host="127.0.0.1"
+        ) as peer:
+            peer_host, peer_port = cast(
+                tuple[str, int], peer.extra(SocketAttribute.local_address)
+            )
+            async with await create_connected_udp_socket(
+                peer_host,
+                peer_port,
+                family=AddressFamily.AF_INET,
+                local_host="127.0.0.1",
+            ) as udp:
+                protocol = cast(Any, udp)._protocol
+                transport_error = ConnectionResetError("ICMP port unreachable")
+
+                async def report_error() -> None:
+                    await wait_all_tasks_blocked()
+                    protocol.error_received(transport_error)
+
+                async with create_task_group() as task_group:
+                    task_group.start_soon(report_error)
+                    with pytest.raises(BrokenResourceError) as exc_info:
+                        await udp.receive()
+
+                assert exc_info.value.__cause__ is transport_error
+
+                host, port = cast(
+                    tuple[str, int], udp.extra(SocketAttribute.local_address)
+                )
+                await peer.sendto(b"still usable", host, port)
+                assert await udp.receive() == b"still usable"
+
     async def test_aclose_waits_for_fd_release(
         self, family: AnyIPAddressFamily, free_udp_port: int
     ) -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1952,6 +1952,51 @@ class TestConnectedUDPSocket:
                 await peer.sendto(b"still usable", host, port)
                 assert await udp.receive() == b"still usable"
 
+    @pytest.mark.skipif(
+        sys.platform != "win32", reason="requires the Windows Proactor event loop"
+    )
+    async def test_receive_icmp_error_rearms_transport(
+        self, anyio_backend_name: str
+    ) -> None:
+        if anyio_backend_name != "asyncio":
+            pytest.skip("asyncio-specific transport behavior")
+
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            peer_host, peer_port = cast(tuple[str, int], probe.getsockname())
+
+        async with await create_connected_udp_socket(
+            peer_host,
+            peer_port,
+            family=AddressFamily.AF_INET,
+            local_host="127.0.0.1",
+        ) as udp:
+            transport = cast(Any, udp)._transport
+            transport_type = type(transport)
+            if (
+                transport_type.__module__ != "asyncio.proactor_events"
+                or transport_type.__name__ != "_ProactorDatagramTransport"
+            ):
+                pytest.skip("requires the CPython Proactor datagram transport")
+
+            await udp.send(b"trigger ICMP port unreachable")
+            with fail_after(5):
+                with pytest.raises(BrokenResourceError) as exc_info:
+                    await udp.receive()
+
+            assert isinstance(exc_info.value.__cause__, OSError)
+
+            peer_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            peer_socket.bind((peer_host, peer_port))
+            peer_socket.setblocking(False)
+            async with await UDPSocket.from_socket(peer_socket) as peer:
+                host, port = cast(
+                    tuple[str, int], udp.extra(SocketAttribute.local_address)
+                )
+                await peer.sendto(b"still usable", host, port)
+                with fail_after(5):
+                    assert await udp.receive() == b"still usable"
+
     async def test_aclose_waits_for_fd_release(
         self, family: AnyIPAddressFamily, free_udp_port: int
     ) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Addresses #1239.

Queue errors reported by asyncio datagram transports alongside received packets. This wakes blocked UDP receivers, preserves the original transport exception as the `BrokenResourceError` cause, and allows later datagrams to be received from the same socket. The queue also preserves callback ordering when an error and packet arrive before the receiver resumes.

Regression coverage exercises both unconnected and connected UDP sockets and verifies that each socket remains usable after the error.

Validation:
- `python -m pytest tests/test_sockets.py::TestUDPSocket::test_receive_transport_error tests/test_sockets.py::TestConnectedUDPSocket::test_receive_transport_error -q` (8 passed, 12 skipped by the existing backend/platform matrix)
- python -m pytest tests/test_sockets.py::TestUDPSocket tests/test_sockets.py::TestConnectedUDPSocket -q (116 passed, 194 skipped by the existing backend/platform matrix)
- `SKIP=mypy pre-commit run --files src/anyio/_backends/_asyncio.py tests/test_sockets.py docs/versionhistory.rst` (passed)
- The unskipped mypy hook was also attempted; it reports 69 existing Windows platform/type-stub errors in unrelated lines and files.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features (no API documentation change is needed)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.