### PR TITLE
don't silently discard UDP errors

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -46,13 +46,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   building a lookup table from the ``if TYPE_CHECKING:`` block. A fallback mode has been
   provided for installations where the source code is unavailable (e.g. PyInstaller).
   (`#1169 <https://github.com/agronholm/anyio/pull/1169>`_)
-- Changed the asyncio backend to set the write buffer high water mark to 0 on UDP
-  sockets (both connected and unconnected), and to wait on the write event both before
-  and after handing the datagram to the transport, so that each ``send()`` waits until
-  its own datagram has actually been passed to the operating system instead of letting
-  the transport buffer it. Note that on asyncio, a ``send()`` cancelled while waiting
-  may still result in the datagram being delivered, as the transport has already
-  accepted it; on trio, a cancelled ``send()`` never sends
+- Changed UDP sockets on the asyncio backend to make ``send()`` wait until the
+  datagram has been passed to the operating system
   (`#1294 <https://github.com/agronholm/anyio/pull/1294>`_; PR by @graingert)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -46,6 +46,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   building a lookup table from the ``if TYPE_CHECKING:`` block. A fallback mode has been
   provided for installations where the source code is unavailable (e.g. PyInstaller).
   (`#1169 <https://github.com/agronholm/anyio/pull/1169>`_)
+- Changed the asyncio backend to set the write buffer high water mark to 0 on UDP
+  sockets (both connected and unconnected), so that ``send()`` waits until the
+  datagram has actually been passed to the operating system instead of letting the
+  transport buffer it
+  (`#1294 <https://github.com/agronholm/anyio/pull/1294>`_; PR by @graingert)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,
   causing AnyIO to behave erroneously in relation to ``start_blocking_portal()`` and

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -47,12 +47,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   provided for installations where the source code is unavailable (e.g. PyInstaller).
   (`#1169 <https://github.com/agronholm/anyio/pull/1169>`_)
 - Changed the asyncio backend to set the write buffer high water mark to 0 on UDP
-  sockets (both connected and unconnected), and to wait on the write event *after*
-  handing the datagram to the transport, so that each ``send()`` waits until its own
-  datagram has actually been passed to the operating system instead of letting the
-  transport buffer it. Note that on asyncio, a ``send()`` cancelled while waiting may
-  still result in the datagram being delivered, as the transport has already accepted
-  it; on trio, a cancelled ``send()`` never sends
+  sockets (both connected and unconnected), and to wait on the write event both before
+  and after handing the datagram to the transport, so that each ``send()`` waits until
+  its own datagram has actually been passed to the operating system instead of letting
+  the transport buffer it. Note that on asyncio, a ``send()`` cancelled while waiting
+  may still result in the datagram being delivered, as the transport has already
+  accepted it; on trio, a cancelled ``send()`` never sends
   (`#1294 <https://github.com/agronholm/anyio/pull/1294>`_; PR by @graingert)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -47,9 +47,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   provided for installations where the source code is unavailable (e.g. PyInstaller).
   (`#1169 <https://github.com/agronholm/anyio/pull/1169>`_)
 - Changed the asyncio backend to set the write buffer high water mark to 0 on UDP
-  sockets (both connected and unconnected), so that ``send()`` waits until the
+  sockets (both connected and unconnected), and to wait on the write event *after*
+  handing the datagram to the transport, so that each ``send()`` waits until its own
   datagram has actually been passed to the operating system instead of letting the
-  transport buffer it
+  transport buffer it. Note that on asyncio, a ``send()`` cancelled while waiting may
+  still result in the datagram being delivered, as the transport has already accepted
+  it; on trio, a cancelled ``send()`` never sends
   (`#1294 <https://github.com/agronholm/anyio/pull/1294>`_; PR by @graingert)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -54,6 +54,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   still result in the datagram being delivered, as the transport has already accepted
   it; on trio, a cancelled ``send()`` never sends
   (`#1294 <https://github.com/agronholm/anyio/pull/1294>`_; PR by @graingert)
+- Fixed UDP sockets on the asyncio backend silently discarding errors reported by the
+  OS (such as an ICMP port unreachable). A task blocked in ``receive()`` or ``send()``
+  is now woken up by such an error, and both raise ``BrokenResourceError``, chained to
+  the original error, as they already did on the Trio backend. As on the Trio backend,
+  the error is only reported once, leaving the socket usable afterwards
+  (`#1294 <https://github.com/agronholm/anyio/pull/1294>`_; PR by @graingert)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,
   causing AnyIO to behave erroneously in relation to ``start_blocking_portal()`` and

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1346,11 +1346,9 @@ class DatagramProtocol(asyncio.DatagramProtocol):
         Return the oldest error reported by the transport, removing it from the queue so
         that it's only reported once, just like the OS does.
 
-        The read event is left alone, as ``receive()`` clears it before waiting on it
-        anyway. The write event, however, was set by :meth:`error_received` in order to
-        wake up any sender waiting on it, so it has to be cleared again if the transport
-        is still paused and no error is left to report, or the back-pressure would be
-        lost.
+        :meth:`error_received` set the write event to wake up any waiting sender, so it
+        has to be cleared again if the transport is still paused and no error is left
+        to report, or the back-pressure would be lost.
 
         """
         if not self.exceptions:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1712,13 +1712,17 @@ class UDPSocket(abc.UDPSocket):
     async def send(self, item: UDPPacketType) -> None:
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
-            await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
             elif self._transport.is_closing():
                 raise BrokenResourceError
-            else:
-                self._transport.sendto(*item)
+
+            self._transport.sendto(*item)
+
+            # If the OS refused the datagram, the transport has buffered it and
+            # (because the high water mark is 0) already cleared the write event, so
+            # this waits until this call's own datagram has been handed to the OS
+            await self._protocol.write_event.wait()
 
 
 class ConnectedUDPSocket(abc.ConnectedUDPSocket):
@@ -1764,13 +1768,17 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
     async def send(self, item: bytes) -> None:
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
-            await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
             elif self._transport.is_closing():
                 raise BrokenResourceError
-            else:
-                self._transport.sendto(item)
+
+            self._transport.sendto(item)
+
+            # If the OS refused the datagram, the transport has buffered it and
+            # (because the high water mark is 0) already cleared the write event, so
+            # this waits until this call's own datagram has been handed to the OS
+            await self._protocol.write_event.wait()
 
 
 class UNIXDatagramSocket(_RawSocketMixin, abc.UNIXDatagramSocket):

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1288,14 +1288,16 @@ class StreamProtocol(asyncio.Protocol):
 
 class DatagramProtocol(asyncio.DatagramProtocol):
     read_queue: deque[tuple[bytes, IPSockAddrType]]
+    exceptions: deque[Exception]
     read_event: asyncio.Event
     write_event: asyncio.Event
     closed_event: asyncio.Event
-    exception: Exception | None = None
     write_paused: bool = False
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.read_queue = deque(maxlen=100)  # arbitrary value
+        # Unbounded, as every error reported by the OS must be raised exactly once
+        self.exceptions = deque()
         self.read_event = asyncio.Event()
         self.write_event = asyncio.Event()
         self.closed_event = asyncio.Event()
@@ -1304,7 +1306,7 @@ class DatagramProtocol(asyncio.DatagramProtocol):
 
     def connection_lost(self, exc: Exception | None) -> None:
         if exc:
-            self.exception = exc
+            self.exceptions.append(exc)
 
         self.read_event.set()
         self.write_event.set()
@@ -1316,7 +1318,7 @@ class DatagramProtocol(asyncio.DatagramProtocol):
         self.read_event.set()
 
     def error_received(self, exc: Exception) -> None:
-        self.exception = exc
+        self.exceptions.append(exc)
         self.read_event.set()
         self.write_event.set()
 
@@ -1330,20 +1332,22 @@ class DatagramProtocol(asyncio.DatagramProtocol):
 
     def take_exception(self) -> Exception | None:
         """
-        Return the last error reported by the transport, clearing it so that it's only
-        reported once, just like the OS does.
+        Return the oldest error reported by the transport, removing it from the queue so
+        that it's only reported once, just like the OS does.
 
         The read event is left alone, as ``receive()`` clears it before waiting on it
         anyway. The write event, however, was set by :meth:`error_received` in order to
         wake up any sender waiting on it, so it has to be cleared again if the transport
-        is still paused, or the back-pressure would be lost.
+        is still paused and no error is left to report, or the back-pressure would be
+        lost.
 
         """
-        exc = self.exception
-        if exc is not None:
-            self.exception = None
-            if self.write_paused:
-                self.write_event.clear()
+        if not self.exceptions:
+            return None
+
+        exc = self.exceptions.popleft()
+        if self.write_paused and not self.exceptions:
+            self.write_event.clear()
 
         return exc
 
@@ -2909,9 +2913,9 @@ class AsyncIOBackend(AsyncBackend):
             family=family,
             reuse_port=reuse_port,
         )
-        if protocol.exception:
+        if (exc := protocol.take_exception()) is not None:
             transport.close()
-            raise protocol.exception
+            raise exc
 
         if not remote_address:
             return UDPSocket(transport, protocol)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1292,6 +1292,7 @@ class DatagramProtocol(asyncio.DatagramProtocol):
     write_event: asyncio.Event
     closed_event: asyncio.Event
     exception: Exception | None = None
+    write_paused: bool = False
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.read_queue = deque(maxlen=100)  # arbitrary value
@@ -1302,6 +1303,9 @@ class DatagramProtocol(asyncio.DatagramProtocol):
         cast(asyncio.WriteTransport, transport).set_write_buffer_limits(0)
 
     def connection_lost(self, exc: Exception | None) -> None:
+        if exc:
+            self.exception = exc
+
         self.read_event.set()
         self.write_event.set()
         self.closed_event.set()
@@ -1313,12 +1317,35 @@ class DatagramProtocol(asyncio.DatagramProtocol):
 
     def error_received(self, exc: Exception) -> None:
         self.exception = exc
+        self.read_event.set()
+        self.write_event.set()
 
     def pause_writing(self) -> None:
+        self.write_paused = True
         self.write_event.clear()
 
     def resume_writing(self) -> None:
+        self.write_paused = False
         self.write_event.set()
+
+    def take_exception(self) -> Exception | None:
+        """
+        Return the last error reported by the transport, clearing it so that it's only
+        reported once, just like the OS does.
+
+        The read event is left alone, as ``receive()`` clears it before waiting on it
+        anyway. The write event, however, was set by :meth:`error_received` in order to
+        wake up any sender waiting on it, so it has to be cleared again if the transport
+        is still paused, or the back-pressure would be lost.
+
+        """
+        exc = self.exception
+        if exc is not None:
+            self.exception = None
+            if self.write_paused:
+                self.write_event.clear()
+
+        return exc
 
 
 class SocketStream(abc.SocketStream):
@@ -1696,24 +1723,29 @@ class UDPSocket(abc.UDPSocket):
         with self._receive_guard:
             await AsyncIOBackend.checkpoint()
 
-            # If the buffer is empty, ask for more data
-            if not self._protocol.read_queue and not self._transport.is_closing():
+            # Wait until there's a packet in the buffer. An error reported by the
+            # transport also wakes us up, but it may have been claimed by a sender
+            # already, in which case there's nothing to do but wait for more data.
+            while not self._protocol.read_queue:
+                if self._closed:
+                    raise ClosedResourceError
+                elif (exc := self._protocol.take_exception()) is not None:
+                    raise BrokenResourceError from exc
+                elif self._transport.is_closing():
+                    raise BrokenResourceError
+
                 self._protocol.read_event.clear()
                 await self._protocol.read_event.wait()
 
-            try:
-                return self._protocol.read_queue.popleft()
-            except IndexError:
-                if self._closed:
-                    raise ClosedResourceError from None
-                else:
-                    raise BrokenResourceError from None
+            return self._protocol.read_queue.popleft()
 
     async def send(self, item: UDPPacketType) -> None:
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
             if self._closed:
                 raise ClosedResourceError
+            elif (exc := self._protocol.take_exception()) is not None:
+                raise BrokenResourceError from exc
             elif self._transport.is_closing():
                 raise BrokenResourceError
 
@@ -1721,8 +1753,23 @@ class UDPSocket(abc.UDPSocket):
 
             # If the OS refused the datagram, the transport has buffered it and
             # (because the high water mark is 0) already cleared the write event, so
-            # this waits until this call's own datagram has been handed to the OS
-            await self._protocol.write_event.wait()
+            # this waits until this call's own datagram has been handed to the OS.
+            # The event may also have been set by error_received() while the transport
+            # is still paused, so keep waiting until writing is actually resumed.
+            while self._protocol.write_paused:
+                await self._protocol.write_event.wait()
+                if self._closed:
+                    raise ClosedResourceError
+                elif (exc := self._protocol.take_exception()) is not None:
+                    raise BrokenResourceError from exc
+                elif self._transport.is_closing():
+                    raise BrokenResourceError
+
+            # A send that fails right away is reported to the protocol; raise it here
+            # instead of leaving it for another task to pick up, as the Trio backend
+            # does
+            if (exc := self._protocol.take_exception()) is not None:
+                raise BrokenResourceError from exc
 
 
 class ConnectedUDPSocket(abc.ConnectedUDPSocket):
@@ -1750,19 +1797,21 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
         with self._receive_guard:
             await AsyncIOBackend.checkpoint()
 
-            # If the buffer is empty, ask for more data
-            if not self._protocol.read_queue and not self._transport.is_closing():
+            # Wait until there's a packet in the buffer. An error reported by the
+            # transport also wakes us up, but it may have been claimed by a sender
+            # already, in which case there's nothing to do but wait for more data.
+            while not self._protocol.read_queue:
+                if self._closed:
+                    raise ClosedResourceError
+                elif (exc := self._protocol.take_exception()) is not None:
+                    raise BrokenResourceError from exc
+                elif self._transport.is_closing():
+                    raise BrokenResourceError
+
                 self._protocol.read_event.clear()
                 await self._protocol.read_event.wait()
 
-            try:
-                packet = self._protocol.read_queue.popleft()
-            except IndexError:
-                if self._closed:
-                    raise ClosedResourceError from None
-                else:
-                    raise BrokenResourceError from None
-
+            packet = self._protocol.read_queue.popleft()
             return packet[0]
 
     async def send(self, item: bytes) -> None:
@@ -1770,6 +1819,8 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
             await AsyncIOBackend.checkpoint()
             if self._closed:
                 raise ClosedResourceError
+            elif (exc := self._protocol.take_exception()) is not None:
+                raise BrokenResourceError from exc
             elif self._transport.is_closing():
                 raise BrokenResourceError
 
@@ -1777,8 +1828,23 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
 
             # If the OS refused the datagram, the transport has buffered it and
             # (because the high water mark is 0) already cleared the write event, so
-            # this waits until this call's own datagram has been handed to the OS
-            await self._protocol.write_event.wait()
+            # this waits until this call's own datagram has been handed to the OS.
+            # The event may also have been set by error_received() while the transport
+            # is still paused, so keep waiting until writing is actually resumed.
+            while self._protocol.write_paused:
+                await self._protocol.write_event.wait()
+                if self._closed:
+                    raise ClosedResourceError
+                elif (exc := self._protocol.take_exception()) is not None:
+                    raise BrokenResourceError from exc
+                elif self._transport.is_closing():
+                    raise BrokenResourceError
+
+            # A send that fails right away is reported to the protocol; raise it here
+            # instead of leaving it for another task to pick up, as the Trio backend
+            # does
+            if (exc := self._protocol.take_exception()) is not None:
+                raise BrokenResourceError from exc
 
 
 class UNIXDatagramSocket(_RawSocketMixin, abc.UNIXDatagramSocket):

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1761,14 +1761,20 @@ class UDPSocket(abc.UDPSocket):
             # Wait until the transport has flushed any datagram the OS previously
             # refused, so that this datagram is not merely appended to the transport's
             # buffer (which would happen if a previous send() was cancelled while
-            # waiting below)
-            await self._protocol.write_event.wait()
-            if self._closed:
-                raise ClosedResourceError
-            elif (exc := self._protocol.take_exception()) is not None:
-                raise BrokenResourceError from exc
-            elif self._transport.is_closing():
-                raise BrokenResourceError
+            # waiting below). As below, error_received() may have set the write event
+            # while the transport is still paused, so it's the pause flag, and not the
+            # event, that says when it's safe to hand over the datagram
+            while True:
+                if self._closed:
+                    raise ClosedResourceError
+                elif (exc := self._protocol.take_exception()) is not None:
+                    raise BrokenResourceError from exc
+                elif self._transport.is_closing():
+                    raise BrokenResourceError
+                elif not self._protocol.write_paused:
+                    break
+
+                await self._protocol.write_event.wait()
 
             self._transport.sendto(*item)
 
@@ -1842,14 +1848,20 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
             # Wait until the transport has flushed any datagram the OS previously
             # refused, so that this datagram is not merely appended to the transport's
             # buffer (which would happen if a previous send() was cancelled while
-            # waiting below)
-            await self._protocol.write_event.wait()
-            if self._closed:
-                raise ClosedResourceError
-            elif (exc := self._protocol.take_exception()) is not None:
-                raise BrokenResourceError from exc
-            elif self._transport.is_closing():
-                raise BrokenResourceError
+            # waiting below). As below, error_received() may have set the write event
+            # while the transport is still paused, so it's the pause flag, and not the
+            # event, that says when it's safe to hand over the datagram
+            while True:
+                if self._closed:
+                    raise ClosedResourceError
+                elif (exc := self._protocol.take_exception()) is not None:
+                    raise BrokenResourceError from exc
+                elif self._transport.is_closing():
+                    raise BrokenResourceError
+                elif not self._protocol.write_paused:
+                    break
+
+                await self._protocol.write_event.wait()
 
             self._transport.sendto(item)
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1299,6 +1299,7 @@ class DatagramProtocol(asyncio.DatagramProtocol):
         self.write_event = asyncio.Event()
         self.closed_event = asyncio.Event()
         self.write_event.set()
+        cast(asyncio.WriteTransport, transport).set_write_buffer_limits(0)
 
     def connection_lost(self, exc: Exception | None) -> None:
         self.read_event.set()

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1713,10 +1713,7 @@ class UDPSocket(abc.UDPSocket):
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
 
-            # Wait until the transport has flushed any datagram the OS previously
-            # refused, so that this datagram is not merely appended to the transport's
-            # buffer (which would happen if a previous send() was cancelled while
-            # waiting below)
+            # Wait for any datagram the transport had to buffer to be flushed first
             await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
@@ -1725,9 +1722,8 @@ class UDPSocket(abc.UDPSocket):
 
             self._transport.sendto(*item)
 
-            # If the OS refused the datagram, the transport has buffered it and
-            # (because the high water mark is 0) already cleared the write event, so
-            # this waits until this call's own datagram has been handed to the OS
+            # The high water mark is 0, so the write event has been cleared if the OS
+            # refused the datagram; wait until it has been handed over
             await self._protocol.write_event.wait()
 
 
@@ -1775,10 +1771,7 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
 
-            # Wait until the transport has flushed any datagram the OS previously
-            # refused, so that this datagram is not merely appended to the transport's
-            # buffer (which would happen if a previous send() was cancelled while
-            # waiting below)
+            # Wait for any datagram the transport had to buffer to be flushed first
             await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
@@ -1787,9 +1780,8 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
 
             self._transport.sendto(item)
 
-            # If the OS refused the datagram, the transport has buffered it and
-            # (because the high water mark is 0) already cleared the write event, so
-            # this waits until this call's own datagram has been handed to the OS
+            # The high water mark is 0, so the write event has been cleared if the OS
+            # refused the datagram; wait until it has been handed over
             await self._protocol.write_event.wait()
 
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1711,22 +1711,32 @@ class UDPSocket(abc.UDPSocket):
 
     async def send(self, item: UDPPacketType) -> None:
         with self._send_guard:
+            await AsyncIOBackend.checkpoint_if_cancelled()
+            yielded = False
+
             # Wait for any datagram the transport had to buffer to be flushed first
-            if self._protocol.write_event.is_set():
-                await AsyncIOBackend.checkpoint()
-            else:
+            if not self._protocol.write_event.is_set():
+                yielded = True
                 await self._protocol.write_event.wait()
 
-            if self._closed:
-                raise ClosedResourceError
-            elif self._transport.is_closing():
-                raise BrokenResourceError
+            try:
+                if self._closed:
+                    raise ClosedResourceError
+                elif self._transport.is_closing():
+                    raise BrokenResourceError
 
-            self._transport.sendto(*item)
+                self._transport.sendto(*item)
 
-            # The high water mark is 0, so the write event has been cleared if the OS
-            # refused the datagram; wait until it has been handed over
-            await self._protocol.write_event.wait()
+                # The high water mark is 0, so the write event has been cleared if the
+                # OS refused the datagram; wait until it has been handed over
+                if not self._protocol.write_event.is_set():
+                    yielded = True
+                    await self._protocol.write_event.wait()
+            finally:
+                # Nothing blocked, so make the mandatory yield here instead, where it
+                # can no longer lose an already sent datagram to cancellation
+                if not yielded:
+                    await AsyncIOBackend.cancel_shielded_checkpoint()
 
 
 class ConnectedUDPSocket(abc.ConnectedUDPSocket):
@@ -1771,22 +1781,32 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
 
     async def send(self, item: bytes) -> None:
         with self._send_guard:
+            await AsyncIOBackend.checkpoint_if_cancelled()
+            yielded = False
+
             # Wait for any datagram the transport had to buffer to be flushed first
-            if self._protocol.write_event.is_set():
-                await AsyncIOBackend.checkpoint()
-            else:
+            if not self._protocol.write_event.is_set():
+                yielded = True
                 await self._protocol.write_event.wait()
 
-            if self._closed:
-                raise ClosedResourceError
-            elif self._transport.is_closing():
-                raise BrokenResourceError
+            try:
+                if self._closed:
+                    raise ClosedResourceError
+                elif self._transport.is_closing():
+                    raise BrokenResourceError
 
-            self._transport.sendto(item)
+                self._transport.sendto(item)
 
-            # The high water mark is 0, so the write event has been cleared if the OS
-            # refused the datagram; wait until it has been handed over
-            await self._protocol.write_event.wait()
+                # The high water mark is 0, so the write event has been cleared if the
+                # OS refused the datagram; wait until it has been handed over
+                if not self._protocol.write_event.is_set():
+                    yielded = True
+                    await self._protocol.write_event.wait()
+            finally:
+                # Nothing blocked, so make the mandatory yield here instead, where it
+                # can no longer lose an already sent datagram to cancellation
+                if not yielded:
+                    await AsyncIOBackend.cancel_shielded_checkpoint()
 
 
 class UNIXDatagramSocket(_RawSocketMixin, abc.UNIXDatagramSocket):

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1714,29 +1714,23 @@ class UDPSocket(abc.UDPSocket):
             await AsyncIOBackend.checkpoint_if_cancelled()
             yielded = False
 
-            # Wait for any datagram the transport had to buffer to be flushed first
+            # Wait out any datagram the transport had to buffer
             if not self._protocol.write_event.is_set():
                 yielded = True
                 await self._protocol.write_event.wait()
 
-            try:
-                if self._closed:
-                    raise ClosedResourceError
-                elif self._transport.is_closing():
-                    raise BrokenResourceError
+            if self._closed:
+                raise ClosedResourceError
+            elif self._transport.is_closing():
+                raise BrokenResourceError
 
-                self._transport.sendto(*item)
+            self._transport.sendto(*item)
 
-                # The high water mark is 0, so the write event has been cleared if the
-                # OS refused the datagram; wait until it has been handed over
-                if not self._protocol.write_event.is_set():
-                    yielded = True
-                    await self._protocol.write_event.wait()
-            finally:
-                # Nothing blocked, so make the mandatory yield here instead, where it
-                # can no longer lose an already sent datagram to cancellation
-                if not yielded:
-                    await AsyncIOBackend.cancel_shielded_checkpoint()
+            # The high water mark is 0, so the event is clear if the OS refused it
+            if not self._protocol.write_event.is_set():
+                await self._protocol.write_event.wait()
+            elif not yielded:
+                await AsyncIOBackend.cancel_shielded_checkpoint()
 
 
 class ConnectedUDPSocket(abc.ConnectedUDPSocket):
@@ -1784,29 +1778,23 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
             await AsyncIOBackend.checkpoint_if_cancelled()
             yielded = False
 
-            # Wait for any datagram the transport had to buffer to be flushed first
+            # Wait out any datagram the transport had to buffer
             if not self._protocol.write_event.is_set():
                 yielded = True
                 await self._protocol.write_event.wait()
 
-            try:
-                if self._closed:
-                    raise ClosedResourceError
-                elif self._transport.is_closing():
-                    raise BrokenResourceError
+            if self._closed:
+                raise ClosedResourceError
+            elif self._transport.is_closing():
+                raise BrokenResourceError
 
-                self._transport.sendto(item)
+            self._transport.sendto(item)
 
-                # The high water mark is 0, so the write event has been cleared if the
-                # OS refused the datagram; wait until it has been handed over
-                if not self._protocol.write_event.is_set():
-                    yielded = True
-                    await self._protocol.write_event.wait()
-            finally:
-                # Nothing blocked, so make the mandatory yield here instead, where it
-                # can no longer lose an already sent datagram to cancellation
-                if not yielded:
-                    await AsyncIOBackend.cancel_shielded_checkpoint()
+            # The high water mark is 0, so the event is clear if the OS refused it
+            if not self._protocol.write_event.is_set():
+                await self._protocol.write_event.wait()
+            elif not yielded:
+                await AsyncIOBackend.cancel_shielded_checkpoint()
 
 
 class UNIXDatagramSocket(_RawSocketMixin, abc.UNIXDatagramSocket):

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1711,10 +1711,12 @@ class UDPSocket(abc.UDPSocket):
 
     async def send(self, item: UDPPacketType) -> None:
         with self._send_guard:
-            await AsyncIOBackend.checkpoint()
-
             # Wait for any datagram the transport had to buffer to be flushed first
-            await self._protocol.write_event.wait()
+            if self._protocol.write_event.is_set():
+                await AsyncIOBackend.checkpoint()
+            else:
+                await self._protocol.write_event.wait()
+
             if self._closed:
                 raise ClosedResourceError
             elif self._transport.is_closing():
@@ -1769,10 +1771,12 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
 
     async def send(self, item: bytes) -> None:
         with self._send_guard:
-            await AsyncIOBackend.checkpoint()
-
             # Wait for any datagram the transport had to buffer to be flushed first
-            await self._protocol.write_event.wait()
+            if self._protocol.write_event.is_set():
+                await AsyncIOBackend.checkpoint()
+            else:
+                await self._protocol.write_event.wait()
+
             if self._closed:
                 raise ClosedResourceError
             elif self._transport.is_closing():

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1712,6 +1712,12 @@ class UDPSocket(abc.UDPSocket):
     async def send(self, item: UDPPacketType) -> None:
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
+
+            # Wait until the transport has flushed any datagram the OS previously
+            # refused, so that this datagram is not merely appended to the transport's
+            # buffer (which would happen if a previous send() was cancelled while
+            # waiting below)
+            await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
             elif self._transport.is_closing():
@@ -1768,6 +1774,12 @@ class ConnectedUDPSocket(abc.ConnectedUDPSocket):
     async def send(self, item: bytes) -> None:
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
+
+            # Wait until the transport has flushed any datagram the OS previously
+            # refused, so that this datagram is not merely appended to the transport's
+            # buffer (which would happen if a previous send() was cancelled while
+            # waiting below)
+            await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
             elif self._transport.is_closing():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,24 @@ for backend_name in get_all_backends():
     )
 
 
+@pytest.fixture
+def check_libuv_udp_error_bug(anyio_backend_options: dict[str, Any]) -> None:
+    """
+    Skip the test on winloop, which never reports ICMP errors on UDP sockets.
+
+    This is not winloop's doing: libuv deliberately ignores ``WSAECONNRESET`` and
+    ``WSAENETRESET`` on Windows UDP receives (``src/win/udp.c``), reporting them as
+    "nothing to read" instead, so the error never reaches the protocol. libuv on other
+    platforms does report them, which is why uvloop is unaffected.
+    """
+    # ``uvloop`` is the winloop module on Windows (see the import above)
+    if (
+        uvloop_name == "winloop"
+        and anyio_backend_options.get("loop_factory") is uvloop.new_event_loop
+    ):
+        pytest.skip("libuv ignores ICMP errors on UDP sockets on Windows")
+
+
 @pytest.fixture(scope="session", autouse=True)
 def suppress_slow_callbacks() -> None:
     class SuppressSlowCallbacks(logging.Filter):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -2087,6 +2087,65 @@ class TestUDPSocket:
 
                 assert b"two" not in received
 
+    @skip_no_dgram_backpressure_mark
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
+    async def test_send_stays_blocked_when_another_task_takes_the_error(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A sender must not be released by an error that another task has claimed.
+
+        ``error_received()`` sets the write event while the transport is still paused,
+        so that a sender blocked on it can raise the error. If a concurrent
+        ``receive()`` claims that error first, the woken sender must go back to waiting
+        instead of handing its datagram to a transport that would merely append it to
+        its buffer.
+        """
+        sock, peer, peer_path, capacity = make_backpressured_pair(
+            tmp_path, connect=False
+        )
+        addr = cast(IPSockAddrType, peer_path)
+        with peer:
+            async with await UDPSocket.from_socket(sock) as udp:
+                protocol = cast(Any, udp)._protocol
+                transport = cast(Any, udp)._transport
+
+                # Fill up the send buffer again
+                for _ in range(capacity):
+                    await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
+
+                # Cancel a paused send, leaving its datagram in the transport's buffer
+                async with create_task_group() as tg:
+                    tg.start_soon(udp.send, (b"one", addr))
+                    await wait_all_tasks_blocked()
+                    tg.cancel_scope.cancel()
+
+                assert protocol.write_paused
+                buffered = transport.get_write_buffer_size()
+                assert buffered > 0
+
+                with fail_after(5):
+                    async with create_task_group() as tg:
+                        tg.start_soon(udp.send, (b"two", addr))
+                        await wait_all_tasks_blocked()
+
+                        # The OS reports an error, waking the blocked sender, but a
+                        # receiver claims it before the sender gets to run
+                        protocol.error_received(OSError(errno.ECONNREFUSED, "nope"))
+                        assert protocol.take_exception() is not None
+
+                        await wait_all_tasks_blocked()
+                        size_while_paused = transport.get_write_buffer_size()
+
+                        # Let the sender finish, so that the transport's buffer is
+                        # empty by the time the socket is closed
+                        received = await receive_datagrams_until(peer, b"two")
+
+                assert size_while_paused == buffered, (
+                    "send() handed its datagram to a still-paused transport"
+                )
+                assert b"one" in received
+
     async def test_iterate(self, family: AnyIPAddressFamily) -> None:
         async def serve() -> None:
             async for packet, addr in server:
@@ -2483,6 +2542,64 @@ class TestConnectedUDPSocket:
                         received = await receive_datagrams_until(peer, b"three")
 
                 assert b"two" not in received
+
+    @skip_no_dgram_backpressure_mark
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
+    async def test_send_stays_blocked_when_another_task_takes_the_error(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A sender must not be released by an error that another task has claimed.
+
+        ``error_received()`` sets the write event while the transport is still paused,
+        so that a sender blocked on it can raise the error. If a concurrent
+        ``receive()`` claims that error first, the woken sender must go back to waiting
+        instead of handing its datagram to a transport that would merely append it to
+        its buffer.
+        """
+        sock, peer, _peer_path, capacity = make_backpressured_pair(
+            tmp_path, connect=True
+        )
+        with peer:
+            async with await ConnectedUDPSocket.from_socket(sock) as udp:
+                protocol = cast(Any, udp)._protocol
+                transport = cast(Any, udp)._transport
+
+                # Fill up the send buffer again
+                for _ in range(capacity):
+                    await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
+
+                # Cancel a paused send, leaving its datagram in the transport's buffer
+                async with create_task_group() as tg:
+                    tg.start_soon(udp.send, b"one")
+                    await wait_all_tasks_blocked()
+                    tg.cancel_scope.cancel()
+
+                assert protocol.write_paused
+                buffered = transport.get_write_buffer_size()
+                assert buffered > 0
+
+                with fail_after(5):
+                    async with create_task_group() as tg:
+                        tg.start_soon(udp.send, b"two")
+                        await wait_all_tasks_blocked()
+
+                        # The OS reports an error, waking the blocked sender, but a
+                        # receiver claims it before the sender gets to run
+                        protocol.error_received(OSError(errno.ECONNREFUSED, "nope"))
+                        assert protocol.take_exception() is not None
+
+                        await wait_all_tasks_blocked()
+                        size_while_paused = transport.get_write_buffer_size()
+
+                        # Let the sender finish, so that the transport's buffer is
+                        # empty by the time the socket is closed
+                        received = await receive_datagrams_until(peer, b"two")
+
+                assert size_while_paused == buffered, (
+                    "send() handed its datagram to a still-paused transport"
+                )
+                assert b"one" in received
 
     async def test_iterate(self, family: AnyIPAddressFamily) -> None:
         async def serve() -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -58,6 +58,7 @@ from anyio import (
     getnameinfo,
     move_on_after,
     notify_closing,
+    sleep,
     sleep_forever,
     wait_all_tasks_blocked,
     wait_readable,
@@ -1943,6 +1944,91 @@ class TestUDPSocket:
                 assert blocked, "send() returned before the OS accepted the datagram"
                 assert send_completed
 
+    async def test_send_reports_error(
+        self, family: AnyIPAddressFamily, free_udp_port: int
+    ) -> None:
+        """
+        ``sendto()`` must report an error reported by the OS instead of silently
+        discarding it, just like the Trio backend does.
+
+        Unconnected sockets are not told about ICMP errors on POSIX, so the error is
+        elicited by sending a datagram larger than the maximum size of a UDP packet,
+        which the OS refuses to send.
+        """
+        host = "127.0.0.1" if family == socket.AF_INET else "::1"
+        async with await create_udp_socket(family=family, local_host=host) as udp:
+            with fail_after(5), pytest.raises(BrokenResourceError) as exc_info:
+                while True:
+                    await udp.sendto(b"\x00" * 70000, host, free_udp_port)
+                    await sleep(0.01)
+
+            # EMSGSIZE on POSIX; WSAEMSGSIZE on Windows
+            assert isinstance(exc_info.value.__cause__, OSError)
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="the proactor event loop only reports the error asynchronously",
+    )
+    async def test_send_error_not_reported_to_receiver(
+        self, family: AnyIPAddressFamily, free_udp_port: int
+    ) -> None:
+        """
+        The error must be raised by the ``sendto()`` call that caused it, and not
+        handed to an unrelated task blocked in ``receive()``.
+
+        On the asyncio backend the transport reports the error to the protocol, which
+        both paths share, so the sender has to claim it before the receiver sees it.
+        """
+        host = "127.0.0.1" if family == socket.AF_INET else "::1"
+        async with await create_udp_socket(family=family, local_host=host) as udp:
+            local_host, local_port = cast(
+                tuple[str, int], udp.extra(SocketAttribute.local_address)
+            )
+
+            async def receive() -> None:
+                packet, _addr = await udp.receive()
+                assert packet == b"hello"
+
+            with fail_after(5):
+                async with create_task_group() as tg:
+                    tg.start_soon(receive)
+                    await wait_all_tasks_blocked()
+                    with pytest.raises(BrokenResourceError) as exc_info:
+                        await udp.sendto(b"\x00" * 70000, host, free_udp_port)
+
+                    assert isinstance(exc_info.value.__cause__, OSError)
+
+                    # The receiver must still be waiting for a real datagram
+                    await wait_all_tasks_blocked()
+                    await udp.sendto(b"hello", local_host, local_port)
+
+    async def test_socket_usable_after_error(
+        self, family: AnyIPAddressFamily, free_udp_port: int
+    ) -> None:
+        """
+        An error reported by the OS must only be raised once, leaving the socket usable
+        afterwards (a rejected datagram does not invalidate the socket).
+        """
+        host = "127.0.0.1" if family == socket.AF_INET else "::1"
+        async with await create_udp_socket(family=family, local_host=host) as udp:
+            with fail_after(5), pytest.raises(BrokenResourceError) as exc_info:
+                while True:
+                    await udp.sendto(b"\x00" * 70000, host, free_udp_port)
+                    await sleep(0.01)
+
+            assert isinstance(exc_info.value.__cause__, OSError)
+
+            # The socket must still be able to send a datagram of a sane size
+            async with await create_udp_socket(
+                family=family, local_host=host, local_port=free_udp_port
+            ) as peer:
+                with fail_after(5):
+                    await udp.sendto(b"hello", host, free_udp_port)
+                    packet, addr = await peer.receive()
+
+                assert packet == b"hello"
+                assert addr == udp.extra(SocketAttribute.local_address)
+
     async def test_iterate(self, family: AnyIPAddressFamily) -> None:
         async def serve() -> None:
             async for packet, addr in server:
@@ -2162,6 +2248,144 @@ class TestConnectedUDPSocket:
                 assert blocked, "send() returned before the OS accepted the datagram"
                 assert send_completed
 
+    @pytest.mark.usefixtures("check_libuv_udp_error_bug")
+    async def test_receive_wakes_up_on_error(
+        self, family: AnyIPAddressFamily, free_udp_port: int
+    ) -> None:
+        """
+        A blocked ``receive()`` must be woken up when the OS reports an error on the
+        socket, instead of blocking forever.
+
+        The error is elicited by sending a datagram to a port nobody is listening on,
+        which makes the OS send back an ICMP port unreachable message.
+        """
+        host = "127.0.0.1" if family == socket.AF_INET else "::1"
+        async with await create_connected_udp_socket(
+            host, free_udp_port, family=family
+        ) as udp:
+
+            async def receive() -> None:
+                with pytest.raises(BrokenResourceError) as exc_info:
+                    await udp.receive()
+
+                # ConnectionRefusedError on POSIX; on Windows either
+                # ConnectionResetError or a plain OSError carrying
+                # ERROR_PORT_UNREACHABLE, depending on the backend
+                assert isinstance(exc_info.value.__cause__, OSError)
+
+            with fail_after(5):
+                async with create_task_group() as tg:
+                    tg.start_soon(receive)
+                    await wait_all_tasks_blocked()
+                    await udp.send(b"blah")
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows only reports the error to the receive path",
+    )
+    async def test_send_reports_error(
+        self, family: AnyIPAddressFamily, free_udp_port: int
+    ) -> None:
+        """
+        ``send()`` must report an error received from the OS instead of silently
+        discarding it, just like the Trio backend does.
+
+        The error is elicited by sending a datagram to a port nobody is listening on,
+        which makes the OS send back an ICMP port unreachable message.
+        """
+        host = "127.0.0.1" if family == socket.AF_INET else "::1"
+        async with await create_connected_udp_socket(
+            host, free_udp_port, family=family
+        ) as udp:
+            with fail_after(5), pytest.raises(BrokenResourceError) as exc_info:
+                while True:
+                    await udp.send(b"blah")
+                    await sleep(0.01)
+
+            # ConnectionRefusedError on POSIX; on Windows either
+            # ConnectionResetError or a plain OSError carrying
+            # ERROR_PORT_UNREACHABLE, depending on the backend
+            assert isinstance(exc_info.value.__cause__, OSError)
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="the proactor event loop only reports the error asynchronously",
+    )
+    async def test_send_error_not_reported_to_receiver(
+        self, family: AnyIPAddressFamily
+    ) -> None:
+        """
+        The error must be raised by the ``send()`` call that caused it, and not handed
+        to an unrelated task blocked in ``receive()``.
+
+        On the asyncio backend the transport reports the error to the protocol, which
+        both paths share, so the sender has to claim it before the receiver sees it.
+        An ICMP port unreachable would only be reported asynchronously, so the error is
+        elicited by sending a datagram larger than the maximum size of a UDP packet,
+        which the OS refuses to send right away.
+        """
+        host = "127.0.0.1" if family == socket.AF_INET else "::1"
+        async with await create_udp_socket(family=family, local_host=host) as peer:
+            peer_host, peer_port = cast(
+                tuple[str, int], peer.extra(SocketAttribute.local_address)
+            )
+            async with await create_connected_udp_socket(
+                peer_host, peer_port, family=family
+            ) as udp:
+                local_host, local_port = cast(
+                    tuple[str, int], udp.extra(SocketAttribute.local_address)
+                )
+
+                async def receive() -> None:
+                    assert await udp.receive() == b"hello"
+
+                with fail_after(5):
+                    async with create_task_group() as tg:
+                        tg.start_soon(receive)
+                        await wait_all_tasks_blocked()
+                        with pytest.raises(BrokenResourceError) as exc_info:
+                            await udp.send(b"\x00" * 70000)
+
+                        # EMSGSIZE on POSIX; WSAEMSGSIZE on Windows
+                        assert isinstance(exc_info.value.__cause__, OSError)
+
+                        # The receiver must still be waiting for a real datagram
+                        await wait_all_tasks_blocked()
+                        await peer.sendto(b"hello", local_host, local_port)
+
+    @pytest.mark.usefixtures("check_libuv_udp_error_bug")
+    async def test_socket_usable_after_error(
+        self, family: AnyIPAddressFamily, free_udp_port: int
+    ) -> None:
+        """
+        An error reported by the OS must only be raised once, leaving the socket
+        usable afterwards, just like on the Trio backend (an ICMP port unreachable
+        does not invalidate the socket).
+        """
+        host = "127.0.0.1" if family == socket.AF_INET else "::1"
+        async with await create_connected_udp_socket(
+            host, free_udp_port, family=family
+        ) as udp:
+            # Elicit an ICMP port unreachable message and let it be reported
+            await udp.send(b"blah")
+            with fail_after(5), pytest.raises(BrokenResourceError) as exc_info:
+                await udp.receive()
+
+            # ConnectionRefusedError on POSIX; on Windows either
+            # ConnectionResetError or a plain OSError carrying
+            # ERROR_PORT_UNREACHABLE, depending on the backend
+            assert isinstance(exc_info.value.__cause__, OSError)
+
+            # The socket must work again now that somebody is listening on the port
+            async with await create_udp_socket(
+                family=family, local_host=host, local_port=free_udp_port
+            ) as peer:
+                with fail_after(5):
+                    await udp.send(b"hello")
+                    packet, _addr = await peer.receive()
+
+                assert packet == b"hello"
+
     async def test_iterate(self, family: AnyIPAddressFamily) -> None:
         async def serve() -> None:
             async for packet in udp2:
@@ -2278,6 +2502,36 @@ class TestConnectedUDPSocket:
         sock_or_fd = sock_or_fd_factory(socket.AF_INET, socket.SOCK_DGRAM, bound=True)
         with pytest.raises(ValueError, match="the socket must be connected"):
             await ConnectedUDPSocket.from_socket(sock_or_fd)
+
+
+@pytest.mark.parametrize("anyio_backend", asyncio_params)
+async def test_datagram_protocol_restores_back_pressure() -> None:
+    """
+    ``error_received()`` wakes up a sender waiting on the write event, but if the
+    transport is still paused, the event has to be cleared again once the error has
+    been raised, or the back-pressure would be lost.
+
+    This can only be tested directly, as pausing a datagram transport requires the OS
+    to refuse datagrams, which loopback UDP sockets never do.
+    """
+    from anyio._backends._asyncio import DatagramProtocol
+
+    protocol = DatagramProtocol()
+    protocol.connection_made(MagicMock())
+    protocol.pause_writing()
+    assert not protocol.write_event.is_set()
+
+    # The sender must be woken up by the error
+    protocol.error_received(ConnectionRefusedError())
+    assert protocol.write_event.is_set()
+
+    # ...but only to raise it, after which it must wait for the transport again
+    assert isinstance(protocol.take_exception(), ConnectionRefusedError)
+    assert protocol.take_exception() is None
+    assert not protocol.write_event.is_set()
+
+    protocol.resume_writing()
+    assert protocol.write_event.is_set()
 
 
 @pytest.mark.skipif(

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1777,6 +1777,23 @@ def drain_datagram_socket(sock: socket.socket) -> None:
         pass
 
 
+async def receive_datagrams_until(sock: socket.socket, sentinel: bytes) -> list[bytes]:
+    """
+    Receive datagrams from ``sock`` until ``sentinel`` has been received.
+
+    :return: every datagram received, in the order they arrived, ``sentinel`` last
+
+    """
+    received: list[bytes] = []
+    while not received or received[-1] != sentinel:
+        try:
+            received.append(sock.recv(65536))
+        except BlockingIOError:
+            await wait_readable(sock)
+
+    return received
+
+
 def make_backpressured_pair(
     tmp_path: Path, *, connect: bool
 ) -> tuple[socket.socket, socket.socket, str, int]:
@@ -1942,6 +1959,47 @@ class TestUDPSocket:
 
                 assert blocked, "send() returned before the OS accepted the datagram"
                 assert send_completed
+
+    @skip_no_dgram_backpressure_mark
+    async def test_cancelled_send_does_not_buffer_the_next_datagram(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A ``send()`` cancelled while blocked must not let the next one skip ahead.
+
+        On asyncio, the datagram of the *first* cancelled send has unavoidably been
+        buffered by the transport already, but any subsequent ``send()`` must wait for
+        that buffer to be flushed instead of appending to it — otherwise repeated
+        cancellation would grow the transport's buffer without bound, despite the zero
+        high water mark.
+        """
+        sock, peer, peer_path, capacity = make_backpressured_pair(
+            tmp_path, connect=False
+        )
+        addr = cast(IPSockAddrType, peer_path)
+        with peer:
+            async with await UDPSocket.from_socket(sock) as udp:
+                # Fill up the send buffer again
+                for _ in range(capacity):
+                    await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
+
+                async def send_and_cancel(payload: bytes) -> None:
+                    async with create_task_group() as tg:
+                        tg.start_soon(udp.send, (payload, addr))
+                        await wait_all_tasks_blocked()
+                        tg.cancel_scope.cancel()
+
+                with fail_after(5):
+                    # The first cancelled send may leave its datagram in the asyncio
+                    # transport's buffer, but the second one must never reach it
+                    await send_and_cancel(b"one")
+                    await send_and_cancel(b"two")
+
+                    async with create_task_group() as tg:
+                        tg.start_soon(udp.send, (b"three", addr))
+                        received = await receive_datagrams_until(peer, b"three")
+
+                assert b"two" not in received
 
     async def test_iterate(self, family: AnyIPAddressFamily) -> None:
         async def serve() -> None:
@@ -2161,6 +2219,46 @@ class TestConnectedUDPSocket:
 
                 assert blocked, "send() returned before the OS accepted the datagram"
                 assert send_completed
+
+    @skip_no_dgram_backpressure_mark
+    async def test_cancelled_send_does_not_buffer_the_next_datagram(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A ``send()`` cancelled while blocked must not let the next one skip ahead.
+
+        On asyncio, the datagram of the *first* cancelled send has unavoidably been
+        buffered by the transport already, but any subsequent ``send()`` must wait for
+        that buffer to be flushed instead of appending to it — otherwise repeated
+        cancellation would grow the transport's buffer without bound, despite the zero
+        high water mark.
+        """
+        sock, peer, _peer_path, capacity = make_backpressured_pair(
+            tmp_path, connect=True
+        )
+        with peer:
+            async with await ConnectedUDPSocket.from_socket(sock) as udp:
+                # Fill up the send buffer again
+                for _ in range(capacity):
+                    await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
+
+                async def send_and_cancel(payload: bytes) -> None:
+                    async with create_task_group() as tg:
+                        tg.start_soon(udp.send, payload)
+                        await wait_all_tasks_blocked()
+                        tg.cancel_scope.cancel()
+
+                with fail_after(5):
+                    # The first cancelled send may leave its datagram in the asyncio
+                    # transport's buffer, but the second one must never reach it
+                    await send_and_cancel(b"one")
+                    await send_and_cancel(b"two")
+
+                    async with create_task_group() as tg:
+                        tg.start_soon(udp.send, b"three")
+                        received = await receive_datagrams_until(peer, b"three")
+
+                assert b"two" not in received
 
     async def test_iterate(self, family: AnyIPAddressFamily) -> None:
         async def serve() -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1926,15 +1926,14 @@ class TestUDPSocket:
 
                 send_completed = False
 
-                async def send_two_more() -> None:
+                async def send_one_more() -> None:
                     nonlocal send_completed
-                    await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
                     await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
                     send_completed = True
 
                 with fail_after(5):
                     async with create_task_group() as tg:
-                        tg.start_soon(send_two_more)
+                        tg.start_soon(send_one_more)
                         await wait_all_tasks_blocked()
                         blocked = not send_completed
 
@@ -2146,15 +2145,14 @@ class TestConnectedUDPSocket:
 
                 send_completed = False
 
-                async def send_two_more() -> None:
+                async def send_one_more() -> None:
                     nonlocal send_completed
-                    await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
                     await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
                     send_completed = True
 
                 with fail_after(5):
                     async with create_task_group() as tg:
-                        tg.start_soon(send_two_more)
+                        tg.start_soon(send_one_more)
                         await wait_all_tasks_blocked()
                         blocked = not send_completed
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -117,6 +117,10 @@ skip_unix_abstract_mark = pytest.mark.skipif(
     not sys.platform.startswith("linux"),
     reason="Abstract namespace sockets is a Linux only feature",
 )
+skip_no_dgram_backpressure_mark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Datagram sockets are only known to refuse datagrams with EAGAIN on Linux",
+)
 
 
 @pytest.fixture
@@ -1761,6 +1765,72 @@ async def test_multi_listener(tmp_path_factory: TempPathFactory) -> None:
         assert client_addresses == expected_addresses
 
 
+DGRAM_BACKPRESSURE_PAYLOAD = b"\x00" * 64
+
+
+def drain_datagram_socket(sock: socket.socket) -> None:
+    """Receive and discard every datagram currently queued on ``sock``."""
+    try:
+        while True:
+            sock.recv(65536)
+    except BlockingIOError:
+        pass
+
+
+def make_backpressured_pair(
+    tmp_path: Path, *, connect: bool
+) -> tuple[socket.socket, socket.socket, str, int]:
+    """
+    Create a datagram socket that the operating system will refuse datagrams from,
+    along with the peer it sends to.
+
+    UNIX datagram sockets are used here because UDP sockets never exert any
+    back-pressure on the loopback interface: the kernel accounts for the datagram
+    only until it has been delivered or dropped, so ``sendto()`` always succeeds, no
+    matter how small the send buffer is or how full the peer's receive buffer is.
+    UNIX datagram sockets, on the other hand, refuse datagrams with ``EAGAIN`` once
+    the send buffer is full, and they go through the very same code path in both
+    backends.
+
+    The send buffer is deliberately made as small as the OS allows, so that only a
+    handful of datagrams are needed to fill it up. The buffer is left empty on
+    return.
+
+    :return: the socket, its peer, the peer's path, and the number of datagrams the
+        OS accepts before it starts refusing them
+
+    """
+    peer_path = str(tmp_path / "peer.sock")
+    peer = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    peer.setblocking(False)
+    peer.bind(peer_path)
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    sock.bind(str(tmp_path / "local.sock"))
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1024)
+    if connect:
+        sock.connect(peer_path)
+
+    sock.setblocking(False)
+
+    # Find out how many datagrams the OS accepts before it refuses any more, and then
+    # empty both buffers again
+    capacity = 0
+    try:
+        while True:
+            if connect:
+                sock.send(DGRAM_BACKPRESSURE_PAYLOAD)
+            else:
+                sock.sendto(DGRAM_BACKPRESSURE_PAYLOAD, peer_path)
+
+            capacity += 1
+    except BlockingIOError:
+        pass
+
+    assert capacity >= 2, f"the send buffer only fits {capacity} datagram(s)"
+    drain_datagram_socket(peer)
+    return sock, peer, peer_path, capacity
+
+
 @pytest.mark.network
 @pytest.mark.usefixtures("check_asyncio_bug")
 class TestUDPSocket:
@@ -1831,6 +1901,48 @@ class TestUDPSocket:
             response, addr = await sock.receive()
             assert response == b"halb"
             assert addr == (host, port)
+
+    @skip_no_dgram_backpressure_mark
+    async def test_send_waits_for_the_os_to_accept_the_datagram(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        ``send()`` must not return before the OS has accepted the datagram.
+
+        The asyncio backend sets the transport's write buffer high water mark to 0,
+        so the transport pauses the sender as soon as it has had to buffer a datagram
+        the OS refused, instead of quietly buffering up to 64 KiB worth of them. The
+        trio backend never buffers datagrams to begin with.
+        """
+        sock, peer, peer_path, capacity = make_backpressured_pair(
+            tmp_path, connect=False
+        )
+        addr = cast(IPSockAddrType, peer_path)
+        with peer:
+            async with await UDPSocket.from_socket(sock) as udp:
+                # Fill up the send buffer again
+                for _ in range(capacity):
+                    await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
+
+                send_completed = False
+
+                async def send_two_more() -> None:
+                    nonlocal send_completed
+                    await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
+                    await udp.send((DGRAM_BACKPRESSURE_PAYLOAD, addr))
+                    send_completed = True
+
+                with fail_after(5):
+                    async with create_task_group() as tg:
+                        tg.start_soon(send_two_more)
+                        await wait_all_tasks_blocked()
+                        blocked = not send_completed
+
+                        # Make room in the send buffer so the sender can continue
+                        drain_datagram_socket(peer)
+
+                assert blocked, "send() returned before the OS accepted the datagram"
+                assert send_completed
 
     async def test_iterate(self, family: AnyIPAddressFamily) -> None:
         async def serve() -> None:
@@ -2010,6 +2122,47 @@ class TestConnectedUDPSocket:
                 await udp1.sendto(b"halb", host, port)
                 response = await udp2.receive()
                 assert response == b"halb"
+
+    @skip_no_dgram_backpressure_mark
+    async def test_send_waits_for_the_os_to_accept_the_datagram(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        ``send()`` must not return before the OS has accepted the datagram.
+
+        The asyncio backend sets the transport's write buffer high water mark to 0,
+        so the transport pauses the sender as soon as it has had to buffer a datagram
+        the OS refused, instead of quietly buffering up to 64 KiB worth of them. The
+        trio backend never buffers datagrams to begin with.
+        """
+        sock, peer, _peer_path, capacity = make_backpressured_pair(
+            tmp_path, connect=True
+        )
+        with peer:
+            async with await ConnectedUDPSocket.from_socket(sock) as udp:
+                # Fill up the send buffer again
+                for _ in range(capacity):
+                    await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
+
+                send_completed = False
+
+                async def send_two_more() -> None:
+                    nonlocal send_completed
+                    await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
+                    await udp.send(DGRAM_BACKPRESSURE_PAYLOAD)
+                    send_completed = True
+
+                with fail_after(5):
+                    async with create_task_group() as tg:
+                        tg.start_soon(send_two_more)
+                        await wait_all_tasks_blocked()
+                        blocked = not send_completed
+
+                        # Make room in the send buffer so the sender can continue
+                        drain_datagram_socket(peer)
+
+                assert blocked, "send() returned before the OS accepted the datagram"
+                assert send_completed
 
     async def test_iterate(self, family: AnyIPAddressFamily) -> None:
         async def serve() -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1769,7 +1769,6 @@ DGRAM_BACKPRESSURE_PAYLOAD = b"\x00" * 64
 
 
 def drain_datagram_socket(sock: socket.socket) -> None:
-    """Receive and discard every datagram currently queued on ``sock``."""
     try:
         while True:
             sock.recv(65536)
@@ -1778,12 +1777,7 @@ def drain_datagram_socket(sock: socket.socket) -> None:
 
 
 async def receive_datagrams_until(sock: socket.socket, sentinel: bytes) -> list[bytes]:
-    """
-    Receive datagrams from ``sock`` until ``sentinel`` has been received.
-
-    :return: every datagram received, in the order they arrived, ``sentinel`` last
-
-    """
+    """Receive datagrams until ``sentinel`` arrives, and return all of them."""
     received: list[bytes] = []
     while not received or received[-1] != sentinel:
         try:
@@ -1798,23 +1792,13 @@ def make_backpressured_pair(
     tmp_path: Path, *, connect: bool
 ) -> tuple[socket.socket, socket.socket, str, int]:
     """
-    Create a datagram socket that the operating system will refuse datagrams from,
-    along with the peer it sends to.
+    Create a datagram socket with a full send buffer, along with the peer it sends to.
 
-    UNIX datagram sockets are used here because UDP sockets never exert any
-    back-pressure on the loopback interface: the kernel accounts for the datagram
-    only until it has been delivered or dropped, so ``sendto()`` always succeeds, no
-    matter how small the send buffer is or how full the peer's receive buffer is.
-    UNIX datagram sockets, on the other hand, refuse datagrams with ``EAGAIN`` once
-    the send buffer is full, and they go through the very same code path in both
-    backends.
+    UNIX datagram sockets are used because UDP sockets never exert back-pressure on the
+    loopback interface, but they take the same code path in both backends.
 
-    The send buffer is deliberately made as small as the OS allows, so that only a
-    handful of datagrams are needed to fill it up. The buffer is left empty on
-    return.
-
-    :return: the socket, its peer, the peer's path, and the number of datagrams the
-        OS accepts before it starts refusing them
+    :return: the socket, its peer, the peer's path, and the number of datagrams the OS
+        accepts before it starts refusing them
 
     """
     peer_path = str(tmp_path / "peer.sock")
@@ -1923,14 +1907,6 @@ class TestUDPSocket:
     async def test_send_waits_for_the_os_to_accept_the_datagram(
         self, tmp_path: Path
     ) -> None:
-        """
-        ``send()`` must not return before the OS has accepted the datagram.
-
-        The asyncio backend sets the transport's write buffer high water mark to 0,
-        so the transport pauses the sender as soon as it has had to buffer a datagram
-        the OS refused, instead of quietly buffering up to 64 KiB worth of them. The
-        trio backend never buffers datagrams to begin with.
-        """
         sock, peer, peer_path, capacity = make_backpressured_pair(
             tmp_path, connect=False
         )
@@ -1964,15 +1940,6 @@ class TestUDPSocket:
     async def test_cancelled_send_does_not_buffer_the_next_datagram(
         self, tmp_path: Path
     ) -> None:
-        """
-        A ``send()`` cancelled while blocked must not let the next one skip ahead.
-
-        On asyncio, the datagram of the *first* cancelled send has unavoidably been
-        buffered by the transport already, but any subsequent ``send()`` must wait for
-        that buffer to be flushed instead of appending to it — otherwise repeated
-        cancellation would grow the transport's buffer without bound, despite the zero
-        high water mark.
-        """
         sock, peer, peer_path, capacity = make_backpressured_pair(
             tmp_path, connect=False
         )
@@ -2184,14 +2151,6 @@ class TestConnectedUDPSocket:
     async def test_send_waits_for_the_os_to_accept_the_datagram(
         self, tmp_path: Path
     ) -> None:
-        """
-        ``send()`` must not return before the OS has accepted the datagram.
-
-        The asyncio backend sets the transport's write buffer high water mark to 0,
-        so the transport pauses the sender as soon as it has had to buffer a datagram
-        the OS refused, instead of quietly buffering up to 64 KiB worth of them. The
-        trio backend never buffers datagrams to begin with.
-        """
         sock, peer, _peer_path, capacity = make_backpressured_pair(
             tmp_path, connect=True
         )
@@ -2224,15 +2183,6 @@ class TestConnectedUDPSocket:
     async def test_cancelled_send_does_not_buffer_the_next_datagram(
         self, tmp_path: Path
     ) -> None:
-        """
-        A ``send()`` cancelled while blocked must not let the next one skip ahead.
-
-        On asyncio, the datagram of the *first* cancelled send has unavoidably been
-        buffered by the transport already, but any subsequent ``send()`` must wait for
-        that buffer to be flushed instead of appending to it — otherwise repeated
-        cancellation would grow the transport's buffer without bound, despite the zero
-        high water mark.
-        """
         sock, peer, _peer_path, capacity = make_backpressured_pair(
             tmp_path, connect=True
         )

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -2525,8 +2525,14 @@ async def test_datagram_protocol_restores_back_pressure() -> None:
     protocol.error_received(ConnectionRefusedError())
     assert protocol.write_event.is_set()
 
-    # ...but only to raise it, after which it must wait for the transport again
+    # Errors are queued, so a second one doesn't displace the first
+    protocol.error_received(ConnectionResetError())
+
+    # ...but the sender is only woken up to raise them, after which it must wait for
+    # the transport again
     assert isinstance(protocol.take_exception(), ConnectionRefusedError)
+    assert protocol.write_event.is_set()
+    assert isinstance(protocol.take_exception(), ConnectionResetError)
     assert protocol.take_exception() is None
     assert not protocol.write_event.is_set()
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1940,14 +1940,8 @@ class TestUDPSocket:
     async def test_send_reports_error(
         self, family: AnyIPAddressFamily, free_udp_port: int
     ) -> None:
-        """
-        ``sendto()`` must report an error reported by the OS instead of silently
-        discarding it, just like the Trio backend does.
-
-        Unconnected sockets are not told about ICMP errors on POSIX, so the error is
-        elicited by sending a datagram larger than the maximum size of a UDP packet,
-        which the OS refuses to send.
-        """
+        # Unconnected sockets are not told about ICMP errors on POSIX, so an
+        # oversized datagram is used to elicit an error from the OS instead
         host = "127.0.0.1" if family == socket.AF_INET else "::1"
         async with await create_udp_socket(family=family, local_host=host) as udp:
             with fail_after(5), pytest.raises(BrokenResourceError) as exc_info:
@@ -1965,13 +1959,8 @@ class TestUDPSocket:
     async def test_send_error_not_reported_to_receiver(
         self, family: AnyIPAddressFamily, free_udp_port: int
     ) -> None:
-        """
-        The error must be raised by the ``sendto()`` call that caused it, and not
-        handed to an unrelated task blocked in ``receive()``.
-
-        On the asyncio backend the transport reports the error to the protocol, which
-        both paths share, so the sender has to claim it before the receiver sees it.
-        """
+        # On asyncio both paths share the protocol the transport reports errors to,
+        # so the sender has to claim the error before the receiver sees it
         host = "127.0.0.1" if family == socket.AF_INET else "::1"
         async with await create_udp_socket(family=family, local_host=host) as udp:
             local_host, local_port = cast(
@@ -1998,10 +1987,8 @@ class TestUDPSocket:
     async def test_socket_usable_after_error(
         self, family: AnyIPAddressFamily, free_udp_port: int
     ) -> None:
-        """
-        An error reported by the OS must only be raised once, leaving the socket usable
-        afterwards (a rejected datagram does not invalidate the socket).
-        """
+        # A rejected datagram does not invalidate the socket, so the error must only
+        # be raised once
         host = "127.0.0.1" if family == socket.AF_INET else "::1"
         async with await create_udp_socket(family=family, local_host=host) as udp:
             with fail_after(5), pytest.raises(BrokenResourceError) as exc_info:
@@ -2060,13 +2047,8 @@ class TestUDPSocket:
         self, tmp_path: Path
     ) -> None:
         """
-        A sender must not be released by an error that another task has claimed.
-
         ``error_received()`` sets the write event while the transport is still paused,
-        so that a sender blocked on it can raise the error. If a concurrent
-        ``receive()`` claims that error first, the woken sender must go back to waiting
-        instead of handing its datagram to a transport that would merely append it to
-        its buffer.
+        so a sender woken by an error that another task claimed must resume waiting.
         """
         sock, peer, peer_path, capacity = make_backpressured_pair(
             tmp_path, connect=False
@@ -2328,13 +2310,6 @@ class TestConnectedUDPSocket:
     async def test_receive_wakes_up_on_error(
         self, family: AnyIPAddressFamily, free_udp_port: int
     ) -> None:
-        """
-        A blocked ``receive()`` must be woken up when the OS reports an error on the
-        socket, instead of blocking forever.
-
-        The error is elicited by sending a datagram to a port nobody is listening on,
-        which makes the OS send back an ICMP port unreachable message.
-        """
         host = "127.0.0.1" if family == socket.AF_INET else "::1"
         async with await create_connected_udp_socket(
             host, free_udp_port, family=family
@@ -2362,13 +2337,6 @@ class TestConnectedUDPSocket:
     async def test_send_reports_error(
         self, family: AnyIPAddressFamily, free_udp_port: int
     ) -> None:
-        """
-        ``send()`` must report an error received from the OS instead of silently
-        discarding it, just like the Trio backend does.
-
-        The error is elicited by sending a datagram to a port nobody is listening on,
-        which makes the OS send back an ICMP port unreachable message.
-        """
         host = "127.0.0.1" if family == socket.AF_INET else "::1"
         async with await create_connected_udp_socket(
             host, free_udp_port, family=family
@@ -2390,16 +2358,10 @@ class TestConnectedUDPSocket:
     async def test_send_error_not_reported_to_receiver(
         self, family: AnyIPAddressFamily
     ) -> None:
-        """
-        The error must be raised by the ``send()`` call that caused it, and not handed
-        to an unrelated task blocked in ``receive()``.
-
-        On the asyncio backend the transport reports the error to the protocol, which
-        both paths share, so the sender has to claim it before the receiver sees it.
-        An ICMP port unreachable would only be reported asynchronously, so the error is
-        elicited by sending a datagram larger than the maximum size of a UDP packet,
-        which the OS refuses to send right away.
-        """
+        # On asyncio both paths share the protocol the transport reports errors to,
+        # so the sender has to claim the error before the receiver sees it. An
+        # oversized datagram is used because an ICMP port unreachable would only be
+        # reported asynchronously
         host = "127.0.0.1" if family == socket.AF_INET else "::1"
         async with await create_udp_socket(family=family, local_host=host) as peer:
             peer_host, peer_port = cast(
@@ -2433,11 +2395,8 @@ class TestConnectedUDPSocket:
     async def test_socket_usable_after_error(
         self, family: AnyIPAddressFamily, free_udp_port: int
     ) -> None:
-        """
-        An error reported by the OS must only be raised once, leaving the socket
-        usable afterwards, just like on the Trio backend (an ICMP port unreachable
-        does not invalidate the socket).
-        """
+        # An ICMP port unreachable does not invalidate the socket, so the error must
+        # only be raised once
         host = "127.0.0.1" if family == socket.AF_INET else "::1"
         async with await create_connected_udp_socket(
             host, free_udp_port, family=family
@@ -2499,13 +2458,8 @@ class TestConnectedUDPSocket:
         self, tmp_path: Path
     ) -> None:
         """
-        A sender must not be released by an error that another task has claimed.
-
         ``error_received()`` sets the write event while the transport is still paused,
-        so that a sender blocked on it can raise the error. If a concurrent
-        ``receive()`` claims that error first, the woken sender must go back to waiting
-        instead of handing its datagram to a transport that would merely append it to
-        its buffer.
+        so a sender woken by an error that another task claimed must resume waiting.
         """
         sock, peer, _peer_path, capacity = make_backpressured_pair(
             tmp_path, connect=True
@@ -2672,12 +2626,8 @@ class TestConnectedUDPSocket:
 @pytest.mark.parametrize("anyio_backend", asyncio_params)
 async def test_datagram_protocol_restores_back_pressure() -> None:
     """
-    ``error_received()`` wakes up a sender waiting on the write event, but if the
-    transport is still paused, the event has to be cleared again once the error has
-    been raised, or the back-pressure would be lost.
-
-    This can only be tested directly, as pausing a datagram transport requires the OS
-    to refuse datagrams, which loopback UDP sockets never do.
+    Tested directly, as pausing a datagram transport requires the OS to refuse
+    datagrams, which loopback UDP sockets never do.
     """
     from anyio._backends._asyncio import DatagramProtocol
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes
Fixed UDP sockets on the asyncio backend silently discarding errors reported by the OS (such as an ICMP port unreachable). A task blocked in ``receive()`` or ``send()`` is now woken up by such an error, and both raise ``BrokenResourceError``, chained to the original error, as they already did on the Trio backend. As on the Trio backend, the error is only reported once, leaving the socket usable afterwards

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
