### PR TITLE
fix timeout in test_pytest_plugin.py::test_keyboard_interrupt_does_not_resume_test

### DIFF
--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -499,7 +499,7 @@ def test_keyboard_interrupt_does_not_resume_test(testdir: Pytester) -> None:
         async def test_keyboard_interrupt(myfixture):
             loop = asyncio.get_running_loop()
             loop.call_soon(signal.raise_signal, signal.SIGINT)
-            await anyio.sleep(3)
+            await anyio.sleep(5)
             print("RESUMED_AFTER_INTERRUPT")
         """
     )

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -499,12 +499,12 @@ def test_keyboard_interrupt_does_not_resume_test(testdir: Pytester) -> None:
         async def test_keyboard_interrupt(myfixture):
             loop = asyncio.get_running_loop()
             loop.call_soon(signal.raise_signal, signal.SIGINT)
-            await anyio.sleep(3600)
+            await anyio.sleep(3)
             print("RESUMED_AFTER_INTERRUPT")
         """
     )
 
-    result = testdir.runpytest_subprocess(*pytest_args, timeout=5)
+    result = testdir.runpytest_subprocess(*pytest_args)
     assert result.ret == 2
     result.stdout.no_fnmatch_line("*RESUMED_AFTER_INTERRUPT*")
     result.stdout.fnmatch_lines(["*KeyboardInterrupt*"])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1244 

`tests/test_pytest_plugin.py::test_keyboard_interrupt_does_not_resume_test` is timing out on its assumed 5-seconds subprocess timeout on resource-constrained environments(see linked issue).
This PR removes the explicit subprocess timeout and reduces the sleep from 3600s to 3s(Reducing the sleep is mainly for how long a regression would take to surface).

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
