### PR TITLE
fix race condition in WorkerThread and timing flakiness on aarch64

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fix race condition in WorkerThread and timing flakiness (`#1265
+  <https://github.com/agronholm/anyio/issues/1265>`_; PR by
+  @mcepl)
 - Added guidance for managing multiple memory object stream producers and consumers
   with cloned streams
   (`#330 <https://github.com/agronholm/anyio/issues/330>`_; PR by @nightcityblade)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1042,9 +1042,13 @@ class WorkerThread(Thread):
                         del threadlocals.current_cancel_scope
 
                     if not self.loop.is_closed():
-                        self.loop.call_soon_threadsafe(
-                            self._report_result, future, result, exception
-                        )
+                        try:
+                            self.loop.call_soon_threadsafe(
+                                self._report_result, future, result, exception
+                            )
+                        except RuntimeError:
+                            # Event loop was closed just after the is_closed() check
+                            pass
 
                     del result, exception
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1265 

The following changes address build failures observed specifically on aarch64 architectures:

1. Fix race condition in AsyncIOBackend.WorkerThread.run() A RuntimeError: "Event loop is closed" was occurring in uvloop when the event loop was closed in the main thread immediately after the worker thread performed a check for `self.loop.is_closed()` but before it could call `self.loop.call_soon_threadsafe()`.

   Wrapped the call in a try-except block to safely ignore the exception if the loop is closed during this transition.

2. Increase timeout margins in test_deadline_moved() The test `test_deadline_moved` failed on aarch64 due to timing jitter where the execution of `await sleep(0.2)` exceeded the total allowed deadline. The timeout values have been increased to provide a larger buffer for architectural overhead and CI environment latency.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch NOT APPLICABLE
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features NOT APPLICABLE
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.