### PR TITLE
Document memory stream clones for multiple workers

### DIFF
--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -76,6 +76,51 @@ Example::
 
     run(main)
 
+Managing multiple producers and consumers
+******************************************
+
+When several tasks share one stream end, the first task to finish would close that
+shared object and disrupt the others. Give each task its own clone so that it can close
+its stream independently::
+
+    from anyio import create_memory_object_stream, create_task_group, run
+    from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+
+
+    async def producer(
+        name: str, send_stream: MemoryObjectSendStream[str]
+    ) -> None:
+        async with send_stream:
+            for number in range(3):
+                await send_stream.send(f"{number} from producer {name}")
+
+
+    async def consumer(
+        name: str, receive_stream: MemoryObjectReceiveStream[str]
+    ) -> None:
+        async with receive_stream:
+            async for item in receive_stream:
+                print(f"consumer {name} received {item!r}")
+
+
+    async def main() -> None:
+        send_stream, receive_stream = create_memory_object_stream[str]()
+        async with create_task_group() as tg:
+            async with send_stream, receive_stream:
+                for name in "A", "B":
+                    tg.start_soon(producer, name, send_stream.clone())
+
+                for name in "X", "Y":
+                    tg.start_soon(consumer, name, receive_stream.clone())
+
+
+    run(main)
+
+The original streams must also be closed after their clones are created. Otherwise,
+for example, the receiving tasks will never see the end of the stream while the
+original send stream remains open. Receive clones distribute items among consumers;
+they do not broadcast every item to every consumer.
+
 In contrast to other AnyIO streams (but in line with Trio's Channels), memory object
 streams can be closed synchronously, using either the ``close()`` method or by using the
 stream as a context manager::

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -105,13 +105,12 @@ its stream independently::
 
     async def main() -> None:
         send_stream, receive_stream = create_memory_object_stream[str]()
-        async with create_task_group() as tg:
-            async with send_stream, receive_stream:
-                for name in "A", "B":
-                    tg.start_soon(producer, name, send_stream.clone())
+        async with create_task_group() as tg, send_stream, receive_stream:
+            for name in "A", "B":
+                tg.start_soon(producer, name, send_stream.clone())
 
-                for name in "X", "Y":
-                    tg.start_soon(consumer, name, receive_stream.clone())
+            for name in "X", "Y":
+                tg.start_soon(consumer, name, receive_stream.clone())
 
 
     run(main)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added guidance for managing multiple memory object stream producers and consumers
+  with cloned streams
+  (`#330 <https://github.com/agronholm/anyio/issues/330>`_; PR by @nightcityblade)
 - Added ``StapledObjectStream.send_nowait()`` that delegates to the underlying
   ``ObjectSendStream``, if it implements it
   (`#1241 <https://github.com/agronholm/anyio/pull/1241>`_; PR by @davidbrochart)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #330.

Add a multiple-producer/multiple-consumer memory object stream example that gives each
task its own clone. The guide also explains why the original endpoints must be closed
and clarifies that receive clones distribute items rather than broadcast them.

Validation:

- `pre-commit run -a`
- `pytest tests/streams/test_memory.py -q` (136 passed)
- `sphinx-build -n -E docs build/sphinx`
- Executed the documented example and confirmed clean shutdown

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

Tests are not added because this PR only documents existing, already-tested behavior.

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
