### PR TITLE
Add missing keyword-only arguments to anyio.Path methods

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,9 +6,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 **UNRELEASED**
 
 - Added support for the newer keyword-only arguments on ``anyio.Path`` methods to match
-  the standard library ``pathlib.Path``: ``follow_symlinks`` on ``exists()`` (Python
-  3.12+), ``follow_symlinks`` on ``is_dir()`` and ``is_file()`` (Python 3.13+), and
-  ``newline`` on ``read_text()`` (Python 3.13+)
+  the standard library ``pathlib.Path``:
+  
+  * ``follow_symlinks`` on ``exists()`` (Python 3.12+)
+  * ``follow_symlinks`` on ``is_dir()`` (Python 3.13+)
+  * ``follow_symlinks`` on ``is_file()`` (Python 3.13+)
+  * ``newline`` on ``read_text()`` (Python 3.13+)
   (`#1286 <https://github.com/agronholm/anyio/pull/1286>`_; PR by @jaideeppyne)
 - Added ``amap``, ``gather``, and ``as_completed`` utility functions to simplify common
   patterns (`#1173 <https://github.com/agronholm/anyio/pull/1173>`_; PR by @Graeme22)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -12,6 +12,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   * ``follow_symlinks`` on ``is_dir()`` (Python 3.13+)
   * ``follow_symlinks`` on ``is_file()`` (Python 3.13+)
   * ``newline`` on ``read_text()`` (Python 3.13+)
+
   (`#1286 <https://github.com/agronholm/anyio/pull/1286>`_; PR by @jaideeppyne)
 - Added ``amap``, ``gather``, and ``as_completed`` utility functions to simplify common
   patterns (`#1173 <https://github.com/agronholm/anyio/pull/1173>`_; PR by @Graeme22)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,7 +7,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Added support for the newer keyword-only arguments on ``anyio.Path`` methods to match
   the standard library ``pathlib.Path``:
-  
+
   * ``follow_symlinks`` on ``exists()`` (Python 3.12+)
   * ``follow_symlinks`` on ``is_dir()`` (Python 3.13+)
   * ``follow_symlinks`` on ``is_file()`` (Python 3.13+)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Added support for the newer keyword-only arguments on ``anyio.Path`` methods to match
+  the standard library ``pathlib.Path``: ``follow_symlinks`` on ``exists()`` (Python
+  3.12+), ``follow_symlinks`` on ``is_dir()`` and ``is_file()`` (Python 3.13+), and
+  ``newline`` on ``read_text()`` (Python 3.13+)
+  (`#1286 <https://github.com/agronholm/anyio/pull/1286>`_; PR by @jaideeppyne)
 - Added ``amap``, ``gather``, and ``as_completed`` utility functions to simplify common
   patterns (`#1173 <https://github.com/agronholm/anyio/pull/1173>`_; PR by @Graeme22)
 - Added ``--anyio-mode`` command-line option as an alternative to the ``anyio_mode``

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -575,10 +575,21 @@ class Path:
         path = await to_thread.run_sync(pathlib.Path.cwd, limiter=limiter)
         return cls(path, limiter=limiter)
 
-    async def exists(self) -> bool:
-        return await to_thread.run_sync(
-            self._path.exists, abandon_on_cancel=True, limiter=self._limiter
-        )
+    if sys.version_info >= (3, 12):
+
+        async def exists(self, *, follow_symlinks: bool = True) -> bool:
+            return await to_thread.run_sync(
+                partial(self._path.exists, follow_symlinks=follow_symlinks),
+                abandon_on_cancel=True,
+                limiter=self._limiter,
+            )
+
+    else:
+
+        async def exists(self) -> bool:
+            return await to_thread.run_sync(
+                self._path.exists, abandon_on_cancel=True, limiter=self._limiter
+            )
 
     async def expanduser(self) -> Self:
         return type(self)(
@@ -653,20 +664,42 @@ class Path:
             self._path.is_char_device, abandon_on_cancel=True, limiter=self._limiter
         )
 
-    async def is_dir(self) -> bool:
-        return await to_thread.run_sync(
-            self._path.is_dir, abandon_on_cancel=True, limiter=self._limiter
-        )
+    if sys.version_info >= (3, 13):
+
+        async def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+            return await to_thread.run_sync(
+                partial(self._path.is_dir, follow_symlinks=follow_symlinks),
+                abandon_on_cancel=True,
+                limiter=self._limiter,
+            )
+
+    else:
+
+        async def is_dir(self) -> bool:
+            return await to_thread.run_sync(
+                self._path.is_dir, abandon_on_cancel=True, limiter=self._limiter
+            )
 
     async def is_fifo(self) -> bool:
         return await to_thread.run_sync(
             self._path.is_fifo, abandon_on_cancel=True, limiter=self._limiter
         )
 
-    async def is_file(self) -> bool:
-        return await to_thread.run_sync(
-            self._path.is_file, abandon_on_cancel=True, limiter=self._limiter
-        )
+    if sys.version_info >= (3, 13):
+
+        async def is_file(self, *, follow_symlinks: bool = True) -> bool:
+            return await to_thread.run_sync(
+                partial(self._path.is_file, follow_symlinks=follow_symlinks),
+                abandon_on_cancel=True,
+                limiter=self._limiter,
+            )
+
+    else:
+
+        async def is_file(self) -> bool:
+            return await to_thread.run_sync(
+                self._path.is_file, abandon_on_cancel=True, limiter=self._limiter
+            )
 
     if sys.version_info >= (3, 12):
 
@@ -771,12 +804,30 @@ class Path:
     async def read_bytes(self) -> bytes:
         return await to_thread.run_sync(self._path.read_bytes, limiter=self._limiter)
 
-    async def read_text(
-        self, encoding: str | None = None, errors: str | None = None
-    ) -> str:
-        return await to_thread.run_sync(
-            self._path.read_text, encoding, errors, limiter=self._limiter
-        )
+    if sys.version_info >= (3, 13):
+
+        async def read_text(
+            self,
+            encoding: str | None = None,
+            errors: str | None = None,
+            newline: str | None = None,
+        ) -> str:
+            return await to_thread.run_sync(
+                self._path.read_text,
+                encoding,
+                errors,
+                newline,
+                limiter=self._limiter,
+            )
+
+    else:
+
+        async def read_text(
+            self, encoding: str | None = None, errors: str | None = None
+        ) -> str:
+            return await to_thread.run_sync(
+                self._path.read_text, encoding, errors, limiter=self._limiter
+            )
 
     if sys.version_info >= (3, 12):
 

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -347,6 +347,50 @@ class TestPath:
 
     @pytest.mark.skipif(
         sys.version_info < (3, 12),
+        reason="Path.exists(follow_symlinks=...) is only available on Python 3.12+",
+    )
+    async def test_exists_follow_symlinks(self, tmp_path: pathlib.Path) -> None:
+        link = tmp_path / "link"
+        link.symlink_to(tmp_path / "missing")
+        assert await Path(link).exists(follow_symlinks=False)
+        assert not await Path(link).exists(follow_symlinks=True)
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 13),
+        reason="Path.is_file(follow_symlinks=...) is only available on Python 3.13+",
+    )
+    async def test_is_file_follow_symlinks(self, tmp_path: pathlib.Path) -> None:
+        target = tmp_path / "target"
+        target.touch()
+        link = tmp_path / "link"
+        link.symlink_to(target)
+        assert await Path(link).is_file(follow_symlinks=True)
+        assert not await Path(link).is_file(follow_symlinks=False)
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 13),
+        reason="Path.is_dir(follow_symlinks=...) is only available on Python 3.13+",
+    )
+    async def test_is_dir_follow_symlinks(self, tmp_path: pathlib.Path) -> None:
+        target = tmp_path / "target"
+        target.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(target, target_is_directory=True)
+        assert await Path(link).is_dir(follow_symlinks=True)
+        assert not await Path(link).is_dir(follow_symlinks=False)
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 13),
+        reason="Path.read_text(newline=...) is only available on Python 3.13+",
+    )
+    async def test_read_text_newline(self, tmp_path: pathlib.Path) -> None:
+        path = tmp_path / "textfile"
+        path.write_bytes(b"a\r\nb")
+        assert await Path(path).read_text(newline="") == "a\r\nb"
+        assert await Path(path).read_text() == "a\nb"
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 12),
         reason="Path.is_junction() is only available on Python 3.12+",
     )
     async def test_is_junction(self, tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
## Changes

`anyio.Path` aims to be a drop-in async mirror of `pathlib.Path`, but a few keyword-only arguments that CPython added in recent versions were missing, so passing them raised `TypeError`. This adds them, gated by `sys.version_info` so older interpreters keep the exact original signatures:

| Method | Argument | Added in stdlib |
|--------|----------|-----------------|
| `exists()` | `follow_symlinks` | Python 3.12 |
| `is_dir()` | `follow_symlinks` | Python 3.13 |
| `is_file()` | `follow_symlinks` | Python 3.13 |
| `read_text()` | `newline` | Python 3.13 |

Before this change, on Python 3.13:

```python
>>> await anyio.Path("link").is_file(follow_symlinks=False)
TypeError: Path.is_file() got an unexpected keyword argument 'follow_symlinks'
```

The new keyword arguments are forwarded to the underlying `pathlib.Path` call (via `partial`/`run_sync`), so the semantics match the standard library exactly.

## Tests

Added regression tests in `tests/test_fileio.py` covering each new argument, each guarded with the appropriate `skipif(sys.version_info < ...)`. They fail on `master` (with `TypeError`) and pass with this change. The existing `test_fileio.py` suite continues to pass, and `ruff check`, `ruff format`, and `mypy` are clean.

A changelog entry has been added under **UNRELEASED**.

---

🤖 This PR was prepared with the assistance of Claude Code.