### PR TITLE
Fix wrong type in move_on_after

### DIFF
--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -6,7 +6,7 @@ from collections.abc import (
     Coroutine,
     Generator,
 )
-from contextlib import AbstractContextManager, contextmanager
+from contextlib import contextmanager
 from enum import Enum, auto
 from inspect import iscoroutine
 from types import TracebackType
@@ -198,9 +198,7 @@ def move_on_at(deadline: float | None, shield: bool = False) -> CancelScope:
     )
 
 
-def move_on_after(
-    delay: float | None, shield: bool = False
-) -> AbstractContextManager[CancelScope]:
+def move_on_after(delay: float | None, shield: bool = False) -> CancelScope:
     """
     Create a cancel scope with a deadline that expires after the given delay.
 


### PR DESCRIPTION
## Changes

Fixes wrong type where `move_on_after` is typed as returning `AbstractContextManager[CancelScope]` even though it actually returns a `CancelScope`. This manifests in code where the scope is created first and entered later:

```python
scope = move_on_after(1)
print(scope.deadline)  # error: "AbstractContextManager[CancelScope, bool | None]" has no attribute "deadline"  [attr-defined]
with scope:
    ...
```

This code works fine, but mypy complains with `error: "AbstractContextManager[CancelScope, bool | None]" has no attribute "deadline"  [attr-defined]` as it (correctly) treats scope as an unentered context manager (like `fail_after` in current implementation) instead of a `CancelScope` that simply defines `__enter__` and `__exit__`.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
