### PR TITLE
Fix UNIX socket close race with cancelled I/O

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,4 @@ __pycache__
 .idea
 .cache
 .local
-.DS_Store
 CLAUDE.local.md

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ __pycache__
 .idea
 .cache
 .local
+.DS_Store
 CLAUDE.local.md

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -23,6 +23,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   module name. (The default name for a task spawned with ``TaskGroup.start_soon`` or
   ``TaskGroup.start`` typically includes the module name.)
   (`#1234 <https://github.com/agronholm/anyio/pull/1234>`_; PR by @gschaffner)
+- Fixed ``UNIXSocketStream.aclose()`` raising ``asyncio.InvalidStateError`` when a
+  concurrent I/O operation had just been cancelled on the asyncio backend
+  (`#1267 <https://github.com/agronholm/anyio/issues/1267>`_; PR by @alloutflo)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,
   causing AnyIO to behave erroneously in relation to ``start_blocking_portal()`` and

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -24,7 +24,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``TaskGroup.start`` typically includes the module name.)
   (`#1234 <https://github.com/agronholm/anyio/pull/1234>`_; PR by @gschaffner)
 - Fixed ``UNIXSocketStream.aclose()`` raising ``asyncio.InvalidStateError`` when a
-  concurrent I/O operation had just been cancelled on the asyncio backend
+  concurrent receive or send operation had just been cancelled on the asyncio backend
   (`#1267 <https://github.com/agronholm/anyio/issues/1267>`_; PR by @alloutflo)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -23,9 +23,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   module name. (The default name for a task spawned with ``TaskGroup.start_soon`` or
   ``TaskGroup.start`` typically includes the module name.)
   (`#1234 <https://github.com/agronholm/anyio/pull/1234>`_; PR by @gschaffner)
-- Fixed ``UNIXSocketStream.aclose()`` raising ``asyncio.InvalidStateError`` when a
-  concurrent receive or send operation had just been cancelled on the asyncio backend
-  (`#1267 <https://github.com/agronholm/anyio/issues/1267>`_; PR by @alloutflo)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,
   causing AnyIO to behave erroneously in relation to ``start_blocking_portal()`` and
@@ -48,6 +45,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``Path(".txt")``) instead of raising ``ValueError`` when given an empty stem on a
   path with a non-empty suffix, unlike :meth:`pathlib.PurePath.with_stem`
   (`#1200 <https://github.com/agronholm/anyio/pull/1200>`_; PR by @Sanjays2402)
+- Fixed ``UNIXSocketStream.aclose()`` raising ``asyncio.InvalidStateError`` when a
+  concurrent receive or send operation had just been cancelled on the asyncio backend
+  (`#1267 <https://github.com/agronholm/anyio/issues/1267>`_; PR by @alloutflo)
 
 **4.14.2**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1444,9 +1444,9 @@ class _RawSocketMixin:
             if self.__raw_socket.fileno() != -1:
                 self.__raw_socket.close()
 
-            if self._receive_future:
+            if self._receive_future and not self._receive_future.done():
                 self._receive_future.set_result(None)
-            if self._send_future:
+            if self._send_future and not self._send_future.done():
                 self._send_future.set_result(None)
 
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -58,6 +58,7 @@ from anyio import (
     getnameinfo,
     move_on_after,
     notify_closing,
+    sleep_forever,
     wait_all_tasks_blocked,
     wait_readable,
     wait_socket_readable,
@@ -1446,6 +1447,33 @@ class TestUNIXStream:
                 tg.start_soon(interrupt)
                 with pytest.raises(ClosedResourceError):
                     await stream.receive()
+
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
+    async def test_close_after_cancelled_receive(self, socket_path: Path) -> None:
+        async def handler(stream: SocketStream) -> None:
+            async def receive() -> None:
+                # Closing may wake the receive before cancellation reaches it.
+                with suppress(ClosedResourceError):
+                    await stream.receive()
+
+            async with create_task_group() as tg:
+                tg.start_soon(receive)
+                try:
+                    await sleep_forever()
+                finally:
+                    await stream.aclose()
+
+        client = None
+        try:
+            async with await create_unix_listener(socket_path) as listener:
+                async with create_task_group() as tg:
+                    tg.start_soon(listener.serve, handler)
+                    client = await connect_unix(socket_path)
+                    await wait_all_tasks_blocked()
+                    tg.cancel_scope.cancel()
+        finally:
+            if client is not None:
+                await client.aclose()
 
     async def test_receive_after_close(
         self, server_sock: socket.socket, socket_path: Path

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1449,15 +1449,22 @@ class TestUNIXStream:
                     await stream.receive()
 
     @pytest.mark.parametrize("anyio_backend", asyncio_params)
-    async def test_close_after_cancelled_receive(self, socket_path: Path) -> None:
+    @pytest.mark.parametrize("operation", ["receive", "send"])
+    async def test_close_after_cancelled_io(
+        self, socket_path: Path, operation: Literal["receive", "send"]
+    ) -> None:
         async def handler(stream: SocketStream) -> None:
-            async def receive() -> None:
-                # Closing may wake the receive before cancellation reaches it.
+            async def operate() -> None:
+                # Closing may wake the operation before cancellation reaches it.
                 with suppress(ClosedResourceError):
-                    await stream.receive()
+                    if operation == "receive":
+                        await stream.receive()
+                    else:
+                        while True:
+                            await stream.send(b"\0" * 4096)
 
             async with create_task_group() as tg:
-                tg.start_soon(receive)
+                tg.start_soon(operate)
                 try:
                     await sleep_forever()
                 finally:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1448,7 +1448,6 @@ class TestUNIXStream:
                 with pytest.raises(ClosedResourceError):
                     await stream.receive()
 
-    @pytest.mark.parametrize("anyio_backend", asyncio_params)
     @pytest.mark.parametrize("operation", ["receive", "send"])
     async def test_close_after_cancelled_io(
         self, socket_path: Path, operation: Literal["receive", "send"]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1267.

Only resolve the raw socket mixin's receive and send futures during close when they
are still pending. This prevents `InvalidStateError` when cancellation has already
completed a future but its cleanup callback has not run yet.

Add end-to-end regression coverage for cancelled UNIX stream reads and writes while
the owning server task closes the stream.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
