### PR TITLE
Ensure socket aclose checkpoints after closing

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -68,6 +68,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``UNIXSocketStream.aclose()`` raising ``asyncio.InvalidStateError`` when a
   concurrent receive or send operation had just been cancelled on the asyncio backend
   (`#1267 <https://github.com/agronholm/anyio/issues/1267>`_; PR by @alloutflo)
+- Fixed socket ``aclose()`` implementations not checkpointing after closing on the
+  asyncio and Trio backends
+  (`#1288 <https://github.com/agronholm/anyio/issues/1288>`_; PR by @hansu650)
 - Fixed the pytest plugin importing the deprecated ``_pytest.python.CallSpec2`` alias,
   which triggers ``PytestRemovedIn10Warning`` on ``pytest>=9.2`` and crashes pytest at
   startup when ``filterwarnings = error`` is configured

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1453,6 +1453,8 @@ class _RawSocketMixin:
             if self._send_future and not self._send_future.done():
                 self._send_future.set_result(None)
 
+        await AsyncIOBackend.checkpoint()
+
 
 class UNIXSocketStream(_RawSocketMixin, abc.UNIXSocketStream):
     async def send_eof(self) -> None:

--- a/src/anyio/_backends/_trio.py
+++ b/src/anyio/_backends/_trio.py
@@ -467,6 +467,8 @@ class _TrioSocketMixin(Generic[T_SockAddr]):
             self._closed = True
             self._trio_socket.close()
 
+        await trio.lowlevel.checkpoint()
+
     def _convert_socket_error(self, exc: BaseException) -> NoReturn:
         if isinstance(exc, trio.ClosedResourceError):
             raise ClosedResourceError from exc

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -37,6 +37,7 @@ from pytest_mock.plugin import MockerFixture
 from anyio import (
     BrokenResourceError,
     BusyResourceError,
+    CancelScope,
     ClosedResourceError,
     EndOfStream,
     Event,
@@ -54,6 +55,7 @@ from anyio import (
     create_unix_datagram_socket,
     create_unix_listener,
     fail_after,
+    get_cancelled_exc_class,
     getaddrinfo,
     getnameinfo,
     move_on_after,
@@ -1498,6 +1500,19 @@ class TestUNIXStream:
         finally:
             if client is not None:
                 await client.aclose()
+
+    async def test_aclose_checkpoints_when_cancelled(
+        self, server_sock: socket.socket, socket_path: Path
+    ) -> None:
+        stream = await connect_unix(socket_path)
+        raw_socket = stream.extra(SocketAttribute.raw_socket)
+
+        with CancelScope() as scope:
+            scope.cancel()
+            with pytest.raises(get_cancelled_exc_class()):
+                await stream.aclose()
+
+        assert raw_socket.fileno() == -1
 
     async def test_receive_after_close(
         self, server_sock: socket.socket, socket_path: Path


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1288.

Add cancellation checkpoints after closing raw sockets in the asyncio and Trio
backends. This ensures that `aclose()` both releases the socket and delivers pending
cancellation. The regression test verifies both outcomes.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features (not applicable: this restores the expected cancellation checkpoint)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.