### PR TITLE
Fixed socket aclose() delayed close, missing checkpoint and Windows hang

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -78,6 +78,15 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``CapacityLimiter`` on the asyncio backend over-granting tokens when
   ``total_tokens`` was raised while the limiter was over-subscribed
   (`#1223 <https://github.com/agronholm/anyio/pull/1223>`_; PR by @zelinewang)
+- Fixed UDP socket closing hanging on Windows if a datagram send was still in flight
+  (`#1237 <https://github.com/agronholm/anyio/issues/1237>`_; PR by @graingert)
+- Fixed concurrent ``aclose_forcefully()`` calls on asyncio socket streams returning
+  before the underlying socket was closed
+  (`#1273 <https://github.com/agronholm/anyio/issues/1273>`_; PR by @graingert)
+- Fixed ``aclose()`` on sockets not checkpointing, and thus failing to raise a
+  cancellation exception when called inside a cancelled scope (affected UNIX socket
+  streams and UNIX datagram sockets on asyncio, and all sockets on Trio)
+  (`#1288 <https://github.com/agronholm/anyio/issues/1288>`_; PR by @graingert)
 
 **4.14.2**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1290,20 +1290,17 @@ class DatagramProtocol(asyncio.DatagramProtocol):
     read_queue: deque[tuple[bytes, IPSockAddrType]]
     read_event: asyncio.Event
     write_event: asyncio.Event
-    closed_event: asyncio.Event
     exception: Exception | None = None
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.read_queue = deque(maxlen=100)  # arbitrary value
         self.read_event = asyncio.Event()
         self.write_event = asyncio.Event()
-        self.closed_event = asyncio.Event()
         self.write_event.set()
 
     def connection_lost(self, exc: Exception | None) -> None:
         self.read_event.set()
         self.write_event.set()
-        self.closed_event.set()
 
     def datagram_received(self, data: bytes, addr: IPSockAddrType) -> None:
         addr = convert_ipv6_sockaddr(addr)
@@ -1397,15 +1394,8 @@ class SocketStream(abc.SocketStream):
 
     async def aclose(self) -> None:
         self._closed = True
-        if not self._transport.is_closing():
-            try:
-                self._transport.write_eof()
-            except OSError:
-                pass
-
-            self._transport.close()
-            await sleep(0)
-            self._transport.abort()
+        self._transport.abort()
+        await AsyncIOBackend.checkpoint()
 
 
 class _RawSocketMixin:
@@ -1443,15 +1433,16 @@ class _RawSocketMixin:
         return f
 
     async def aclose(self) -> None:
-        if not self._closing:
-            self._closing = True
-            if self.__raw_socket.fileno() != -1:
-                self.__raw_socket.close()
-
+        closing = self._closing
+        self._closing = True
+        self.__raw_socket.close()
+        if not closing:
             if self._receive_future and not self._receive_future.done():
                 self._receive_future.set_result(None)
             if self._send_future and not self._send_future.done():
                 self._send_future.set_result(None)
+
+        await AsyncIOBackend.checkpoint()
 
 
 class UNIXSocketStream(_RawSocketMixin, abc.UNIXSocketStream):
@@ -1664,6 +1655,7 @@ class UNIXSocketListener(abc.SocketListener):
     async def aclose(self) -> None:
         self._closed = True
         self.__raw_socket.close()
+        await AsyncIOBackend.checkpoint()
 
     @property
     def _raw_socket(self) -> socket.socket:
@@ -1686,10 +1678,8 @@ class UDPSocket(abc.UDPSocket):
 
     async def aclose(self) -> None:
         self._closed = True
-        if not self._transport.is_closing():
-            self._transport.close()
-
-        await self._protocol.closed_event.wait()
+        self._transport.abort()
+        await AsyncIOBackend.checkpoint()
 
     async def receive(self) -> tuple[bytes, IPSockAddrType]:
         with self._receive_guard:
@@ -1736,10 +1726,8 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
 
     async def aclose(self) -> None:
         self._closed = True
-        if not self._transport.is_closing():
-            self._transport.close()
-
-        await self._protocol.closed_event.wait()
+        self._transport.abort()
+        await AsyncIOBackend.checkpoint()
 
     async def receive(self) -> bytes:
         with self._receive_guard:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -463,9 +463,9 @@ class _TrioSocketMixin(Generic[T_SockAddr]):
         return self._trio_socket._sock  # type: ignore[attr-defined]
 
     async def aclose(self) -> None:
-        if self._trio_socket.fileno() >= 0:
-            self._closed = True
-            self._trio_socket.close()
+        self._closed = True
+        self._trio_socket.close()
+        await trio.lowlevel.checkpoint()
 
     def _convert_socket_error(self, exc: BaseException) -> NoReturn:
         if isinstance(exc, trio.ClosedResourceError):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -37,12 +37,14 @@ from pytest_mock.plugin import MockerFixture
 from anyio import (
     BrokenResourceError,
     BusyResourceError,
+    CancelScope,
     ClosedResourceError,
     EndOfStream,
     Event,
     TCPConnectable,
     TypedAttributeLookupError,
     UNIXConnectable,
+    aclose_forcefully,
     as_connectable,
     connect_tcp,
     connect_unix,
@@ -54,6 +56,7 @@ from anyio import (
     create_unix_datagram_socket,
     create_unix_listener,
     fail_after,
+    get_cancelled_exc_class,
     getaddrinfo,
     getnameinfo,
     move_on_after,
@@ -507,6 +510,46 @@ class TestTCPStream:
                 tg.start_soon(interrupt)
                 with pytest.raises(ClosedResourceError):
                     await stream.receive()
+
+    async def test_aclose_forcefully(self, server_addr: tuple[str, int]) -> None:
+        stream = await connect_tcp(*server_addr)
+        sock = stream.extra(SocketAttribute.raw_socket)
+        await stream.send(b"x")
+        await aclose_forcefully(stream)
+        assert sock.fileno() == -1
+
+    async def test_concurrent_aclose_forcefully_returns_before_socket_closes(
+        self, server_addr: tuple[str, int]
+    ) -> None:
+        stream = await connect_tcp(*server_addr)
+        raw_socket = stream.extra(SocketAttribute.raw_socket)
+        fds: list[int] = []
+
+        async def do_aclose() -> None:
+            await aclose_forcefully(stream)
+            fds.append(raw_socket.fileno())
+
+        async with create_task_group() as tg:
+            tg.start_soon(do_aclose)
+            tg.start_soon(do_aclose)
+
+        assert fds == [-1, -1]
+
+    async def test_aclose_in_cancelled_scope_raises_cancelled_exc(
+        self, server_addr: tuple[str, int]
+    ) -> None:
+        exc = None
+        stream = await connect_tcp(*server_addr)
+
+        with CancelScope() as scope:
+            scope.cancel()
+            try:
+                await stream.aclose()
+            except get_cancelled_exc_class() as e:
+                exc = e
+                raise
+
+        assert exc is not None
 
     async def test_receive_after_close(self, server_addr: tuple[str, int]) -> None:
         stream = await connect_tcp(*server_addr)
@@ -1499,6 +1542,39 @@ class TestUNIXStream:
             if client is not None:
                 await client.aclose()
 
+    async def test_concurrent_aclose_forcefully_returns_before_socket_closes(
+        self, server_sock: socket.socket, socket_path: Path
+    ) -> None:
+        stream = await connect_unix(socket_path)
+        raw_socket = stream.extra(SocketAttribute.raw_socket)
+        fds: list[int] = []
+
+        async def do_aclose() -> None:
+            await aclose_forcefully(stream)
+            fds.append(raw_socket.fileno())
+
+        async with create_task_group() as tg:
+            tg.start_soon(do_aclose)
+            tg.start_soon(do_aclose)
+
+        assert fds == [-1, -1]
+
+    async def test_aclose_in_cancelled_scope_raises_cancelled_exc(
+        self, server_sock: socket.socket, socket_path: Path
+    ) -> None:
+        exc = None
+        stream = await connect_unix(socket_path)
+
+        with CancelScope() as scope:
+            scope.cancel()
+            try:
+                await stream.aclose()
+            except get_cancelled_exc_class() as e:
+                exc = e
+                raise
+
+        assert exc is not None
+
     async def test_receive_after_close(
         self, server_sock: socket.socket, socket_path: Path
     ) -> None:
@@ -1797,6 +1873,15 @@ class TestUDPSocket:
             udp = await UDPSocket.from_socket(sock)
             await udp.aclose()
 
+    async def test_aclose_during_send(self, free_udp_port: int) -> None:
+        udp = await create_udp_socket(local_host="127.0.0.1")
+        sock = udp.extra(SocketAttribute.raw_socket)
+        await udp.sendto(b"x", "127.0.0.1", free_udp_port)
+        with fail_after(1):
+            await aclose_forcefully(udp)
+
+        assert sock.fileno() == -1
+
     async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:
         async with await create_udp_socket(
             family=family, local_host="localhost"
@@ -1902,6 +1987,41 @@ class TestUDPSocket:
             with pytest.raises(ClosedResourceError):
                 await udp.receive()
 
+    async def test_concurrent_aclose_forcefully_returns_before_socket_closes(
+        self,
+    ) -> None:
+        udp = await create_udp_socket(
+            family=AddressFamily.AF_INET, local_host="localhost"
+        )
+        raw_socket = udp.extra(SocketAttribute.raw_socket)
+        fds: list[int] = []
+
+        async def do_aclose() -> None:
+            await aclose_forcefully(udp)
+            fds.append(raw_socket.fileno())
+
+        async with create_task_group() as tg:
+            tg.start_soon(do_aclose)
+            tg.start_soon(do_aclose)
+
+        assert fds == [-1, -1]
+
+    async def test_aclose_in_cancelled_scope_raises_cancelled_exc(self) -> None:
+        exc = None
+        udp = await create_udp_socket(
+            family=AddressFamily.AF_INET, local_host="localhost"
+        )
+
+        with CancelScope() as scope:
+            scope.cancel()
+            try:
+                await udp.aclose()
+            except get_cancelled_exc_class() as e:
+                exc = e
+                raise
+
+        assert exc is not None
+
     async def test_receive_after_close(self) -> None:
         udp = await create_udp_socket(
             family=AddressFamily.AF_INET, local_host="localhost"
@@ -1973,6 +2093,12 @@ class TestConnectedUDPSocket:
                 await udp.aclose()
         finally:
             peer.close()
+
+    async def test_aclose_during_send(self, free_udp_port: int) -> None:
+        udp = await create_connected_udp_socket("127.0.0.1", free_udp_port)
+        await udp.send(b"x")
+        with fail_after(1):
+            await udp.aclose()
 
     async def test_extra_attributes(self, family: AnyIPAddressFamily) -> None:
         async with await create_connected_udp_socket(
@@ -2084,6 +2210,43 @@ class TestConnectedUDPSocket:
             tg.start_soon(close_when_blocked)
             with pytest.raises(ClosedResourceError):
                 await udp.receive()
+
+    async def test_concurrent_aclose_forcefully_returns_before_socket_closes(
+        self, family: AnyIPAddressFamily
+    ) -> None:
+        udp = await create_connected_udp_socket(
+            "localhost", 5000, local_host="localhost", family=family
+        )
+        raw_socket = udp.extra(SocketAttribute.raw_socket)
+        fds: list[int] = []
+
+        async def do_aclose() -> None:
+            await aclose_forcefully(udp)
+            fds.append(raw_socket.fileno())
+
+        async with create_task_group() as tg:
+            tg.start_soon(do_aclose)
+            tg.start_soon(do_aclose)
+
+        assert fds == [-1, -1]
+
+    async def test_aclose_in_cancelled_scope_raises_cancelled_exc(
+        self, family: AnyIPAddressFamily
+    ) -> None:
+        exc = None
+        udp = await create_connected_udp_socket(
+            "localhost", 5000, local_host="localhost", family=family
+        )
+
+        with CancelScope() as scope:
+            scope.cancel()
+            try:
+                await udp.aclose()
+            except get_cancelled_exc_class() as e:
+                exc = e
+                raise
+
+        assert exc is not None
 
     async def test_receive_after_close(self, family: AnyIPAddressFamily) -> None:
         udp = await create_connected_udp_socket(
@@ -2242,6 +2405,39 @@ class TestUNIXDatagramSocket:
                 tg.start_soon(close_when_blocked)
                 with pytest.raises(ClosedResourceError):
                     await unix_dg.receive()
+
+    async def test_concurrent_aclose_forcefully_returns_before_socket_closes(
+        self,
+    ) -> None:
+        unix_dg = await create_unix_datagram_socket()
+        raw_socket = unix_dg.extra(SocketAttribute.raw_socket)
+        fds: list[int] = []
+
+        async def do_aclose() -> None:
+            await aclose_forcefully(unix_dg)
+            fds.append(raw_socket.fileno())
+
+        async with create_task_group() as tg:
+            tg.start_soon(do_aclose)
+            tg.start_soon(do_aclose)
+
+        assert fds == [-1, -1]
+
+    async def test_aclose_in_cancelled_scope_raises_cancelled_exc(
+        self,
+    ) -> None:
+        exc = None
+        unix_dg = await create_unix_datagram_socket()
+
+        with CancelScope() as scope:
+            scope.cancel()
+            try:
+                await unix_dg.aclose()
+            except get_cancelled_exc_class() as e:
+                exc = e
+                raise
+
+        assert exc is not None
 
     async def test_receive_after_close(self) -> None:
         unix_dg = await create_unix_datagram_socket()
@@ -2446,6 +2642,39 @@ class TestConnectedUNIXDatagramSocket:
             tg.start_soon(close_when_blocked)
             with pytest.raises(ClosedResourceError):
                 await udp.receive()
+
+    async def test_concurrent_aclose_forcefully_returns_before_socket_closes(
+        self, peer_socket_path_or_str: Path | str, peer_sock: socket.socket
+    ) -> None:
+        udp = await create_connected_unix_datagram_socket(peer_socket_path_or_str)
+        raw_socket = udp.extra(SocketAttribute.raw_socket)
+        fds: list[int] = []
+
+        async def do_aclose() -> None:
+            await aclose_forcefully(udp)
+            fds.append(raw_socket.fileno())
+
+        async with create_task_group() as tg:
+            tg.start_soon(do_aclose)
+            tg.start_soon(do_aclose)
+
+        assert fds == [-1, -1]
+
+    async def test_aclose_in_cancelled_scope_raises_cancelled_exc(
+        self, peer_socket_path_or_str: Path | str, peer_sock: socket.socket
+    ) -> None:
+        exc = None
+        udp = await create_connected_unix_datagram_socket(peer_socket_path_or_str)
+
+        with CancelScope() as scope:
+            scope.cancel()
+            try:
+                await udp.aclose()
+            except get_cancelled_exc_class() as e:
+                exc = e
+                raise
+
+        assert exc is not None
 
     async def test_receive_after_close(
         self, peer_socket_path_or_str: Path | str, peer_sock: socket.socket


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1237. Fixes #1273. Fixes #1288.

Socket `aclose()` implementations had three related problems.

On the asyncio backend, `SocketStream`, `UDPSocket` and `ConnectedUDPSocket` closed
through `transport.close()`, which only *schedules* the FD-closing `connection_lost`
callback via `loop.call_soon`. A second, concurrent `aclose()` — as
`aclose_forcefully()` can produce — therefore returned while the socket was still open,
and on Windows closing a UDP socket with a datagram still in flight could hang outright.
All three now `abort()` the transport directly, which also makes
`DatagramProtocol.closed_event` unnecessary.

None of the implementations checkpointed either, so `aclose()` called inside an
already-cancelled scope returned normally instead of raising a cancellation exception.
This affected UNIX socket streams and UNIX datagram sockets on asyncio, and every socket
type on Trio.

`_RawSocketMixin.aclose()` now always closes the raw socket and checkpoints, while still
resolving pending receive and send futures only on the first call, so a task blocked in
`receive()` or `send()` is woken exactly once.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.
