### PR TITLE
Fix UDP socket close hangs on Windows

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -17,6 +17,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   module name. (The default name for a task spawned with ``TaskGroup.start_soon`` or
   ``TaskGroup.start`` typically includes the module name.)
   (`#1234 <https://github.com/agronholm/anyio/pull/1234>`_; PR by @gschaffner)
+- Fixed UDP socket closing hanging on Windows if a datagram send was still in flight
+  (`#1237 <https://github.com/agronholm/anyio/issues/1237>`_; PR by @Guflly)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,
   causing AnyIO to behave erroneously in relation to ``start_blocking_portal()`` and

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1403,8 +1403,11 @@ class SocketStream(abc.SocketStream):
                 pass
 
             self._transport.close()
-            await sleep(0)
-            self._transport.abort()
+            try:
+                await sleep(0)
+            finally:
+                self._transport.abort()
+                await AsyncIOBackend.cancel_shielded_checkpoint()
 
 
 class _RawSocketMixin:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1687,8 +1687,11 @@ class UDPSocket(abc.UDPSocket):
         self._closed = True
         if not self._transport.is_closing():
             self._transport.close()
-            await sleep(0)
-            self._transport.abort()
+            try:
+                await sleep(0)
+            finally:
+                self._transport.abort()
+                await AsyncIOBackend.cancel_shielded_checkpoint()
 
         await self._protocol.closed_event.wait()
 
@@ -1739,8 +1742,11 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
         self._closed = True
         if not self._transport.is_closing():
             self._transport.close()
-            await sleep(0)
-            self._transport.abort()
+            try:
+                await sleep(0)
+            finally:
+                self._transport.abort()
+                await AsyncIOBackend.cancel_shielded_checkpoint()
 
         await self._protocol.closed_event.wait()
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1687,6 +1687,8 @@ class UDPSocket(abc.UDPSocket):
         self._closed = True
         if not self._transport.is_closing():
             self._transport.close()
+            await sleep(0)
+            self._transport.abort()
 
         await self._protocol.closed_event.wait()
 
@@ -1737,6 +1739,8 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
         self._closed = True
         if not self._transport.is_closing():
             self._transport.close()
+            await sleep(0)
+            self._transport.abort()
 
         await self._protocol.closed_event.wait()
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -34,6 +34,7 @@ from _pytest.tmpdir import TempPathFactory
 from pytest import FixtureRequest
 from pytest_mock.plugin import MockerFixture
 
+import anyio
 from anyio import (
     BrokenResourceError,
     BusyResourceError,
@@ -1747,9 +1748,12 @@ class TestUDPSocket:
     @pytest.mark.parametrize("anyio_backend", asyncio_params)
     async def test_aclose_during_send(self) -> None:
         udp = await create_udp_socket(local_host="127.0.0.1")
+        sock = udp.extra(SocketAttribute.raw_socket)
         await udp.sendto(b"x", "127.0.0.1", 9999)
         with fail_after(1):
-            await udp.aclose()
+            await anyio.aclose_forcefully(udp)
+
+        assert sock.fileno() == -1
 
     async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:
         async with await create_udp_socket(

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -519,6 +519,16 @@ class TestTCPStream:
         with pytest.raises(ClosedResourceError):
             await stream.send(b"foo")
 
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
+    async def test_aclose_forcefully(
+        self, server_addr: tuple[str, int]
+    ) -> None:
+        stream = await connect_tcp(*server_addr)
+        sock = stream.extra(SocketAttribute.raw_socket)
+        await stream.send(b"x")
+        await anyio.aclose_forcefully(stream)
+        assert sock.fileno() == -1
+
     async def test_receive_after_peer_closed(
         self, family: AnyIPAddressFamily, request: FixtureRequest
     ) -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -520,9 +520,7 @@ class TestTCPStream:
             await stream.send(b"foo")
 
     @pytest.mark.parametrize("anyio_backend", asyncio_params)
-    async def test_aclose_forcefully(
-        self, server_addr: tuple[str, int]
-    ) -> None:
+    async def test_aclose_forcefully(self, server_addr: tuple[str, int]) -> None:
         stream = await connect_tcp(*server_addr)
         sock = stream.extra(SocketAttribute.raw_socket)
         await stream.send(b"x")

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1743,6 +1743,14 @@ class TestUDPSocket:
             udp = await UDPSocket.from_socket(sock)
             await udp.aclose()
 
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
+    async def test_aclose_during_send(self) -> None:
+        udp = await create_udp_socket(local_host="127.0.0.1")
+        await udp.sendto(b"x", "127.0.0.1", 9999)
+        with fail_after(1):
+            await udp.aclose()
+
     async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:
         async with await create_udp_socket(
             family=family, local_host="localhost"
@@ -1913,6 +1921,14 @@ class TestConnectedUDPSocket:
                 await udp.aclose()
         finally:
             peer.close()
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
+    async def test_aclose_during_send(self) -> None:
+        udp = await create_connected_udp_socket("127.0.0.1", 9999)
+        await udp.send(b"x")
+        with fail_after(1):
+            await udp.aclose()
 
     async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:
         async with await create_connected_udp_socket(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1237.

On Windows Proactor event loops, closing a UDP socket while a datagram send is in flight can leave `connection_lost()` unscheduled and make `aclose()` wait indefinitely. Follow the transport close with an event-loop turn and `abort()`, matching the existing stream cleanup path, so the protocol close event is always delivered.

The regression tests cover connected and unconnected UDP sockets on Windows.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
