### PR TITLE
docs: minimum Python is 3.10, not 3.8

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -3,7 +3,7 @@ The basics
 
 .. py:currentmodule:: anyio
 
-AnyIO requires Python 3.8 or later to run. It is recommended that you set up a
+AnyIO requires Python 3.10 or later to run. It is recommended that you set up a
 virtualenv_ when developing or playing around with AnyIO.
 
 Installation


### PR DESCRIPTION
The installation section of `docs/basics.rst` says:

> AnyIO requires Python 3.8 or later to run.

but `pyproject.toml` has `requires-python = ">= 3.10"`, so `pip` refuses to install AnyIO on 3.8 or 3.9 with a `Requires-Python` error. The version history records both drops (3.8 in 4.6.0, 3.9 afterwards), so 3.10 is the current floor.

One-line docs fix so the install page matches what the package actually accepts. The version-history mentions of 3.8/3.9 are historical and correct as written; only the current-tense "requires" line was stale.