### PR TITLE
fix: do not swallow concurrent native Task.cancel on CancelScope exit (#1214)

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,13 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed ``CancelScope`` on the asyncio backend swallowing a concurrent native
+  ``Task.cancel()`` when the scope was also cancelled (e.g. Happy Eyeballs
+  winning and cancelling the host task group while the caller cancels the host
+  task). The host task previously returned normally with ``cancelling() > 0``
+  and ``cancelled() is False``; ``CancelledError`` now propagates as expected
+  (`#1214 <https://github.com/agronholm/anyio/issues/1214>`_; PR by
+  @MohammedAnasNathani)
 - Added ``StapledObjectStream.send_nowait()`` that delegates to the underlying
   ``ObjectSendStream``, if it implements it
   (`#1241 <https://github.com/agronholm/anyio/pull/1241>`_; PR by @davidbrochart)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -391,6 +391,7 @@ class CancelScope(BaseCancelScope):
         "_child_scopes",
         "_deadline",
         "_host_task",
+        "_host_task_cancel_count_at_enter",
         "_parent_scope",
         "_pending_uncancellations",
         "_shield",
@@ -416,6 +417,9 @@ class CancelScope(BaseCancelScope):
         self._cancel_handle: asyncio.Handle | None = None
         self._tasks: set[asyncio.Task] = set()
         self._host_task: asyncio.Task | None = None
+        # Snapshot of host Task.cancelling() at __enter__; used so that on exit we
+        # only treat *new* native cancels (above this baseline) as external (#1214).
+        self._host_task_cancel_count_at_enter: int = 0
         if sys.version_info >= (3, 11):
             self._pending_uncancellations: int | None = 0
         else:
@@ -445,6 +449,8 @@ class CancelScope(BaseCancelScope):
 
         self._timeout()
         self._active = True
+        if sys.version_info >= (3, 11):
+            self._host_task_cancel_count_at_enter = host_task.cancelling()
 
         # Start cancelling the host task if the scope was cancelled before entering
         if self._cancel_called:
@@ -502,6 +508,23 @@ class CancelScope(BaseCancelScope):
                     self._host_task.uncancel()
                     self._pending_uncancellations -= 1
 
+                # If a native Task.cancel() landed *while this scope was active*
+                # (e.g. Happy Eyeballs wins and cancels the host TG at the same
+                # time the caller cancels the host task), the CancelledError we
+                # hold may be the AnyIO-tagged one, but after undoing *our*
+                # cancels the host still has a cancel count above the enter
+                # baseline. Swallowing would leave cancelling() elevated with
+                # no exception propagating — the task returns normally and the
+                # caller's await never sees CancelledError (#1214).
+                # Compare against the enter baseline so a cancel that was
+                # already pending before ``__enter__`` does not block swallow
+                # (see test_cancel_message_replaced).
+                external_cancel_pending = (
+                    self._pending_uncancellations is not None
+                    and self._host_task.cancelling()
+                    > self._host_task_cancel_count_at_enter
+                )
+
                 # Update cancelled_caught and check for exceptions we must not swallow
                 if isinstance(exc_val, BaseExceptionGroup):
                     cancelleds_caught, remaining = exc_val.split(
@@ -517,7 +540,7 @@ class CancelScope(BaseCancelScope):
                     self._cancelled_caught = True
 
                     if remaining is None:
-                        return True
+                        return not external_cancel_pending
 
                     context = remaining.__context__
                     try:
@@ -533,7 +556,7 @@ class CancelScope(BaseCancelScope):
                         exc_val
                     ):
                         self._cancelled_caught = True
-                        return True
+                        return not external_cancel_pending
                     else:
                         return False
             else:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1688,6 +1688,49 @@ class TestUncancel:
         assert task.cancelling() == 1
         task.uncancel()
 
+    async def test_child_scope_cancel_does_not_swallow_native_host_cancel(
+        self,
+    ) -> None:
+        """
+        When a child cancels its task group (Happy Eyeballs style) and a native
+        ``Task.cancel()`` lands on the host in the same cycle, the host must still
+        observe ``CancelledError`` — not return normally with ``cancelling() > 0``.
+
+        Regression test for #1214.
+        """
+        attempt_started = asyncio.Event()
+        connection_won = asyncio.Event()
+
+        async def operation() -> None:
+            async with create_task_group() as task_group:
+
+                async def connect_attempt() -> None:
+                    attempt_started.set()
+                    await connection_won.wait()
+                    # Same pattern as connect_tcp(): winner cancels the group.
+                    task_group.cancel_scope.cancel()
+
+                task_group.start_soon(connect_attempt)
+                await sleep_forever()
+
+        task = asyncio.create_task(operation())
+        await attempt_started.wait()
+
+        external_cancel_accepted: list[bool] = []
+
+        def externally_cancel() -> None:
+            external_cancel_accepted.append(task.cancel("external cancellation"))
+
+        connection_won.set()
+        asyncio.get_running_loop().call_soon(externally_cancel)
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert external_cancel_accepted == [True]
+        assert task.cancelled()
+        assert task.cancelling() >= 1
+
     async def test_cancel_message_replaced(self) -> None:
         task = asyncio.current_task()
         assert task


### PR DESCRIPTION
## Changes

On the asyncio backend, when a `CancelScope` cancels its host task **and** a concurrent native `Task.cancel()` lands in the same event-loop cycle, `__exit__` could swallow the AnyIO-tagged `CancelledError` after undoing only the scope's own cancel counts. The host then **returned normally** with `task.cancelled() is False` and `task.cancelling() > 0`, so callers awaiting the task never saw cancellation.

This is the Happy Eyeballs / `connect_tcp` pattern from production: a child cancels the task group while an unrelated caller cancels the host task.

### Fix

1. Snapshot `Task.cancelling()` when the scope is entered.
2. On exit, after calling `uncancel()` for each cancel this scope delivered to the host, **do not swallow** if `cancelling()` is still above that baseline — a native cancel that arrived *while the scope was active* must still propagate.
3. Cancels that were already pending *before* enter are ignored for this check (preserves `test_cancel_message_replaced` and related uncancel semantics).

### Checklist

- [x] Tests which would fail without the patch (`TestUncancel.test_child_scope_cancel_does_not_swallow_native_host_cancel`, mirrors the #1214 repro)
- [x] Changelog entry in `docs/versionhistory.rst`
- [x] Existing `TestUncancel` suite green; full `tests/test_taskgroups.py`: 539 passed

### Related

Fixes #1214

<details>
<summary>Verification</summary>

```
# Issue repro (before: returned normally / cancelled=False / cancelling=1)
# After: CancelledError propagates / cancelled=True / cancelling=1

pytest tests/test_taskgroups.py::TestUncancel   # 30 passed
pytest tests/test_taskgroups.py                 # 539 passed, 153 skipped, 4 xfailed
```
</details>