### PR TITLE
fix: do not prefer IPv6 when host has only link-local IPv6

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed ``connect_tcp()`` preferring IPv6 on hosts that only have a link-local
+  IPv6 address, which caused an unnecessary failed attempt (often "Network is
+  unreachable") before falling back to IPv4
+  (`#1230 <https://github.com/agronholm/anyio/issues/1230>`_; PR by
+  @MohammedAnasNathani)
 - Added ``StapledObjectStream.send_nowait()`` that delegates to the underlying
   ``ObjectSendStream``, if it implements it
   (`#1241 <https://github.com/agronholm/anyio/pull/1241>`_; PR by @davidbrochart)

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -107,7 +107,7 @@ def _ipv6_addr_is_locally_usable(host: str) -> bool:
 
 def _order_happy_eyeballs_targets(
     gai_res: list[tuple[Any, ...]], *, has_global_ipv6: bool
-) -> list[tuple[int, str]]:
+) -> list[tuple[AddressFamily, str]]:
     """Reorder ``getaddrinfo`` results for Happy Eyeballs (RFC 6555).
 
     Promotes the first *usable* IPv6 address to the front and the first IPv4
@@ -120,21 +120,22 @@ def _order_happy_eyeballs_targets(
       working IPv4 is not delayed (#1230).
     """
     v6_found = v4_found = False
-    target_addrs: list[tuple[int, str]] = []
+    target_addrs: list[tuple[AddressFamily, str]] = []
     for af, *_, sa in gai_res:
+        family = cast(AddressFamily, af)
         host = sa[0]
-        if af == socket.AF_INET6 and not v6_found:
+        if family == socket.AF_INET6 and not v6_found:
             if has_global_ipv6 or _ipv6_addr_is_locally_usable(host):
                 v6_found = True
-                target_addrs.insert(0, (af, host))
+                target_addrs.insert(0, (family, host))
             else:
                 # Global AAAA on a link-local-only host — do not promote.
-                target_addrs.append((af, host))
-        elif af == socket.AF_INET and not v4_found and v6_found:
+                target_addrs.append((family, host))
+        elif family == socket.AF_INET and not v4_found and v6_found:
             v4_found = True
-            target_addrs.insert(1, (af, host))
+            target_addrs.insert(1, (family, host))
         else:
-            target_addrs.append((af, host))
+            target_addrs.append((family, host))
     return target_addrs
 
 

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -68,15 +68,18 @@ def idna2008_resolve(host: str) -> bytes:
         return idna.encode(host, uts46=True)
 
 
-def _host_has_routable_ipv6() -> bool:
-    """Return True if this host can source a non-link-local IPv6 address.
+def _host_has_global_ipv6() -> bool:
+    """Return True if this host can source a global/ULA IPv6 address.
 
     ``getaddrinfo`` with ``AI_ADDRCONFIG`` still returns AAAA records when the
     only configured IPv6 address is link-local (``fe80::/10``). Preferring
-    those remote AAAA results first makes ``connect_tcp`` burn a failed IPv6
+    those *global* AAAA results first makes ``connect_tcp`` burn a failed
     attempt (often "Network is unreachable") before falling back to IPv4.
+
     A UDP ``connect`` to a well-known global address reveals the kernel's
-    chosen source address without sending packets.
+    chosen source without sending packets. Loopback-only IPv6 (``::1``) is
+    intentionally *not* treated as global: dual-stack localhost still
+    promotes ``::1`` via :func:`_ipv6_addr_is_locally_usable`.
     """
     if not getattr(socket, "has_ipv6", False):
         return False
@@ -93,30 +96,45 @@ def _host_has_routable_ipv6() -> bool:
     return not (local.is_link_local or local.is_loopback or local.is_unspecified)
 
 
+def _ipv6_addr_is_locally_usable(host: str) -> bool:
+    """True for loopback/link-local literals that work without global IPv6."""
+    try:
+        addr = ip_address(host.split("%", 1)[0])
+    except ValueError:
+        return False
+    return isinstance(addr, IPv6Address) and (addr.is_loopback or addr.is_link_local)
+
+
 def _order_happy_eyeballs_targets(
-    gai_res: list[tuple[Any, ...]], *, prefer_ipv6: bool
+    gai_res: list[tuple[Any, ...]], *, has_global_ipv6: bool
 ) -> list[tuple[int, str]]:
     """Reorder ``getaddrinfo`` results for Happy Eyeballs (RFC 6555).
 
-    When *prefer_ipv6* is true, the first IPv6 address is placed first and the
-    first IPv4 address second. When false (link-local-only IPv6 hosts), results
-    keep encounter order so a working IPv4 address is not delayed behind an
-    unreachable AAAA.
-    """
-    if not prefer_ipv6:
-        return [(af, sa[0]) for af, *_, sa in gai_res]
+    Promotes the first *usable* IPv6 address to the front and the first IPv4
+    address to second place:
 
+    * Loopback / link-local IPv6 (``::1``, ``fe80::…``) is always promotable
+      so dual-stack ``localhost`` keeps working without global IPv6.
+    * Global/ULA AAAA is promotable only when *has_global_ipv6* is true; on
+      link-local-only hosts those AAAA entries stay in encounter order so a
+      working IPv4 is not delayed (#1230).
+    """
     v6_found = v4_found = False
     target_addrs: list[tuple[int, str]] = []
     for af, *_, sa in gai_res:
+        host = sa[0]
         if af == socket.AF_INET6 and not v6_found:
-            v6_found = True
-            target_addrs.insert(0, (af, sa[0]))
+            if has_global_ipv6 or _ipv6_addr_is_locally_usable(host):
+                v6_found = True
+                target_addrs.insert(0, (af, host))
+            else:
+                # Global AAAA on a link-local-only host — do not promote.
+                target_addrs.append((af, host))
         elif af == socket.AF_INET and not v4_found and v6_found:
             v4_found = True
-            target_addrs.insert(1, (af, sa[0]))
+            target_addrs.insert(1, (af, host))
         else:
-            target_addrs.append((af, sa[0]))
+            target_addrs.append((af, host))
     return target_addrs
 
 
@@ -285,11 +303,11 @@ async def connect_tcp(
             target_host, remote_port, family=family, type=socket.SOCK_STREAM
         )
 
-        # Prefer IPv6 first only when this host has a routable IPv6 source
-        # address. Link-local-only hosts still get AAAA from AI_ADDRCONFIG, but
-        # outbound IPv6 then fails with "Network is unreachable" (#1230).
+        # Prefer global AAAA first only with a global/ULA IPv6 source. Always
+        # still promote loopback/link-local IPv6 (dual-stack localhost).
+        # Link-local-only hosts otherwise keep AAAA in encounter order (#1230).
         target_addrs = _order_happy_eyeballs_targets(
-            list(gai_res), prefer_ipv6=_host_has_routable_ipv6()
+            list(gai_res), has_global_ipv6=_host_has_global_ipv6()
         )
 
     oserrors: list[OSError] = []

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -68,6 +68,9 @@ def idna2008_resolve(host: str) -> bytes:
         return idna.encode(host, uts46=True)
 
 
+_global_ipv6_cache: bool | None = None
+
+
 def _host_has_global_ipv6() -> bool:
     """Return True if this host can source a global/ULA IPv6 address.
 
@@ -80,20 +83,34 @@ def _host_has_global_ipv6() -> bool:
     chosen source without sending packets. Loopback-only IPv6 (``::1``) is
     intentionally *not* treated as global: dual-stack localhost still
     promotes ``::1`` via :func:`_ipv6_addr_is_locally_usable`.
+
+    This function performs a blocking socket operation and must not be called
+    directly on the event-loop thread (blockbuster / asyncio policy). Callers
+    in async code should use :func:`to_thread.run_sync`. The result is cached
+    for the process lifetime.
     """
-    if not getattr(socket, "has_ipv6", False):
-        return False
-    try:
-        with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as sock:
-            # Google Public DNS — connect() on UDP selects a route/source only.
-            sock.connect(("2001:4860:4860::8888", 53))
-            local = ip_address(sock.getsockname()[0])
-    except OSError:
-        return False
-    if not isinstance(local, IPv6Address):
-        return False
-    # Link-local / loopback / unspecified cannot reach global destinations.
-    return not (local.is_link_local or local.is_loopback or local.is_unspecified)
+    global _global_ipv6_cache
+    if _global_ipv6_cache is not None:
+        return _global_ipv6_cache
+
+    result = False
+    if getattr(socket, "has_ipv6", False):
+        try:
+            with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as sock:
+                # Google Public DNS — connect() on UDP selects a route/source only.
+                sock.connect(("2001:4860:4860::8888", 53))
+                local = ip_address(sock.getsockname()[0])
+        except OSError:
+            result = False
+        else:
+            if isinstance(local, IPv6Address):
+                # Link-local / loopback / unspecified cannot reach global destinations.
+                result = not (
+                    local.is_link_local or local.is_loopback or local.is_unspecified
+                )
+
+    _global_ipv6_cache = result
+    return result
 
 
 def _ipv6_addr_is_locally_usable(host: str) -> bool:
@@ -307,8 +324,10 @@ async def connect_tcp(
         # Prefer global AAAA first only with a global/ULA IPv6 source. Always
         # still promote loopback/link-local IPv6 (dual-stack localhost).
         # Link-local-only hosts otherwise keep AAAA in encounter order (#1230).
+        # Probe off the event loop: the check uses a blocking UDP connect.
+        has_global_ipv6 = await to_thread.run_sync(_host_has_global_ipv6)
         target_addrs = _order_happy_eyeballs_targets(
-            list(gai_res), has_global_ipv6=_host_has_global_ipv6()
+            list(gai_res), has_global_ipv6=has_global_ipv6
         )
 
     oserrors: list[OSError] = []

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -68,6 +68,58 @@ def idna2008_resolve(host: str) -> bytes:
         return idna.encode(host, uts46=True)
 
 
+def _host_has_routable_ipv6() -> bool:
+    """Return True if this host can source a non-link-local IPv6 address.
+
+    ``getaddrinfo`` with ``AI_ADDRCONFIG`` still returns AAAA records when the
+    only configured IPv6 address is link-local (``fe80::/10``). Preferring
+    those remote AAAA results first makes ``connect_tcp`` burn a failed IPv6
+    attempt (often "Network is unreachable") before falling back to IPv4.
+    A UDP ``connect`` to a well-known global address reveals the kernel's
+    chosen source address without sending packets.
+    """
+    if not getattr(socket, "has_ipv6", False):
+        return False
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as sock:
+            # Google Public DNS — connect() on UDP selects a route/source only.
+            sock.connect(("2001:4860:4860::8888", 53))
+            local = ip_address(sock.getsockname()[0])
+    except OSError:
+        return False
+    if not isinstance(local, IPv6Address):
+        return False
+    # Link-local / loopback / unspecified cannot reach global destinations.
+    return not (local.is_link_local or local.is_loopback or local.is_unspecified)
+
+
+def _order_happy_eyeballs_targets(
+    gai_res: list[tuple[Any, ...]], *, prefer_ipv6: bool
+) -> list[tuple[int, str]]:
+    """Reorder ``getaddrinfo`` results for Happy Eyeballs (RFC 6555).
+
+    When *prefer_ipv6* is true, the first IPv6 address is placed first and the
+    first IPv4 address second. When false (link-local-only IPv6 hosts), results
+    keep encounter order so a working IPv4 address is not delayed behind an
+    unreachable AAAA.
+    """
+    if not prefer_ipv6:
+        return [(af, sa[0]) for af, *_, sa in gai_res]
+
+    v6_found = v4_found = False
+    target_addrs: list[tuple[int, str]] = []
+    for af, *_, sa in gai_res:
+        if af == socket.AF_INET6 and not v6_found:
+            v6_found = True
+            target_addrs.insert(0, (af, sa[0]))
+        elif af == socket.AF_INET and not v4_found and v6_found:
+            v4_found = True
+            target_addrs.insert(1, (af, sa[0]))
+        else:
+            target_addrs.append((af, sa[0]))
+    return target_addrs
+
+
 # tls_hostname given
 @overload
 async def connect_tcp(
@@ -233,19 +285,12 @@ async def connect_tcp(
             target_host, remote_port, family=family, type=socket.SOCK_STREAM
         )
 
-        # Organize the list so that the first address is an IPv6 address (if available)
-        # and the second one is an IPv4 addresses. The rest can be in whatever order.
-        v6_found = v4_found = False
-        target_addrs = []
-        for af, *_, sa in gai_res:
-            if af == socket.AF_INET6 and not v6_found:
-                v6_found = True
-                target_addrs.insert(0, (af, sa[0]))
-            elif af == socket.AF_INET and not v4_found and v6_found:
-                v4_found = True
-                target_addrs.insert(1, (af, sa[0]))
-            else:
-                target_addrs.append((af, sa[0]))
+        # Prefer IPv6 first only when this host has a routable IPv6 source
+        # address. Link-local-only hosts still get AAAA from AI_ADDRCONFIG, but
+        # outbound IPv6 then fails with "Network is unreachable" (#1230).
+        target_addrs = _order_happy_eyeballs_targets(
+            list(gai_res), prefer_ipv6=_host_has_routable_ipv6()
+        )
 
     oserrors: list[OSError] = []
     try:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -2557,6 +2557,65 @@ async def test_connect_tcp_getaddrinfo_context() -> None:
     assert exc_info.value.__context__ is None
 
 
+def test_order_happy_eyeballs_prefers_ipv6_when_routable() -> None:
+    from anyio._core._sockets import _order_happy_eyeballs_targets
+
+    # Encounter order: IPv4 then IPv6 — with prefer_ipv6, IPv6 moves first.
+    gai = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 443)),
+        (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2001:db8::1", 443, 0, 0)),
+    ]
+    ordered = _order_happy_eyeballs_targets(gai, prefer_ipv6=True)
+    assert ordered[0] == (socket.AF_INET6, "2001:db8::1")
+    assert ordered[1] == (socket.AF_INET, "1.2.3.4")
+
+
+def test_order_happy_eyeballs_keeps_order_without_routable_ipv6() -> None:
+    from anyio._core._sockets import _order_happy_eyeballs_targets
+
+    # Link-local-only hosts: do not promote IPv6 ahead of a working IPv4 (#1230).
+    gai = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 443)),
+        (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2001:db8::1", 443, 0, 0)),
+    ]
+    ordered = _order_happy_eyeballs_targets(gai, prefer_ipv6=False)
+    assert ordered == [
+        (socket.AF_INET, "1.2.3.4"),
+        (socket.AF_INET6, "2001:db8::1"),
+    ]
+
+
+def test_host_has_routable_ipv6_false_when_disabled(monkeypatch: MonkeyPatch) -> None:
+    from anyio._core._sockets import _host_has_routable_ipv6
+
+    monkeypatch.setattr(socket, "has_ipv6", False)
+    assert _host_has_routable_ipv6() is False
+
+
+def test_host_has_routable_ipv6_false_on_link_local(monkeypatch: MonkeyPatch) -> None:
+    from anyio._core._sockets import _host_has_routable_ipv6
+
+    class FakeSock:
+        def connect(self, address: object) -> None:
+            pass
+
+        def getsockname(self) -> tuple[str, int, int, int]:
+            return ("fe80::1", 0, 0, 0)
+
+        def __enter__(self) -> FakeSock:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(socket, "has_ipv6", True)
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: FakeSock())
+    assert _host_has_routable_ipv6() is False
+
+
 @pytest.mark.parametrize("socket_type", ["socket", "fd"])
 @pytest.mark.parametrize("event", ["readable", "writable"])
 async def test_wait_socket(event: str, socket_type: str) -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -2599,13 +2599,16 @@ def test_order_happy_eyeballs_still_promotes_loopback_without_global() -> None:
 
 
 def test_host_has_global_ipv6_false_when_disabled(monkeypatch: MonkeyPatch) -> None:
+    import anyio._core._sockets as sockets_mod
     from anyio._core._sockets import _host_has_global_ipv6
 
+    monkeypatch.setattr(sockets_mod, "_global_ipv6_cache", None)
     monkeypatch.setattr(socket, "has_ipv6", False)
     assert _host_has_global_ipv6() is False
 
 
 def test_host_has_global_ipv6_false_on_link_local(monkeypatch: MonkeyPatch) -> None:
+    import anyio._core._sockets as sockets_mod
     from anyio._core._sockets import _host_has_global_ipv6
 
     class FakeSock:
@@ -2624,6 +2627,7 @@ def test_host_has_global_ipv6_false_on_link_local(monkeypatch: MonkeyPatch) -> N
         def close(self) -> None:
             pass
 
+    monkeypatch.setattr(sockets_mod, "_global_ipv6_cache", None)
     monkeypatch.setattr(socket, "has_ipv6", True)
     monkeypatch.setattr(socket, "socket", lambda *a, **k: FakeSock())
     assert _host_has_global_ipv6() is False

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -2557,43 +2557,56 @@ async def test_connect_tcp_getaddrinfo_context() -> None:
     assert exc_info.value.__context__ is None
 
 
-def test_order_happy_eyeballs_prefers_ipv6_when_routable() -> None:
+def test_order_happy_eyeballs_prefers_global_ipv6_when_routable() -> None:
     from anyio._core._sockets import _order_happy_eyeballs_targets
 
-    # Encounter order: IPv4 then IPv6 — with prefer_ipv6, IPv6 moves first.
+    # Encounter order: IPv4 then global IPv6 — with global IPv6, AAAA moves first.
     gai = [
         (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 443)),
         (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2001:db8::1", 443, 0, 0)),
     ]
-    ordered = _order_happy_eyeballs_targets(gai, prefer_ipv6=True)
+    ordered = _order_happy_eyeballs_targets(gai, has_global_ipv6=True)
     assert ordered[0] == (socket.AF_INET6, "2001:db8::1")
     assert ordered[1] == (socket.AF_INET, "1.2.3.4")
 
 
-def test_order_happy_eyeballs_keeps_order_without_routable_ipv6() -> None:
+def test_order_happy_eyeballs_does_not_promote_global_aaaa_without_route() -> None:
     from anyio._core._sockets import _order_happy_eyeballs_targets
 
-    # Link-local-only hosts: do not promote IPv6 ahead of a working IPv4 (#1230).
+    # Link-local-only hosts: do not promote global AAAA ahead of IPv4 (#1230).
     gai = [
         (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 443)),
         (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2001:db8::1", 443, 0, 0)),
     ]
-    ordered = _order_happy_eyeballs_targets(gai, prefer_ipv6=False)
+    ordered = _order_happy_eyeballs_targets(gai, has_global_ipv6=False)
     assert ordered == [
         (socket.AF_INET, "1.2.3.4"),
         (socket.AF_INET6, "2001:db8::1"),
     ]
 
 
-def test_host_has_routable_ipv6_false_when_disabled(monkeypatch: MonkeyPatch) -> None:
-    from anyio._core._sockets import _host_has_routable_ipv6
+def test_order_happy_eyeballs_still_promotes_loopback_without_global() -> None:
+    from anyio._core._sockets import _order_happy_eyeballs_targets
+
+    # Dual-stack localhost must keep preferring ::1 even without global IPv6.
+    gai = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0)),
+        (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::1", 0, 0, 0)),
+    ]
+    ordered = _order_happy_eyeballs_targets(gai, has_global_ipv6=False)
+    assert ordered[0] == (socket.AF_INET6, "::1")
+    assert ordered[1] == (socket.AF_INET, "127.0.0.1")
+
+
+def test_host_has_global_ipv6_false_when_disabled(monkeypatch: MonkeyPatch) -> None:
+    from anyio._core._sockets import _host_has_global_ipv6
 
     monkeypatch.setattr(socket, "has_ipv6", False)
-    assert _host_has_routable_ipv6() is False
+    assert _host_has_global_ipv6() is False
 
 
-def test_host_has_routable_ipv6_false_on_link_local(monkeypatch: MonkeyPatch) -> None:
-    from anyio._core._sockets import _host_has_routable_ipv6
+def test_host_has_global_ipv6_false_on_link_local(monkeypatch: MonkeyPatch) -> None:
+    from anyio._core._sockets import _host_has_global_ipv6
 
     class FakeSock:
         def connect(self, address: object) -> None:
@@ -2613,7 +2626,7 @@ def test_host_has_routable_ipv6_false_on_link_local(monkeypatch: MonkeyPatch) ->
 
     monkeypatch.setattr(socket, "has_ipv6", True)
     monkeypatch.setattr(socket, "socket", lambda *a, **k: FakeSock())
-    assert _host_has_routable_ipv6() is False
+    assert _host_has_global_ipv6() is False
 
 
 @pytest.mark.parametrize("socket_type", ["socket", "fd"])


### PR DESCRIPTION
## Summary

Fixes #1230.

On hosts whose only IPv6 address is link-local (`fe80::/10`), `getaddrinfo` with `AI_ADDRCONFIG` still returns AAAA records for dual-stack names. `connect_tcp` then **forced IPv6 first**, so the first Happy Eyeballs attempt often failed with `Network is unreachable` before IPv4 was tried.

## Approach

1. **`_host_has_routable_ipv6()`** — UDP `connect` to a well-known global address (no packets sent) and inspect the kernel-chosen source. Returns false for link-local / loopback / unspecified / no IPv6.
2. **`_order_happy_eyeballs_targets(...)`** — pure reorder helper:
   - `prefer_ipv6=True` → same as before (IPv6 first, IPv4 second)
   - `prefer_ipv6=False` → keep `getaddrinfo` encounter order (IPv4 is not delayed behind a doomed AAAA)
3. **`connect_tcp`** uses (1) to decide (2).

Happy Eyeballs still races multiple addresses; this only stops *blindly* promoting IPv6 when the host cannot source a routable IPv6 address.

## Tests

- Prefer-IPv6 reorder (IPv4-then-IPv6 input → IPv6 first)
- No-prefer reorder keeps encounter order (#1230)
- `_host_has_routable_ipv6` false when `has_ipv6` is false
- `_host_has_routable_ipv6` false when source is `fe80::1`

## Checklist

- [x] Tests which would fail without the patch
- [x] Changelog entry in `docs/versionhistory.rst`
- [ ] Docs — behavior note only in changelog (API unchanged)

## LLM use

AI assistant helped structure helpers/tests and PR text; I verified the #1230 root cause against the Happy Eyeballs reorder loop and the link-local probe semantics.