### PR TITLE
fix: Guard deprecated pytest CallSpec2 import

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -48,6 +48,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``UNIXSocketStream.aclose()`` raising ``asyncio.InvalidStateError`` when a
   concurrent receive or send operation had just been cancelled on the asyncio backend
   (`#1267 <https://github.com/agronholm/anyio/issues/1267>`_; PR by @alloutflo)
+- Fixed the pytest plugin importing the deprecated ``_pytest.python.CallSpec2`` alias,
+  which triggers ``PytestRemovedIn10Warning`` on ``pytest>=9.2`` and crashes pytest at
+  startup when ``filterwarnings = error`` is configured
+  (`#1271 <https://github.com/agronholm/anyio/issues/1271>`_; PR by @matthewfeickert)
 
 **4.14.2**
 

--- a/src/anyio/pytest_plugin.py
+++ b/src/anyio/pytest_plugin.py
@@ -6,12 +6,11 @@ import sys
 from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack, contextmanager
 from inspect import isasyncgenfunction, iscoroutinefunction, ismethod
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from _pytest.fixtures import FuncFixtureInfo, SubRequest
 from _pytest.outcomes import Exit
-from _pytest.python import CallSpec2
 from _pytest.scope import Scope
 
 from . import get_available_backends
@@ -26,6 +25,17 @@ from .abc import TestRunner
 
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
+
+if TYPE_CHECKING:
+    # pytest >= 9.2 keeps CallSpec2 as a TYPE_CHECKING-only alias of CallSpec
+    from _pytest.python import CallSpec2 as CallSpec
+else:
+    try:
+        # c.f. https://github.com/pytest-dev/pytest/pull/14742
+        # pytest >= 9.2
+        from _pytest.python import CallSpec
+    except ImportError:
+        from _pytest.python import CallSpec2 as CallSpec
 
 _current_runner: TestRunner | None = None
 _runner_stack: ExitStack | None = None
@@ -188,13 +198,13 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         ):
             new_items = []
             try:
-                cs_fields = {f.name for f in dataclasses.fields(CallSpec2)}
+                cs_fields = {f.name for f in dataclasses.fields(CallSpec)}
             except TypeError:
                 cs_fields = set()
 
             for param_index, backend in enumerate(get_available_backends()):
                 if "_arg2scope" in cs_fields:  # pytest >= 8
-                    callspec = CallSpec2(
+                    callspec = CallSpec(
                         params={"anyio_backend": backend},
                         indices={"anyio_backend": param_index},
                         _arg2scope={"anyio_backend": Scope.Module},
@@ -202,7 +212,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
                         marks=[],
                     )
                 else:  # pytest 7.x
-                    callspec = CallSpec2(  # type: ignore[call-arg]
+                    callspec = CallSpec(  # type: ignore[call-arg]
                         funcargs={},
                         params={"anyio_backend": backend},
                         indices={"anyio_backend": param_index},

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -822,3 +822,27 @@ def test_func_as_parametrize_param_name(testdir: Pytester) -> None:
 
     result = testdir.runpytest(*pytest_args)
     result.assert_outcomes(passed=len(get_available_backends()))
+
+
+def test_plugin_loads_with_filterwarnings_error(testdir: Pytester) -> None:
+    """
+    Regression test for Issue #1271: importing the plugin must not touch the
+    deprecated ``_pytest.python.CallSpec2`` alias, which crashes pytest at startup
+    on pytest >= 9.2 when ``filterwarnings = error`` is configured, as pytest applies
+    the ini filters while importing plugins.
+    """
+    testdir.makeini(
+        """
+        [pytest]
+        filterwarnings = error
+        """
+    )
+    testdir.makepyfile(
+        """
+        def test_ok():
+            assert True
+        """
+    )
+
+    result = testdir.runpytest_subprocess(*pytest_args)
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

* `pytest` `v9.2` renamed the private `_pytest.python.CallSpec2` to `CallSpec` (c.f. https://github.com/pytest-dev/pytest/pull/14742), keeping a module-level `__getattr__` alias that emits `PytestRemovedIn10Warning` on access and is scheduled for removal in `pytest` `v10`. As pytest now also applies the project's `filterwarnings` ini configuration while importing plugins (c.f. https://github.com/pytest-dev/pytest/pull/14776), any project with `anyio` installed and `filterwarnings = error` crashes at pytest startup before test collection begins.
* Import `CallSpec` when available, falling back to `CallSpec2` on `pytest<9.2`. The `TYPE_CHECKING` branch uses the `CallSpec2` name, which `pytest>=9.2` keeps as a type-checking-only alias, so `mypy` strict mode passes against both old and new pytest.
* Add fix summary to version history docs.

Fixes #1271.

Assisted-by: ClaudeCode:claude-fable-5

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [N/A] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

<!--
### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
-->