### PR TITLE
Add follow_symlinks argument to anyio.Path.owner() and group()

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -14,6 +14,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   * ``newline`` on ``read_text()`` (Python 3.13+)
 
   (`#1286 <https://github.com/agronholm/anyio/pull/1286>`_; PR by @jaideeppyne)
+- Added the ``follow_symlinks`` keyword-only argument to ``anyio.Path.owner()`` and
+  ``anyio.Path.group()`` (Python 3.13+) to match the standard library ``pathlib.Path``.
+  Previously these were rejected with ``TypeError``
+  (`#XXXX <https://github.com/agronholm/anyio/pull/XXXX>`_; PR by @jaideeppyne)
 - Added ``amap``, ``gather``, and ``as_completed`` utility functions to simplify common
   patterns (`#1173 <https://github.com/agronholm/anyio/pull/1173>`_; PR by @Graeme22)
 - Added ``--anyio-mode`` command-line option as an alternative to the ``anyio_mode``

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -17,7 +17,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Added the ``follow_symlinks`` keyword-only argument to ``anyio.Path.owner()`` and
   ``anyio.Path.group()`` (Python 3.13+) to match the standard library ``pathlib.Path``.
   Previously these were rejected with ``TypeError``
-  (`#XXXX <https://github.com/agronholm/anyio/pull/XXXX>`_; PR by @jaideeppyne)
+  (`#1293 <https://github.com/agronholm/anyio/pull/1293>`_; PR by @jaideeppyne)
 - Added ``amap``, ``gather``, and ``as_completed`` utility functions to simplify common
   patterns (`#1173 <https://github.com/agronholm/anyio/pull/1173>`_; PR by @Graeme22)
 - Added ``--anyio-mode`` command-line option as an alternative to the ``anyio_mode``

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,13 +11,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   * ``follow_symlinks`` on ``exists()`` (Python 3.12+)
   * ``follow_symlinks`` on ``is_dir()`` (Python 3.13+)
   * ``follow_symlinks`` on ``is_file()`` (Python 3.13+)
+  * ``follow_symlinks`` on ``owner()`` (Python 3.13+)
+  * ``follow_symlinks`` on ``group()`` (Python 3.13+)
   * ``newline`` on ``read_text()`` (Python 3.13+)
 
-  (`#1286 <https://github.com/agronholm/anyio/pull/1286>`_; PR by @jaideeppyne)
-- Added the ``follow_symlinks`` keyword-only argument to ``anyio.Path.owner()`` and
-  ``anyio.Path.group()`` (Python 3.13+) to match the standard library ``pathlib.Path``.
-  Previously these were rejected with ``TypeError``
-  (`#1293 <https://github.com/agronholm/anyio/pull/1293>`_; PR by @jaideeppyne)
+  (`#1286 <https://github.com/agronholm/anyio/pull/1286>`_,
+  `#1293 <https://github.com/agronholm/anyio/pull/1293>`_; PR by @jaideeppyne)
 - Added ``amap``, ``gather``, and ``as_completed`` utility functions to simplify common
   patterns (`#1173 <https://github.com/agronholm/anyio/pull/1173>`_; PR by @Graeme22)
 - Added ``--anyio-mode`` command-line option as an alternative to the ``anyio_mode``

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -633,10 +633,21 @@ class Path:
             )
             return _PathIterator(gen, self._limiter, type(self))
 
-    async def group(self) -> str:
-        return await to_thread.run_sync(
-            self._path.group, abandon_on_cancel=True, limiter=self._limiter
-        )
+    if sys.version_info >= (3, 13):
+
+        async def group(self, *, follow_symlinks: bool = True) -> str:
+            return await to_thread.run_sync(
+                partial(self._path.group, follow_symlinks=follow_symlinks),
+                abandon_on_cancel=True,
+                limiter=self._limiter,
+            )
+
+    else:
+
+        async def group(self) -> str:
+            return await to_thread.run_sync(
+                self._path.group, abandon_on_cancel=True, limiter=self._limiter
+            )
 
     async def hardlink_to(
         self, target: str | bytes | PathLike[str] | PathLike[bytes]
@@ -796,10 +807,21 @@ class Path:
         )
         return AsyncFile(fp, limiter=self._limiter)
 
-    async def owner(self) -> str:
-        return await to_thread.run_sync(
-            self._path.owner, abandon_on_cancel=True, limiter=self._limiter
-        )
+    if sys.version_info >= (3, 13):
+
+        async def owner(self, *, follow_symlinks: bool = True) -> str:
+            return await to_thread.run_sync(
+                partial(self._path.owner, follow_symlinks=follow_symlinks),
+                abandon_on_cancel=True,
+                limiter=self._limiter,
+            )
+
+    else:
+
+        async def owner(self) -> str:
+            return await to_thread.run_sync(
+                self._path.owner, abandon_on_cancel=True, limiter=self._limiter
+            )
 
     async def read_bytes(self) -> bytes:
         return await to_thread.run_sync(self._path.read_bytes, limiter=self._limiter)

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -713,6 +713,24 @@ class TestPath:
         group_name = grp.getgrgid(os.getegid()).gr_name
         assert await Path(tmp_path).group() == group_name
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="owner and group are not supported on Windows",
+    )
+    @pytest.mark.skipif(
+        sys.version_info < (3, 13),
+        reason="Path.group(follow_symlinks=...) is only available on Python 3.13+",
+    )
+    async def test_group_follow_symlinks(self, tmp_path: pathlib.Path) -> None:
+        import grp
+
+        group_name = grp.getgrgid(os.getegid()).gr_name
+        link = tmp_path / "link"
+        link.symlink_to(tmp_path / "missing")
+        assert await Path(link).group(follow_symlinks=False) == group_name
+        with pytest.raises(FileNotFoundError):
+            await Path(link).group(follow_symlinks=True)
+
     async def test_mkdir(self, tmp_path: pathlib.Path) -> None:
         path = tmp_path / "testdir"
         await Path(path).mkdir()
@@ -738,6 +756,24 @@ class TestPath:
 
         user_name = pwd.getpwuid(os.geteuid()).pw_name
         assert await Path(tmp_path).owner() == user_name
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="owner and group are not supported on Windows",
+    )
+    @pytest.mark.skipif(
+        sys.version_info < (3, 13),
+        reason="Path.owner(follow_symlinks=...) is only available on Python 3.13+",
+    )
+    async def test_owner_follow_symlinks(self, tmp_path: pathlib.Path) -> None:
+        import pwd
+
+        user_name = pwd.getpwuid(os.geteuid()).pw_name
+        link = tmp_path / "link"
+        link.symlink_to(tmp_path / "missing")
+        assert await Path(link).owner(follow_symlinks=False) == user_name
+        with pytest.raises(FileNotFoundError):
+            await Path(link).owner(follow_symlinks=True)
 
     @pytest.mark.skipif(
         platform.system() == "Windows",


### PR DESCRIPTION
Follow-up to #1286. `pathlib.Path.owner()` and `pathlib.Path.group()` gained a keyword-only `follow_symlinks` argument in Python 3.13, but `anyio.Path` didn't expose it, so passing it raised `TypeError`. #1286 added the newer keyword-only arguments for `exists()`/`is_dir()`/`is_file()`/`read_text()`, but `owner()`/`group()` were the two remaining methods that also gained `follow_symlinks` in 3.13.

This mirrors the existing version-gated pattern used for `is_dir()`/`is_file()`: on Python 3.13+ the argument is forwarded to the underlying `pathlib` method; on older interpreters the original signature is preserved.

Added regression tests (parametrized over both backends) covering a dangling symlink: `follow_symlinks=False` resolves the owner/group of the link itself, while `follow_symlinks=True` (the default) raises `FileNotFoundError` — matching `pathlib`. Tests skip on Windows (owner/group unsupported) and on Python < 3.13. Changelog updated; ruff and mypy pass.
