### PR TITLE
Make the custom thread limiter test deterministic

### DIFF
--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -19,7 +19,6 @@ from anyio import (
     Event,
     create_task_group,
     from_thread,
-    sleep,
     to_thread,
     wait_all_tasks_blocked,
 )
@@ -67,6 +66,9 @@ async def test_run_in_custom_limiter() -> None:
         nonlocal max_active_threads
         active_threads.add(threading.current_thread())
         max_active_threads = max(max_active_threads, len(active_threads))
+        if len(active_threads) == 3:
+            from_thread.run_sync(threads_started.set)
+
         event.wait(1)
         active_threads.remove(threading.current_thread())
 
@@ -74,13 +76,14 @@ async def test_run_in_custom_limiter() -> None:
         await to_thread.run_sync(thread_worker, limiter=limiter)
 
     event = threading.Event()
+    threads_started = Event()
     limiter = CapacityLimiter(3)
     active_threads: set[threading.Thread] = set()
     async with create_task_group() as tg:
         for _ in range(4):
             tg.start_soon(task_worker)
 
-        await sleep(0.1)
+        await threads_started.wait()
         assert len(active_threads) == 3
         assert limiter.borrowed_tokens == 3
         event.set()

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -69,7 +69,7 @@ async def test_run_in_custom_limiter() -> None:
         if len(active_threads) == 3:
             from_thread.run_sync(threads_started.set)
 
-        event.wait(1)
+        event.wait(10)
         active_threads.remove(threading.current_thread())
 
     async def task_worker() -> None:


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes the timing failure observed in https://github.com/agronholm/anyio/pull/1275.

Make `test_run_in_custom_limiter` wait for the third worker to enter before asserting limiter state. The test previously used a fixed delay, which can expire before the third worker is scheduled on free-threaded Python. The event preserves the assertion that a `CapacityLimiter(3)` permits exactly three concurrent workers without depending on scheduler timing.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] Documentation is not applicable to this test-only change
- [x] A changelog entry is not applicable to this test-only change

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
