### PR TITLE
Fixed cancellation retry for tasks with native cancellation

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,6 +8,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Added the ``anyio.Future`` synchronization primitive which behaves similar to
   ``asyncio.Future``, allowing tasks to wait for a value (or exception) from another
   task (`#1146 <https://github.com/agronholm/anyio/pull/1146>`_; PR by @Vizonex)
+- Fixed cancellation delivery on asyncio scheduling an unnecessary retry for tasks
+  that already had native cancellation pending
+  (`#1258 <https://github.com/agronholm/anyio/issues/1258>`_; PR by @subotac)
 - Added guidance for managing multiple memory object stream producers and consumers
   with cloned streams
   (`#330 <https://github.com/agronholm/anyio/issues/330>`_; PR by @nightcityblade)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,9 +8,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Added the ``anyio.Future`` synchronization primitive which behaves similar to
   ``asyncio.Future``, allowing tasks to wait for a value (or exception) from another
   task (`#1146 <https://github.com/agronholm/anyio/pull/1146>`_; PR by @Vizonex)
-- Fixed cancellation delivery on asyncio scheduling an unnecessary retry for tasks
-  that already had native cancellation pending
-  (`#1258 <https://github.com/agronholm/anyio/issues/1258>`_; PR by @subotac)
 - Added guidance for managing multiple memory object stream producers and consumers
   with cloned streams
   (`#330 <https://github.com/agronholm/anyio/issues/330>`_; PR by @nightcityblade)
@@ -48,6 +45,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``Path(".txt")``) instead of raising ``ValueError`` when given an empty stem on a
   path with a non-empty suffix, unlike :meth:`pathlib.PurePath.with_stem`
   (`#1200 <https://github.com/agronholm/anyio/pull/1200>`_; PR by @Sanjays2402)
+- Fixed cancellation delivery on asyncio scheduling an unnecessary retry for tasks
+  that already had native cancellation pending
+  (`#1258 <https://github.com/agronholm/anyio/issues/1258>`_; PR by @subotac)
 
 **4.14.2**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -595,9 +595,10 @@ class CancelScope(BaseCancelScope):
             if task.done():
                 continue
 
-            should_retry = True
             if task._must_cancel:  # type: ignore[attr-defined]
                 continue
+
+            should_retry = True
 
             # The task is eligible for cancellation if it has started
             if task is not current and (task is self._host_task or _task_started(task)):

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -400,6 +400,45 @@ async def test_no_spin_on_done_task_in_cancel_scope(mocker: MockerFixture) -> No
     spy.assert_called_once()
 
 
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
+async def test_no_retry_for_task_with_pending_cancellation(
+    mocker: MockerFixture,
+) -> None:
+    """Regression test for #1258."""
+    from anyio._backends import _asyncio
+
+    # To allow the mocker to override a @final class
+    class EditableCancelScope(_asyncio.CancelScope):
+        pass
+
+    async def owner(
+        started: asyncio.Future[EditableCancelScope], blocker: asyncio.Future[None]
+    ) -> None:
+        scope = EditableCancelScope().__enter__()
+        started.set_result(scope)
+        await blocker
+
+    loop = asyncio.get_running_loop()
+    started: asyncio.Future[EditableCancelScope] = loop.create_future()
+    blocker: asyncio.Future[None] = loop.create_future()
+    task = asyncio.create_task(owner(started, blocker))
+    scope = await started
+    spy = mocker.spy(scope, "_deliver_cancellation")
+
+    # Make the waiter done before cancelling the task so asyncio marks the task
+    # itself for cancellation instead of forwarding cancellation to the waiter.
+    blocker.set_result(None)
+    task.cancel()
+    assert task._must_cancel  # type: ignore[attr-defined]
+
+    scope.cancel()
+    assert scope._cancel_handle is None
+    spy.assert_called_once()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
 @pytest.mark.parametrize("return_handle", [False, True])
 async def test_start_exception_delivery(return_handle: bool) -> None:
     def task_fn(*, task_status: TaskStatus[str] = TASK_STATUS_IGNORED) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

  **NOTE** Erasing or replacing the contents of this template will result in your pull
  request being summarily closed without consideration!

  ## Changes

  Fixes #1258.

  Avoid retrying AnyIO cancellation delivery when the underlying asyncio task already has native cancellation pending. This prevents `_must_cancel` tasks from being unnecessarily re-armed after leaving a
  cancelled scope.

  ## Checklist

  If this is a user-facing code change, like a bugfix or a new feature, please ensure that
  you've fulfilled the following conditions (where applicable):

  - [x] You've added tests (in `tests/`) which would fail without your patch
  - [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
  features
  - [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

  If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
  these instructions.

  ### Updating the changelog

  If there are no entries after the last release, use `**UNRELEASED**` as the version.
  If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

  - Fix big bad boo-boo in task groups
    (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)

  If there's no issue linked, just link to your pull request instead by updating the
  changelog after you've created the PR.