### PR TITLE
call set_write_buffer_limits(0) for UDPSockets so that send returns once data hits the kernel

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -46,13 +46,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   building a lookup table from the ``if TYPE_CHECKING:`` block. A fallback mode has been
   provided for installations where the source code is unavailable (e.g. PyInstaller).
   (`#1169 <https://github.com/agronholm/anyio/pull/1169>`_)
-- Changed the asyncio backend to set the write buffer high water mark to 0 on UDP
-  sockets (both connected and unconnected), and to wait on the write event both before
-  and after handing the datagram to the transport, so that each ``send()`` waits until
-  its own datagram has actually been passed to the operating system instead of letting
-  the transport buffer it. Note that on asyncio, a ``send()`` cancelled while waiting
-  may still result in the datagram being delivered, as the transport has already
-  accepted it; on trio, a cancelled ``send()`` never sends
+- Changed UDP sockets on the asyncio backend to make ``send()`` wait until the
+  datagram has been passed to the operating system
   (`#1294 <https://github.com/agronholm/anyio/pull/1294>`_; PR by @graingert)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -46,6 +46,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   building a lookup table from the ``if TYPE_CHECKING:`` block. A fallback mode has been
   provided for installations where the source code is unavailable (e.g. PyInstaller).
   (`#1169 <https://github.com/agronholm/anyio/pull/1169>`_)
+- Changed the asyncio backend to set the write buffer high water mark to 0 on UDP
+  sockets (both connected and unconnected), so that ``send()`` waits until the
+  datagram has actually been passed to the operating system instead of letting the
+  transport buffer it
+  (`#1294 <https://github.com/agronholm/anyio/pull/1294>`_; PR by @graingert)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,
   causing AnyIO to behave erroneously in relation to ``start_blocking_portal()`` and

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -47,12 +47,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   provided for installations where the source code is unavailable (e.g. PyInstaller).
   (`#1169 <https://github.com/agronholm/anyio/pull/1169>`_)
 - Changed the asyncio backend to set the write buffer high water mark to 0 on UDP
-  sockets (both connected and unconnected), and to wait on the write event *after*
-  handing the datagram to the transport, so that each ``send()`` waits until its own
-  datagram has actually been passed to the operating system instead of letting the
-  transport buffer it. Note that on asyncio, a ``send()`` cancelled while waiting may
-  still result in the datagram being delivered, as the transport has already accepted
-  it; on trio, a cancelled ``send()`` never sends
+  sockets (both connected and unconnected), and to wait on the write event both before
+  and after handing the datagram to the transport, so that each ``send()`` waits until
+  its own datagram has actually been passed to the operating system instead of letting
+  the transport buffer it. Note that on asyncio, a ``send()`` cancelled while waiting
+  may still result in the datagram being delivered, as the transport has already
+  accepted it; on trio, a cancelled ``send()`` never sends
   (`#1294 <https://github.com/agronholm/anyio/pull/1294>`_; PR by @graingert)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -47,9 +47,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   provided for installations where the source code is unavailable (e.g. PyInstaller).
   (`#1169 <https://github.com/agronholm/anyio/pull/1169>`_)
 - Changed the asyncio backend to set the write buffer high water mark to 0 on UDP
-  sockets (both connected and unconnected), so that ``send()`` waits until the
+  sockets (both connected and unconnected), and to wait on the write event *after*
+  handing the datagram to the transport, so that each ``send()`` waits until its own
   datagram has actually been passed to the operating system instead of letting the
-  transport buffer it
+  transport buffer it. Note that on asyncio, a ``send()`` cancelled while waiting may
+  still result in the datagram being delivered, as the transport has already accepted
+  it; on trio, a cancelled ``send()`` never sends
   (`#1294 <https://github.com/agronholm/anyio/pull/1294>`_; PR by @graingert)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1712,13 +1712,17 @@ class UDPSocket(abc.UDPSocket):
     async def send(self, item: UDPPacketType) -> None:
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
-            await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
             elif self._transport.is_closing():
                 raise BrokenResourceError
-            else:
-                self._transport.sendto(*item)
+
+            self._transport.sendto(*item)
+
+            # If the OS refused the datagram, the transport has buffered it and
+            # (because the high water mark is 0) already cleared the write event, so
+            # this waits until this call's own datagram has been handed to the OS
+            await self._protocol.write_event.wait()
 
 
 class ConnectedUDPSocket(abc.ConnectedUDPSocket):
@@ -1764,13 +1768,17 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
     async def send(self, item: bytes) -> None:
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
-            await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
             elif self._transport.is_closing():
                 raise BrokenResourceError
-            else:
-                self._transport.sendto(item)
+
+            self._transport.sendto(item)
+
+            # If the OS refused the datagram, the transport has buffered it and
+            # (because the high water mark is 0) already cleared the write event, so
+            # this waits until this call's own datagram has been handed to the OS
+            await self._protocol.write_event.wait()
 
 
 class UNIXDatagramSocket(_RawSocketMixin, abc.UNIXDatagramSocket):

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1299,6 +1299,7 @@ class DatagramProtocol(asyncio.DatagramProtocol):
         self.write_event = asyncio.Event()
         self.closed_event = asyncio.Event()
         self.write_event.set()
+        cast(asyncio.WriteTransport, transport).set_write_buffer_limits(0)
 
     def connection_lost(self, exc: Exception | None) -> None:
         self.read_event.set()

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1713,10 +1713,7 @@ class UDPSocket(abc.UDPSocket):
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
 
-            # Wait until the transport has flushed any datagram the OS previously
-            # refused, so that this datagram is not merely appended to the transport's
-            # buffer (which would happen if a previous send() was cancelled while
-            # waiting below)
+            # Wait for any datagram the transport had to buffer to be flushed first
             await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
@@ -1725,9 +1722,8 @@ class UDPSocket(abc.UDPSocket):
 
             self._transport.sendto(*item)
 
-            # If the OS refused the datagram, the transport has buffered it and
-            # (because the high water mark is 0) already cleared the write event, so
-            # this waits until this call's own datagram has been handed to the OS
+            # The high water mark is 0, so the write event has been cleared if the OS
+            # refused the datagram; wait until it has been handed over
             await self._protocol.write_event.wait()
 
 
@@ -1775,10 +1771,7 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
 
-            # Wait until the transport has flushed any datagram the OS previously
-            # refused, so that this datagram is not merely appended to the transport's
-            # buffer (which would happen if a previous send() was cancelled while
-            # waiting below)
+            # Wait for any datagram the transport had to buffer to be flushed first
             await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
@@ -1787,9 +1780,8 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
 
             self._transport.sendto(item)
 
-            # If the OS refused the datagram, the transport has buffered it and
-            # (because the high water mark is 0) already cleared the write event, so
-            # this waits until this call's own datagram has been handed to the OS
+            # The high water mark is 0, so the write event has been cleared if the OS
+            # refused the datagram; wait until it has been handed over
             await self._protocol.write_event.wait()
 
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1711,22 +1711,32 @@ class UDPSocket(abc.UDPSocket):
 
     async def send(self, item: UDPPacketType) -> None:
         with self._send_guard:
+            await AsyncIOBackend.checkpoint_if_cancelled()
+            yielded = False
+
             # Wait for any datagram the transport had to buffer to be flushed first
-            if self._protocol.write_event.is_set():
-                await AsyncIOBackend.checkpoint()
-            else:
+            if not self._protocol.write_event.is_set():
+                yielded = True
                 await self._protocol.write_event.wait()
 
-            if self._closed:
-                raise ClosedResourceError
-            elif self._transport.is_closing():
-                raise BrokenResourceError
+            try:
+                if self._closed:
+                    raise ClosedResourceError
+                elif self._transport.is_closing():
+                    raise BrokenResourceError
 
-            self._transport.sendto(*item)
+                self._transport.sendto(*item)
 
-            # The high water mark is 0, so the write event has been cleared if the OS
-            # refused the datagram; wait until it has been handed over
-            await self._protocol.write_event.wait()
+                # The high water mark is 0, so the write event has been cleared if the
+                # OS refused the datagram; wait until it has been handed over
+                if not self._protocol.write_event.is_set():
+                    yielded = True
+                    await self._protocol.write_event.wait()
+            finally:
+                # Nothing blocked, so make the mandatory yield here instead, where it
+                # can no longer lose an already sent datagram to cancellation
+                if not yielded:
+                    await AsyncIOBackend.cancel_shielded_checkpoint()
 
 
 class ConnectedUDPSocket(abc.ConnectedUDPSocket):
@@ -1771,22 +1781,32 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
 
     async def send(self, item: bytes) -> None:
         with self._send_guard:
+            await AsyncIOBackend.checkpoint_if_cancelled()
+            yielded = False
+
             # Wait for any datagram the transport had to buffer to be flushed first
-            if self._protocol.write_event.is_set():
-                await AsyncIOBackend.checkpoint()
-            else:
+            if not self._protocol.write_event.is_set():
+                yielded = True
                 await self._protocol.write_event.wait()
 
-            if self._closed:
-                raise ClosedResourceError
-            elif self._transport.is_closing():
-                raise BrokenResourceError
+            try:
+                if self._closed:
+                    raise ClosedResourceError
+                elif self._transport.is_closing():
+                    raise BrokenResourceError
 
-            self._transport.sendto(item)
+                self._transport.sendto(item)
 
-            # The high water mark is 0, so the write event has been cleared if the OS
-            # refused the datagram; wait until it has been handed over
-            await self._protocol.write_event.wait()
+                # The high water mark is 0, so the write event has been cleared if the
+                # OS refused the datagram; wait until it has been handed over
+                if not self._protocol.write_event.is_set():
+                    yielded = True
+                    await self._protocol.write_event.wait()
+            finally:
+                # Nothing blocked, so make the mandatory yield here instead, where it
+                # can no longer lose an already sent datagram to cancellation
+                if not yielded:
+                    await AsyncIOBackend.cancel_shielded_checkpoint()
 
 
 class UNIXDatagramSocket(_RawSocketMixin, abc.UNIXDatagramSocket):

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1714,29 +1714,23 @@ class UDPSocket(abc.UDPSocket):
             await AsyncIOBackend.checkpoint_if_cancelled()
             yielded = False
 
-            # Wait for any datagram the transport had to buffer to be flushed first
+            # Wait out any datagram the transport had to buffer
             if not self._protocol.write_event.is_set():
                 yielded = True
                 await self._protocol.write_event.wait()
 
-            try:
-                if self._closed:
-                    raise ClosedResourceError
-                elif self._transport.is_closing():
-                    raise BrokenResourceError
+            if self._closed:
+                raise ClosedResourceError
+            elif self._transport.is_closing():
+                raise BrokenResourceError
 
-                self._transport.sendto(*item)
+            self._transport.sendto(*item)
 
-                # The high water mark is 0, so the write event has been cleared if the
-                # OS refused the datagram; wait until it has been handed over
-                if not self._protocol.write_event.is_set():
-                    yielded = True
-                    await self._protocol.write_event.wait()
-            finally:
-                # Nothing blocked, so make the mandatory yield here instead, where it
-                # can no longer lose an already sent datagram to cancellation
-                if not yielded:
-                    await AsyncIOBackend.cancel_shielded_checkpoint()
+            # The high water mark is 0, so the event is clear if the OS refused it
+            if not self._protocol.write_event.is_set():
+                await self._protocol.write_event.wait()
+            elif not yielded:
+                await AsyncIOBackend.cancel_shielded_checkpoint()
 
 
 class ConnectedUDPSocket(abc.ConnectedUDPSocket):
@@ -1784,29 +1778,23 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
             await AsyncIOBackend.checkpoint_if_cancelled()
             yielded = False
 
-            # Wait for any datagram the transport had to buffer to be flushed first
+            # Wait out any datagram the transport had to buffer
             if not self._protocol.write_event.is_set():
                 yielded = True
                 await self._protocol.write_event.wait()
 
-            try:
-                if self._closed:
-                    raise ClosedResourceError
-                elif self._transport.is_closing():
-                    raise BrokenResourceError
+            if self._closed:
+                raise ClosedResourceError
+            elif self._transport.is_closing():
+                raise BrokenResourceError
 
-                self._transport.sendto(item)
+            self._transport.sendto(item)
 
-                # The high water mark is 0, so the write event has been cleared if the
-                # OS refused the datagram; wait until it has been handed over
-                if not self._protocol.write_event.is_set():
-                    yielded = True
-                    await self._protocol.write_event.wait()
-            finally:
-                # Nothing blocked, so make the mandatory yield here instead, where it
-                # can no longer lose an already sent datagram to cancellation
-                if not yielded:
-                    await AsyncIOBackend.cancel_shielded_checkpoint()
+            # The high water mark is 0, so the event is clear if the OS refused it
+            if not self._protocol.write_event.is_set():
+                await self._protocol.write_event.wait()
+            elif not yielded:
+                await AsyncIOBackend.cancel_shielded_checkpoint()
 
 
 class UNIXDatagramSocket(_RawSocketMixin, abc.UNIXDatagramSocket):

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1711,10 +1711,12 @@ class UDPSocket(abc.UDPSocket):
 
     async def send(self, item: UDPPacketType) -> None:
         with self._send_guard:
-            await AsyncIOBackend.checkpoint()
-
             # Wait for any datagram the transport had to buffer to be flushed first
-            await self._protocol.write_event.wait()
+            if self._protocol.write_event.is_set():
+                await AsyncIOBackend.checkpoint()
+            else:
+                await self._protocol.write_event.wait()
+
             if self._closed:
                 raise ClosedResourceError
             elif self._transport.is_closing():
@@ -1769,10 +1771,12 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
 
     async def send(self, item: bytes) -> None:
         with self._send_guard:
-            await AsyncIOBackend.checkpoint()
-
             # Wait for any datagram the transport had to buffer to be flushed first
-            await self._protocol.write_event.wait()
+            if self._protocol.write_event.is_set():
+                await AsyncIOBackend.checkpoint()
+            else:
+                await self._protocol.write_event.wait()
+
             if self._closed:
                 raise ClosedResourceError
             elif self._transport.is_closing():

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1712,6 +1712,12 @@ class UDPSocket(abc.UDPSocket):
     async def send(self, item: UDPPacketType) -> None:
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
+
+            # Wait until the transport has flushed any datagram the OS previously
+            # refused, so that this datagram is not merely appended to the transport's
+            # buffer (which would happen if a previous send() was cancelled while
+            # waiting below)
+            await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
             elif self._transport.is_closing():
@@ -1768,6 +1774,12 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
     async def send(self, item: bytes) -> None:
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
+
+            # Wait until the transport has flushed any datagram the OS previously
+            # refused, so that this datagram is not merely appended to the transport's
+            # buffer (which would happen if a previous send() was cancelled while
+            # waiting below)
+            await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
             elif self._transport.is_closing():

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1777,6 +1777,23 @@ def drain_datagram_socket(sock: socket.socket) -> None:
         pass
 
 
+async def receive_datagrams_until(sock: socket.socket, sentinel: bytes) -> list[bytes]:
+    """
+    Receive datagrams from ``sock`` until ``sentinel`` has been received.
+
+    :return: every datagram received, in the order they arrived, ``sentinel`` last
+
+    """
+    received: list[bytes] = []
+    while not received or received[-1] != sentinel:
+        try:
+            received.append(sock.recv(65536))
+        except BlockingIOError:
+            await wait_readable(sock)
+
+    return received
+
+
 def make_backpressured_pair(
     tmp_path: Path, *, connect: bool
 ) -> tuple[socket.socket, socket.socket, str, int]:
@@ -1942,6 +1959,47 @@ class TestUDPSocket:
 
                 assert blocked, "send() returned before the OS accepted the datagram"
                 assert send_completed
+
+    @skip_no_dgram_backpressure_mark
+    async def test_cancelled_send_does_not_buffer_the_next_datagram(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A ``send()`` cancelled while blocked must not let the next one skip ahead.
+
+        On asyncio, the datagram of the *first* cancelled send has unavoidably been
+        buffered by the transport already, but any subsequent ``send()`` must wait for
+        that buffer to be flushed instead of appending to it — otherwise repeated
+        cancellation would grow the transport's buffer without bound, despite the zero
+        high water mark.
+        """
+        sock, peer, peer_path, capacity = make_backpressured_pair(
+            tmp_path, connect=False
+        )
+        addr = cast(IPSockAddrType, peer_path)
+        with peer:
+            async with await UDPSocket.from_socket(sock) as udp:
+                # Fill up the send buffer again
+                for _ in range(capacity):
+                    await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
+
+                async def send_and_cancel(payload: bytes) -> None:
+                    async with create_task_group() as tg:
+                        tg.start_soon(udp.send, (payload, addr))
+                        await wait_all_tasks_blocked()
+                        tg.cancel_scope.cancel()
+
+                with fail_after(5):
+                    # The first cancelled send may leave its datagram in the asyncio
+                    # transport's buffer, but the second one must never reach it
+                    await send_and_cancel(b"one")
+                    await send_and_cancel(b"two")
+
+                    async with create_task_group() as tg:
+                        tg.start_soon(udp.send, (b"three", addr))
+                        received = await receive_datagrams_until(peer, b"three")
+
+                assert b"two" not in received
 
     async def test_iterate(self, family: AnyIPAddressFamily) -> None:
         async def serve() -> None:
@@ -2161,6 +2219,46 @@ class TestConnectedUDPSocket:
 
                 assert blocked, "send() returned before the OS accepted the datagram"
                 assert send_completed
+
+    @skip_no_dgram_backpressure_mark
+    async def test_cancelled_send_does_not_buffer_the_next_datagram(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A ``send()`` cancelled while blocked must not let the next one skip ahead.
+
+        On asyncio, the datagram of the *first* cancelled send has unavoidably been
+        buffered by the transport already, but any subsequent ``send()`` must wait for
+        that buffer to be flushed instead of appending to it — otherwise repeated
+        cancellation would grow the transport's buffer without bound, despite the zero
+        high water mark.
+        """
+        sock, peer, _peer_path, capacity = make_backpressured_pair(
+            tmp_path, connect=True
+        )
+        with peer:
+            async with await ConnectedUDPSocket.from_socket(sock) as udp:
+                # Fill up the send buffer again
+                for _ in range(capacity):
+                    await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
+
+                async def send_and_cancel(payload: bytes) -> None:
+                    async with create_task_group() as tg:
+                        tg.start_soon(udp.send, payload)
+                        await wait_all_tasks_blocked()
+                        tg.cancel_scope.cancel()
+
+                with fail_after(5):
+                    # The first cancelled send may leave its datagram in the asyncio
+                    # transport's buffer, but the second one must never reach it
+                    await send_and_cancel(b"one")
+                    await send_and_cancel(b"two")
+
+                    async with create_task_group() as tg:
+                        tg.start_soon(udp.send, b"three")
+                        received = await receive_datagrams_until(peer, b"three")
+
+                assert b"two" not in received
 
     async def test_iterate(self, family: AnyIPAddressFamily) -> None:
         async def serve() -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1926,15 +1926,14 @@ class TestUDPSocket:
 
                 send_completed = False
 
-                async def send_two_more() -> None:
+                async def send_one_more() -> None:
                     nonlocal send_completed
-                    await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
                     await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
                     send_completed = True
 
                 with fail_after(5):
                     async with create_task_group() as tg:
-                        tg.start_soon(send_two_more)
+                        tg.start_soon(send_one_more)
                         await wait_all_tasks_blocked()
                         blocked = not send_completed
 
@@ -2146,15 +2145,14 @@ class TestConnectedUDPSocket:
 
                 send_completed = False
 
-                async def send_two_more() -> None:
+                async def send_one_more() -> None:
                     nonlocal send_completed
-                    await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
                     await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
                     send_completed = True
 
                 with fail_after(5):
                     async with create_task_group() as tg:
-                        tg.start_soon(send_two_more)
+                        tg.start_soon(send_one_more)
                         await wait_all_tasks_blocked()
                         blocked = not send_completed
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -117,6 +117,10 @@ skip_unix_abstract_mark = pytest.mark.skipif(
     not sys.platform.startswith("linux"),
     reason="Abstract namespace sockets is a Linux only feature",
 )
+skip_no_dgram_backpressure_mark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Datagram sockets are only known to refuse datagrams with EAGAIN on Linux",
+)
 
 
 @pytest.fixture
@@ -1761,6 +1765,72 @@ async def test_multi_listener(tmp_path_factory: TempPathFactory) -> None:
         assert client_addresses == expected_addresses
 
 
+DGRAM_BACKPRESSURE_PAYLOAD = b"\x00" * 64
+
+
+def drain_datagram_socket(sock: socket.socket) -> None:
+    """Receive and discard every datagram currently queued on ``sock``."""
+    try:
+        while True:
+            sock.recv(65536)
+    except BlockingIOError:
+        pass
+
+
+def make_backpressured_pair(
+    tmp_path: Path, *, connect: bool
+) -> tuple[socket.socket, socket.socket, str, int]:
+    """
+    Create a datagram socket that the operating system will refuse datagrams from,
+    along with the peer it sends to.
+
+    UNIX datagram sockets are used here because UDP sockets never exert any
+    back-pressure on the loopback interface: the kernel accounts for the datagram
+    only until it has been delivered or dropped, so ``sendto()`` always succeeds, no
+    matter how small the send buffer is or how full the peer's receive buffer is.
+    UNIX datagram sockets, on the other hand, refuse datagrams with ``EAGAIN`` once
+    the send buffer is full, and they go through the very same code path in both
+    backends.
+
+    The send buffer is deliberately made as small as the OS allows, so that only a
+    handful of datagrams are needed to fill it up. The buffer is left empty on
+    return.
+
+    :return: the socket, its peer, the peer's path, and the number of datagrams the
+        OS accepts before it starts refusing them
+
+    """
+    peer_path = str(tmp_path / "peer.sock")
+    peer = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    peer.setblocking(False)
+    peer.bind(peer_path)
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    sock.bind(str(tmp_path / "local.sock"))
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1024)
+    if connect:
+        sock.connect(peer_path)
+
+    sock.setblocking(False)
+
+    # Find out how many datagrams the OS accepts before it refuses any more, and then
+    # empty both buffers again
+    capacity = 0
+    try:
+        while True:
+            if connect:
+                sock.send(DGRAM_BACKPRESSURE_PAYLOAD)
+            else:
+                sock.sendto(DGRAM_BACKPRESSURE_PAYLOAD, peer_path)
+
+            capacity += 1
+    except BlockingIOError:
+        pass
+
+    assert capacity >= 2, f"the send buffer only fits {capacity} datagram(s)"
+    drain_datagram_socket(peer)
+    return sock, peer, peer_path, capacity
+
+
 @pytest.mark.network
 @pytest.mark.usefixtures("check_asyncio_bug")
 class TestUDPSocket:
@@ -1831,6 +1901,48 @@ class TestUDPSocket:
             response, addr = await sock.receive()
             assert response == b"halb"
             assert addr == (host, port)
+
+    @skip_no_dgram_backpressure_mark
+    async def test_send_waits_for_the_os_to_accept_the_datagram(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        ``send()`` must not return before the OS has accepted the datagram.
+
+        The asyncio backend sets the transport's write buffer high water mark to 0,
+        so the transport pauses the sender as soon as it has had to buffer a datagram
+        the OS refused, instead of quietly buffering up to 64 KiB worth of them. The
+        trio backend never buffers datagrams to begin with.
+        """
+        sock, peer, peer_path, capacity = make_backpressured_pair(
+            tmp_path, connect=False
+        )
+        addr = cast(IPSockAddrType, peer_path)
+        with peer:
+            async with await UDPSocket.from_socket(sock) as udp:
+                # Fill up the send buffer again
+                for _ in range(capacity):
+                    await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
+
+                send_completed = False
+
+                async def send_two_more() -> None:
+                    nonlocal send_completed
+                    await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
+                    await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
+                    send_completed = True
+
+                with fail_after(5):
+                    async with create_task_group() as tg:
+                        tg.start_soon(send_two_more)
+                        await wait_all_tasks_blocked()
+                        blocked = not send_completed
+
+                        # Make room in the send buffer so the sender can continue
+                        drain_datagram_socket(peer)
+
+                assert blocked, "send() returned before the OS accepted the datagram"
+                assert send_completed
 
     async def test_iterate(self, family: AnyIPAddressFamily) -> None:
         async def serve() -> None:
@@ -2010,6 +2122,47 @@ class TestConnectedUDPSocket:
                 await udp1.sendto(b"halb", host, port)
                 response = await udp2.receive()
                 assert response == b"halb"
+
+    @skip_no_dgram_backpressure_mark
+    async def test_send_waits_for_the_os_to_accept_the_datagram(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        ``send()`` must not return before the OS has accepted the datagram.
+
+        The asyncio backend sets the transport's write buffer high water mark to 0,
+        so the transport pauses the sender as soon as it has had to buffer a datagram
+        the OS refused, instead of quietly buffering up to 64 KiB worth of them. The
+        trio backend never buffers datagrams to begin with.
+        """
+        sock, peer, _peer_path, capacity = make_backpressured_pair(
+            tmp_path, connect=True
+        )
+        with peer:
+            async with await ConnectedUDPSocket.from_socket(sock) as udp:
+                # Fill up the send buffer again
+                for _ in range(capacity):
+                    await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
+
+                send_completed = False
+
+                async def send_two_more() -> None:
+                    nonlocal send_completed
+                    await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
+                    await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
+                    send_completed = True
+
+                with fail_after(5):
+                    async with create_task_group() as tg:
+                        tg.start_soon(send_two_more)
+                        await wait_all_tasks_blocked()
+                        blocked = not send_completed
+
+                        # Make room in the send buffer so the sender can continue
+                        drain_datagram_socket(peer)
+
+                assert blocked, "send() returned before the OS accepted the datagram"
+                assert send_completed
 
     async def test_iterate(self, family: AnyIPAddressFamily) -> None:
         async def serve() -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1769,7 +1769,6 @@ DGRAM_BACKPRESSURE_PAYLOAD = b"\x00" * 64
 
 
 def drain_datagram_socket(sock: socket.socket) -> None:
-    """Receive and discard every datagram currently queued on ``sock``."""
     try:
         while True:
             sock.recv(65536)
@@ -1778,12 +1777,7 @@ def drain_datagram_socket(sock: socket.socket) -> None:
 
 
 async def receive_datagrams_until(sock: socket.socket, sentinel: bytes) -> list[bytes]:
-    """
-    Receive datagrams from ``sock`` until ``sentinel`` has been received.
-
-    :return: every datagram received, in the order they arrived, ``sentinel`` last
-
-    """
+    """Receive datagrams until ``sentinel`` arrives, and return all of them."""
     received: list[bytes] = []
     while not received or received[-1] != sentinel:
         try:
@@ -1798,23 +1792,13 @@ def make_backpressured_pair(
     tmp_path: Path, *, connect: bool
 ) -> tuple[socket.socket, socket.socket, str, int]:
     """
-    Create a datagram socket that the operating system will refuse datagrams from,
-    along with the peer it sends to.
+    Create a datagram socket with a full send buffer, along with the peer it sends to.
 
-    UNIX datagram sockets are used here because UDP sockets never exert any
-    back-pressure on the loopback interface: the kernel accounts for the datagram
-    only until it has been delivered or dropped, so ``sendto()`` always succeeds, no
-    matter how small the send buffer is or how full the peer's receive buffer is.
-    UNIX datagram sockets, on the other hand, refuse datagrams with ``EAGAIN`` once
-    the send buffer is full, and they go through the very same code path in both
-    backends.
+    UNIX datagram sockets are used because UDP sockets never exert back-pressure on the
+    loopback interface, but they take the same code path in both backends.
 
-    The send buffer is deliberately made as small as the OS allows, so that only a
-    handful of datagrams are needed to fill it up. The buffer is left empty on
-    return.
-
-    :return: the socket, its peer, the peer's path, and the number of datagrams the
-        OS accepts before it starts refusing them
+    :return: the socket, its peer, the peer's path, and the number of datagrams the OS
+        accepts before it starts refusing them
 
     """
     peer_path = str(tmp_path / "peer.sock")
@@ -1923,14 +1907,6 @@ class TestUDPSocket:
     async def test_send_waits_for_the_os_to_accept_the_datagram(
         self, tmp_path: Path
     ) -> None:
-        """
-        ``send()`` must not return before the OS has accepted the datagram.
-
-        The asyncio backend sets the transport's write buffer high water mark to 0,
-        so the transport pauses the sender as soon as it has had to buffer a datagram
-        the OS refused, instead of quietly buffering up to 64 KiB worth of them. The
-        trio backend never buffers datagrams to begin with.
-        """
         sock, peer, peer_path, capacity = make_backpressured_pair(
             tmp_path, connect=False
         )
@@ -1964,15 +1940,6 @@ class TestUDPSocket:
     async def test_cancelled_send_does_not_buffer_the_next_datagram(
         self, tmp_path: Path
     ) -> None:
-        """
-        A ``send()`` cancelled while blocked must not let the next one skip ahead.
-
-        On asyncio, the datagram of the *first* cancelled send has unavoidably been
-        buffered by the transport already, but any subsequent ``send()`` must wait for
-        that buffer to be flushed instead of appending to it — otherwise repeated
-        cancellation would grow the transport's buffer without bound, despite the zero
-        high water mark.
-        """
         sock, peer, peer_path, capacity = make_backpressured_pair(
             tmp_path, connect=False
         )
@@ -2184,14 +2151,6 @@ class TestConnectedUDPSocket:
     async def test_send_waits_for_the_os_to_accept_the_datagram(
         self, tmp_path: Path
     ) -> None:
-        """
-        ``send()`` must not return before the OS has accepted the datagram.
-
-        The asyncio backend sets the transport's write buffer high water mark to 0,
-        so the transport pauses the sender as soon as it has had to buffer a datagram
-        the OS refused, instead of quietly buffering up to 64 KiB worth of them. The
-        trio backend never buffers datagrams to begin with.
-        """
         sock, peer, _peer_path, capacity = make_backpressured_pair(
             tmp_path, connect=True
         )
@@ -2224,15 +2183,6 @@ class TestConnectedUDPSocket:
     async def test_cancelled_send_does_not_buffer_the_next_datagram(
         self, tmp_path: Path
     ) -> None:
-        """
-        A ``send()`` cancelled while blocked must not let the next one skip ahead.
-
-        On asyncio, the datagram of the *first* cancelled send has unavoidably been
-        buffered by the transport already, but any subsequent ``send()`` must wait for
-        that buffer to be flushed instead of appending to it — otherwise repeated
-        cancellation would grow the transport's buffer without bound, despite the zero
-        high water mark.
-        """
         sock, peer, _peer_path, capacity = make_backpressured_pair(
             tmp_path, connect=True
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Changed the asyncio backend to set the write buffer high water mark to 0 on UDP sockets (both connected and unconnected), so that ``send()`` waits until the datagram has actually been passed to the operating system instead of letting the transport buffer it

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
