### PR TITLE
Fixed SocketStream close race on asyncio

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -17,6 +17,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   module name. (The default name for a task spawned with ``TaskGroup.start_soon`` or
   ``TaskGroup.start`` typically includes the module name.)
   (`#1234 <https://github.com/agronholm/anyio/pull/1234>`_; PR by @gschaffner)
+- Fixed ``SocketStream.aclose()`` raising an ``AttributeError`` on the asyncio backend
+  when the write buffer drained between closing and aborting the transport
+  (`#1250 <https://github.com/agronholm/anyio/issues/1250>`_; PR by @subotac)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,
   causing AnyIO to behave erroneously in relation to ``start_blocking_portal()`` and

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1250,6 +1250,7 @@ class StreamProtocol(asyncio.Protocol):
     write_event: asyncio.Event
     exception: Exception | None = None
     is_at_eof: bool = False
+    is_connection_lost: bool = False
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.read_queue = deque()
@@ -1259,6 +1260,7 @@ class StreamProtocol(asyncio.Protocol):
         cast(asyncio.Transport, transport).set_write_buffer_limits(0)
 
     def connection_lost(self, exc: Exception | None) -> None:
+        self.is_connection_lost = True
         if exc:
             self.exception = exc
 
@@ -1401,7 +1403,8 @@ class SocketStream(abc.SocketStream):
 
             self._transport.close()
             await sleep(0)
-            self._transport.abort()
+            if not self._protocol.is_connection_lost:
+                self._transport.abort()
 
 
 class _RawSocketMixin:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -506,6 +506,28 @@ class TestTCPStream:
                 with pytest.raises(ClosedResourceError):
                     await stream.receive()
 
+    @pytest.mark.parametrize("anyio_backend", asyncio_params[:1])
+    async def test_close_after_connection_lost(
+        self, server_addr: tuple[str, int], mocker: MockerFixture
+    ) -> None:
+        stream = cast(Any, await connect_tcp(*server_addr))
+        original_close = stream._transport.close
+
+        def close() -> None:
+            original_close()
+            stream._protocol.connection_lost(None)
+
+        mocker.patch.object(stream._transport, "close", side_effect=close)
+        abort = mocker.patch.object(
+            stream._transport,
+            "abort",
+            side_effect=AttributeError(
+                "'NoneType' object has no attribute 'call_soon'"
+            ),
+        )
+        await stream.aclose()
+        abort.assert_not_called()
+
     async def test_receive_after_close(self, server_addr: tuple[str, int]) -> None:
         stream = await connect_tcp(*server_addr)
         await stream.aclose()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

  **NOTE** Erasing or replacing the contents of this template will result in your pull
  request being summarily closed without consideration!

  ## Changes

  Fixes #1250.

  On the asyncio backend, `SocketStream.aclose()` closes the transport, yields once, and then aborts it. If the write buffer drains during that checkpoint, `connection_lost()` may finalize the
  transport before `abort()` runs, causing asyncio to access a transport loop that has already been cleared.

  Track whether `StreamProtocol.connection_lost()` has run and skip the redundant abort in that case. Add a deterministic regression test covering this interleaving.

  ## Checklist

  If this is a user-facing code change, like a bugfix or a new feature, please ensure that
  you've fulfilled the following conditions (where applicable):

  - [x] You've added tests (in `tests/`) which would fail without your patch
  - [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
  features
    - Not applicable: this fixes an internal cleanup race without changing the documented API.
  - [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

  If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
  these instructions.

  ### Updating the changelog

  If there are no entries after the last release, use `**UNRELEASED**` as the version.
  If, say, your patch fixes issue <span>#</span>123, the entry should look like this:


  - Fix big bad boo-boo in task groups
    (#123 <https://github.com/agronholm/anyio/issues/123>_; PR by @subotac)


  If there's no issue linked, just link to your pull request instead by updating the
  changelog after you've created the PR.