### PR TITLE
Don't mask AttributeError in StapledObjectStream.send_nowait()

### DIFF
--- a/src/anyio/streams/stapled.py
+++ b/src/anyio/streams/stapled.py
@@ -87,11 +87,13 @@ class StapledObjectStream(ObjectStream[T_Item], Generic[T_Item]):
 
     def send_nowait(self, item: T_Item) -> None:
         try:
-            self.send_stream.send_nowait(item)  # type: ignore[attr-defined]
+            send_nowait = self.send_stream.send_nowait  # type: ignore[attr-defined]
         except AttributeError as exc:
             raise NotImplementedError(
                 f"'send_nowait' method not implemented in {type(self.send_stream)}"
             ) from exc
+
+        send_nowait(item)
 
     async def send_eof(self) -> None:
         await self.send_stream.aclose()

--- a/tests/streams/test_stapled.py
+++ b/tests/streams/test_stapled.py
@@ -150,6 +150,11 @@ class DummyObjectSendStreamWithSendNowait(DummyObjectSendStream[T_Item]):
         self.buffer.append(item)
 
 
+class DummyObjectSendStreamWithBrokenSendNowait(DummyObjectSendStream[T_Item]):
+    def send_nowait(self, item: T_Item) -> None:
+        raise AttributeError("no attribute 'nonexistent'")
+
+
 class TestStapledObjectStream:
     @pytest.fixture
     def receive_stream(self) -> DummyObjectReceiveStream[str]:
@@ -208,6 +213,15 @@ class TestStapledObjectStream:
             match="'send_nowait' method not implemented in "
             "<class 'tests.streams.test_stapled.DummyObjectSendStream'>",
         ):
+            stapled.send_nowait("hello")
+
+    def test_send_nowait_does_not_mask_attribute_error(
+        self, receive_stream: DummyObjectReceiveStream[str]
+    ) -> None:
+        stapled = StapledObjectStream(
+            DummyObjectSendStreamWithBrokenSendNowait[str](), receive_stream
+        )
+        with pytest.raises(AttributeError, match="no attribute 'nonexistent'"):
             stapled.send_nowait("hello")
 
     async def test_send_eof(self, stapled: StapledObjectStream[str]) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

No linked issue — this is a follow-up to #1241, which added
`StapledObjectStream.send_nowait()`.

The `try` block there wraps the call, not just the attribute lookup:

```python
try:
    self.send_stream.send_nowait(item)
except AttributeError as exc:
    raise NotImplementedError(
        f"'send_nowait' method not implemented in {type(self.send_stream)}"
    ) from exc
```

So an `AttributeError` raised *inside* a `send_nowait()` that does exist is caught
and reported as the method not existing. With a send stream that implements
`send_nowait()` but has a bug in it:

```
NotImplementedError: 'send_nowait' method not implemented in <class 'SendStreamWithBug'>
  caused by AttributeError: 'collections.deque' object has no attribute 'appendd'
```

The message is untrue — `hasattr(send_stream, "send_nowait")` is `True` — and it
points at the wrong stream and the wrong problem. The real error is only reachable
through `__cause__`, which is easy to miss.

This looks up the bound method inside the `try` and calls it outside, so only a
genuinely missing method turns into `NotImplementedError` and anything the
implementation itself raises propagates untouched.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

`tests/streams/test_stapled.py` gains `DummyObjectSendStreamWithBrokenSendNowait`,
whose `send_nowait()` raises `AttributeError`, and a test asserting it reaches the
caller. Without the patch that test fails with the misleading
`NotImplementedError` quoted above. `tests/streams` passes (424) on both backends,
and ruff, ruff-format and mypy are clean on the two changed files.

I left the docs and changelog boxes unchecked deliberately. `send_nowait()` is
still under `**UNRELEASED**`, so a "Fixed" entry would describe a bug that no
release ever had, and I didn't want to rewrite the existing `Added` entry from
#1241. Say the word and I'll add an entry in whichever form you prefer.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
