### PR TITLE
Fix CancelScope reuse not being detected on the asyncio backend

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -95,6 +95,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
     task.
 
   (`#1197 <https://github.com/agronholm/anyio/issues/1197>`_; PR by @tapetersen)
+- Fixed ``CancelScope`` on the asyncio backend allowing a scope to be entered again
+  after it had been exited, instead of raising ``RuntimeError`` like the Trio backend
+  does. Reusing a cancelled scope silently cancelled the body of the second ``with``
+  block (`#1296 <https://github.com/agronholm/anyio/pull/1296>`_;
+  PR by @jaideeppyne)
 
 **4.14.2**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -390,6 +390,7 @@ class CancelScope(BaseCancelScope):
         "_cancelled_caught",
         "_child_scopes",
         "_deadline",
+        "_has_been_entered",
         "_host_task",
         "_parent_scope",
         "_pending_uncancellations",
@@ -410,6 +411,7 @@ class CancelScope(BaseCancelScope):
         self._cancel_reason: str | None = None
         self._cancelled_caught = False
         self._active = False
+        self._has_been_entered = False
         self._timeout_handle: asyncio.TimerHandle | None = None
         self._cancel_handle: asyncio.Handle | None = None
         self._tasks: set[asyncio.Task] = set()
@@ -420,11 +422,12 @@ class CancelScope(BaseCancelScope):
             self._pending_uncancellations = None
 
     def __enter__(self) -> Self:
-        if self._active:
+        if self._has_been_entered:
             raise RuntimeError(
                 "Each CancelScope may only be used for a single 'with' block"
             )
 
+        self._has_been_entered = True
         self._host_task = host_task = cast(asyncio.Task, current_task())
         self._tasks.add(host_task)
         try:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -1604,6 +1604,42 @@ async def test_cancelscope_exit_before_enter() -> None:
     pytest.raises(RuntimeError, scope.__exit__, None, None, None)
 
 
+async def test_cancelscope_reuse() -> None:
+    """
+    Test that a RuntimeError is raised if one tries to enter a cancel scope that has
+    already been exited.
+
+    """
+    scope = CancelScope()
+    with scope:
+        pass
+
+    with pytest.raises(
+        RuntimeError,
+        match="Each CancelScope may only be used for a single 'with' block",
+    ):
+        with scope:
+            pass
+
+
+async def test_cancelscope_reuse_after_cancel() -> None:
+    """
+    Test that reusing a cancelled cancel scope raises a RuntimeError instead of
+    silently cancelling the body of the second ``with`` block.
+
+    """
+    scope = CancelScope()
+    with scope:
+        scope.cancel()
+
+    with pytest.raises(
+        RuntimeError,
+        match="Each CancelScope may only be used for a single 'with' block",
+    ):
+        with scope:
+            await checkpoint()
+
+
 @pytest.mark.parametrize(
     "anyio_backend", asyncio_params
 )  # trio does not check for this yet


### PR DESCRIPTION
## Changes

`CancelScope.__enter__` on the asyncio backend guards against reuse with `if self._active:`, but `__exit__` sets `_active = False`. So the guard only catches re-entering a scope that is still active, and entering a scope again *after* it has exited slips through silently, even though the guard's own message promises that each scope may only be used for a single `with` block. The Trio backend raises `RuntimeError` here.

`_cancel_called` also survives the first block, so reusing a cancelled scope silently cancels the body of the second block:

```python
import anyio

async def main():
    scope = anyio.CancelScope()
    with scope:
        scope.cancel()

    with scope:
        await anyio.sleep(0)
        print("this never runs on asyncio")

anyio.run(main)                   # prints nothing, no error
anyio.run(main, backend="trio")   # RuntimeError: Each CancelScope may only be used for a single 'with' block
```

I track entry with a separate `_has_been_entered` flag that is never reset, which is how `TaskGroup` already guards its own re-entry in the same module. Both backends now raise the same `RuntimeError`.

The two new tests fail on `asyncio`, `asyncio+uvloop` and `asyncio+eager` without the patch, and already passed on Trio.

I found this with an asyncio/Trio differential harness. AI-assisted, and I ran and reviewed all of it myself.

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
