### PR TITLE
Fix SocketStream.send() writing to a paused transport after a cancelled send

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -85,10 +85,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   fails; default task creation is unaffected
   (`#1274 <https://github.com/agronholm/anyio/issues/1274>`_; PR by @dsfaccini)
 - Fixed ``SocketStream.send()`` on the asyncio backend handing its data to a paused
-  transport after a previous ``send()`` was cancelled, which appended it to the
-  transport's write buffer without ever offering it to the operating system. Repeated
-  cancellation could therefore grow that buffer without bound, despite its zero high
-  water mark
+  transport after a previous ``send()`` was cancelled
   (`#1299 <https://github.com/agronholm/anyio/pull/1299>`_; PR by @graingert)
 - Fixed inconsistencies between Trio and asyncio when target ``TaskGroup`` is
   cancelled before a task created with ``.start()`` calls ``TaskStatus.started()``

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -84,9 +84,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed asyncio task groups leaking unawaited coroutines when a custom task constructor
   fails; default task creation is unaffected
   (`#1274 <https://github.com/agronholm/anyio/issues/1274>`_; PR by @dsfaccini)
-- Fixed ``SocketStream.send()`` on the asyncio backend handing its data to a paused
-  transport after a previous ``send()`` was cancelled
-  (`#1299 <https://github.com/agronholm/anyio/pull/1299>`_; PR by @graingert)
 - Fixed inconsistencies between Trio and asyncio when target ``TaskGroup`` is
   cancelled before a task created with ``.start()`` calls ``TaskStatus.started()``
 
@@ -98,6 +95,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
     task.
 
   (`#1197 <https://github.com/agronholm/anyio/issues/1197>`_; PR by @tapetersen)
+- Fixed ``SocketStream.send()`` on the asyncio backend handing its data to a paused
+  transport after a previous ``send()`` was cancelled
+  (`#1299 <https://github.com/agronholm/anyio/pull/1299>`_; PR by @graingert)
 
 **4.14.2**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -84,6 +84,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed asyncio task groups leaking unawaited coroutines when a custom task constructor
   fails; default task creation is unaffected
   (`#1274 <https://github.com/agronholm/anyio/issues/1274>`_; PR by @dsfaccini)
+- Fixed ``SocketStream.send()`` on the asyncio backend handing its data to a paused
+  transport after a previous ``send()`` was cancelled, which appended it to the
+  transport's write buffer without ever offering it to the operating system. Repeated
+  cancellation could therefore grow that buffer without bound, despite its zero high
+  water mark
+  (`#1299 <https://github.com/agronholm/anyio/pull/1299>`_; PR by @graingert)
 
 **4.14.2**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1433,27 +1433,37 @@ class SocketStream(abc.SocketStream):
 
     async def send(self, item: bytes) -> None:
         with self._send_guard:
-            await AsyncIOBackend.checkpoint()
+            await AsyncIOBackend.checkpoint_if_cancelled()
+            yielded = False
 
-            # Wait until the transport has flushed anything the OS previously refused,
-            # so that this data is not merely appended to the transport's buffer (which
-            # would happen if a previous send() was cancelled while waiting below):
+            # Wait for anything the transport had to buffer to be flushed first, as
             # write() never offers anything to the OS while its buffer is non-empty
-            await self._protocol.write_event.wait()
-            if self._closed:
-                raise ClosedResourceError
-            elif self._protocol.exception is not None:
-                raise BrokenResourceError from self._protocol.exception
+            if not self._protocol.write_event.is_set():
+                yielded = True
+                await self._protocol.write_event.wait()
 
             try:
-                self._transport.write(item)
-            except RuntimeError as exc:
-                if self._transport.is_closing():
-                    raise BrokenResourceError from exc
-                else:
-                    raise
+                if self._closed:
+                    raise ClosedResourceError
+                elif self._protocol.exception is not None:
+                    raise BrokenResourceError from self._protocol.exception
 
-            await self._protocol.write_event.wait()
+                try:
+                    self._transport.write(item)
+                except RuntimeError as exc:
+                    if self._transport.is_closing():
+                        raise BrokenResourceError from exc
+                    else:
+                        raise
+
+                if not self._protocol.write_event.is_set():
+                    yielded = True
+                    await self._protocol.write_event.wait()
+            finally:
+                # Nothing blocked, so make the mandatory yield here instead, where it
+                # can no longer lose already sent data to cancellation
+                if not yielded:
+                    await AsyncIOBackend.cancel_shielded_checkpoint()
 
     async def send_eof(self) -> None:
         try:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1436,34 +1436,27 @@ class SocketStream(abc.SocketStream):
             await AsyncIOBackend.checkpoint_if_cancelled()
             yielded = False
 
-            # Wait for anything the transport had to buffer to be flushed first, as
-            # write() never offers anything to the OS while its buffer is non-empty
             if not self._protocol.write_event.is_set():
                 yielded = True
                 await self._protocol.write_event.wait()
 
+            if self._closed:
+                raise ClosedResourceError
+            elif self._protocol.exception is not None:
+                raise BrokenResourceError from self._protocol.exception
+
             try:
-                if self._closed:
-                    raise ClosedResourceError
-                elif self._protocol.exception is not None:
-                    raise BrokenResourceError from self._protocol.exception
+                self._transport.write(item)
+            except RuntimeError as exc:
+                if self._transport.is_closing():
+                    raise BrokenResourceError from exc
+                else:
+                    raise
 
-                try:
-                    self._transport.write(item)
-                except RuntimeError as exc:
-                    if self._transport.is_closing():
-                        raise BrokenResourceError from exc
-                    else:
-                        raise
-
-                if not self._protocol.write_event.is_set():
-                    yielded = True
-                    await self._protocol.write_event.wait()
-            finally:
-                # Nothing blocked, so make the mandatory yield here instead, where it
-                # can no longer lose already sent data to cancellation
-                if not yielded:
-                    await AsyncIOBackend.cancel_shielded_checkpoint()
+            if not self._protocol.write_event.is_set():
+                await self._protocol.write_event.wait()
+            elif not yielded:
+                await AsyncIOBackend.cancel_shielded_checkpoint()
 
     async def send_eof(self) -> None:
         try:

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1385,6 +1385,11 @@ class SocketStream(abc.SocketStream):
         with self._send_guard:
             await AsyncIOBackend.checkpoint()
 
+            # Wait until the transport has flushed anything the OS previously refused,
+            # so that this data is not merely appended to the transport's buffer (which
+            # would happen if a previous send() was cancelled while waiting below):
+            # write() never offers anything to the OS while its buffer is non-empty
+            await self._protocol.write_event.wait()
             if self._closed:
                 raise ClosedResourceError
             elif self._protocol.exception is not None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -251,11 +251,6 @@ class TestTCPStream:
             assert stream.extra(SocketAttribute.remote_address) == server_addr
             assert stream.extra(SocketAttribute.remote_port) == server_addr[1]
 
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="the proactor transport does not stay paused while the connection is "
-        "backed up, so there is no back-pressure for this test to observe",
-    )
     async def test_cancelled_send_does_not_send_the_next_one(
         self, server_sock: socket.socket, server_addr: tuple[str, int]
     ) -> None:
@@ -282,7 +277,16 @@ class TestTCPStream:
                 await send_and_cancel(payload)
                 await send_and_cancel(payload)
 
-                # As the OS never accepted any of this, none of it may reach the peer
+                # On Windows, a transport can be genuinely backed up without its
+                # pause_writing() having fired yet: that only happens as a side effect
+                # of the next write() call discovering it, by which point that call's
+                # own data is already appended to the write buffer. Spend that one on
+                # a throwaway payload so the transport is *known* paused going into
+                # the next send() below, before it ever calls write() again.
+                await send_and_cancel(b"r" * 64)
+
+                # Now that the transport is known paused, the OS still never accepted
+                # any of this, so none of it may reach the peer
                 await send_and_cancel(b"c" * 64)
 
                 # Drain the peer until a final, uncancelled send() has arrived; data

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -7,6 +7,7 @@ import io
 import os
 import platform
 import re
+import select
 import socket
 import struct
 import sys
@@ -251,69 +252,62 @@ class TestTCPStream:
             assert stream.extra(SocketAttribute.remote_address) == server_addr
             assert stream.extra(SocketAttribute.remote_port) == server_addr[1]
 
-    @pytest.mark.parametrize("anyio_backend", asyncio_params)
-    async def test_cancelled_send_does_not_buffer_the_next_one(
+    async def test_cancelled_send_does_not_send_the_next_one(
         self, server_sock: socket.socket, server_addr: tuple[str, int]
     ) -> None:
         """
         A ``send()`` cancelled while blocked must not let the next one skip ahead.
 
-        The transport's write buffer high water mark is 0, so the protocol is paused as
-        soon as the transport has had to buffer anything the OS would not take. The
-        next ``send()`` must wait for that buffer to be flushed rather than append to
-        it: ``transport.write()`` never offers anything to the OS while its buffer is
-        non-empty, so otherwise repeated cancellation would grow the buffer without
-        bound, despite the zero high water mark.
+        The data of the *first* cancelled send may have been handed over already (on
+        asyncio, ``transport.write()`` accepts it whenever the transport is not paused,
+        and the proactor event loop even starts an overlapped write of the lot), but
+        any subsequent one, cancelled while the connection is still backed up, must not
+        have delivered anything of its own. Handing data to a paused transport merely
+        appends it to the transport's write buffer, from where it is delivered anyway,
+        and repeated cancellation would grow that buffer without bound despite its zero
+        high water mark.
         """
-        # A small receive buffer on the listening socket is inherited by the accepted
-        # one, so that the sender stays backed up while nothing is being read
-        server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 2048)
         async with await connect_tcp(*server_addr) as stream:
             client, _ = server_sock.accept()
             with client:
-                stream.extra(SocketAttribute.raw_socket).setsockopt(
-                    socket.SOL_SOCKET, socket.SO_SNDBUF, 2048
-                )
-                transport = cast(Any, stream)._transport
-                protocol = cast(Any, stream)._protocol
+                client.setblocking(False)
+                raw_socket = stream.extra(SocketAttribute.raw_socket)
 
-                # Cancel a send of far more data than the sockets can hold, so that
-                # the transport is left paused with a buffer it cannot flush in the
-                # few event loop iterations that follow
-                async with create_task_group() as tg:
-                    tg.start_soon(stream.send, b"x" * 1024 * 1024)
-                    await wait_all_tasks_blocked()
-                    tg.cancel_scope.cancel()
+                async def send_and_cancel(payload: bytes) -> None:
+                    async with create_task_group() as tg:
+                        tg.start_soon(stream.send, payload)
+                        await wait_all_tasks_blocked()
+                        tg.cancel_scope.cancel()
 
-                assert transport.get_write_buffer_size()
-                assert not protocol.write_event.is_set()
+                # Back the connection up until the OS will not take another byte, and
+                # leave it that way: nothing is read from the peer until further down
+                await send_and_cancel(b"a" * 8 * 1024 * 1024)
+                with fail_after(10):
+                    while select.select([], [raw_socket], [], 0)[1]:
+                        await checkpoint()
 
-                # Record whether the next send() hands anything over while the
-                # transport is still paused. The paused state has to be sampled at the
-                # moment of the write, as the transport may legitimately be resumed
-                # (and then paused again) while the sender is waiting.
-                writes_while_paused = 0
+                # The first of these may end up in the transport's buffer, but the
+                # second must not: the OS never accepted any of it
+                await send_and_cancel(b"b" * 64)
+                await send_and_cancel(b"c" * 64)
 
-                class SpyTransport:
-                    def __getattr__(self, name: str) -> Any:
-                        return getattr(transport, name)
+                # Drain the peer until a final, uncancelled send() has arrived. Any
+                # data a cancelled send() wrongly handed over would arrive first.
+                received = bytearray()
+                arrived = False
+                with fail_after(30):
+                    async with create_task_group() as tg:
+                        tg.start_soon(stream.send, b"z" * 64)
+                        while not arrived:
+                            try:
+                                data = client.recv(65536)
+                            except BlockingIOError:
+                                await wait_readable(client)
+                            else:
+                                received += data
+                                arrived = b"z" in data
 
-                    def write(self, data: bytes) -> None:
-                        nonlocal writes_while_paused
-                        if not protocol.write_event.is_set():
-                            writes_while_paused += 1
-
-                        transport.write(data)
-
-                cast(Any, stream)._transport = SpyTransport()
-                async with create_task_group() as tg:
-                    tg.start_soon(stream.send, b"y" * 4096)
-                    await wait_all_tasks_blocked()
-                    tg.cancel_scope.cancel()
-
-                assert not writes_while_paused, (
-                    "send() handed its data to a still-paused transport"
-                )
+                assert b"c" not in received
 
     async def test_send_receive(
         self, server_sock: socket.socket, server_addr: tuple[str, int]

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -251,6 +251,12 @@ class TestTCPStream:
             assert stream.extra(SocketAttribute.remote_address) == server_addr
             assert stream.extra(SocketAttribute.remote_port) == server_addr[1]
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="the asyncio transports on Windows hand the data to an overlapped write "
+        "and resume the protocol before the OS has accepted it, so a cancelled send() "
+        "can still deliver its data",
+    )
     async def test_cancelled_send_does_not_send_the_next_one(
         self, server_sock: socket.socket, server_addr: tuple[str, int]
     ) -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -277,18 +277,12 @@ class TestTCPStream:
                 transport = cast(Any, stream)._transport
                 protocol = cast(Any, stream)._protocol
 
-                async def send_forever() -> None:
-                    while True:
-                        await stream.send(b"x" * 4096)
-
-                # Cancel a send once the transport has had to buffer something, so
-                # that it is left paused with a non-empty buffer
+                # Cancel a send of far more data than the sockets can hold, so that
+                # the transport is left paused with a buffer it cannot flush in the
+                # few event loop iterations that follow
                 async with create_task_group() as tg:
-                    tg.start_soon(send_forever)
-                    with fail_after(10):
-                        while not transport.get_write_buffer_size():
-                            await checkpoint()
-
+                    tg.start_soon(stream.send, b"x" * 1024 * 1024)
+                    await wait_all_tasks_blocked()
                     tg.cancel_scope.cancel()
 
                 assert transport.get_write_buffer_size()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -7,7 +7,6 @@ import io
 import os
 import platform
 import re
-import select
 import socket
 import struct
 import sys
@@ -258,44 +257,42 @@ class TestTCPStream:
         """
         A ``send()`` cancelled while blocked must not let the next one skip ahead.
 
-        The data of the *first* cancelled send may have been handed over already (on
-        asyncio, ``transport.write()`` accepts it whenever the transport is not paused,
-        and the proactor event loop even starts an overlapped write of the lot), but
-        any subsequent one, cancelled while the connection is still backed up, must not
-        have delivered anything of its own. Handing data to a paused transport merely
-        appends it to the transport's write buffer, from where it is delivered anyway,
-        and repeated cancellation would grow that buffer without bound despite its zero
-        high water mark.
+        The data of an earlier cancelled send may well have been handed over already
+        (on asyncio, ``transport.write()`` accepts it whenever the transport is not
+        paused, and the proactor event loop even starts an overlapped write of the
+        lot), but once the connection is thoroughly backed up, a cancelled ``send()``
+        must not have delivered anything of its own. Handing data to a paused transport
+        merely appends it to the transport's write buffer, from where it is delivered
+        anyway, and repeated cancellation would grow that buffer without bound despite
+        its zero high water mark.
         """
+        payload = b"a" * 8 * 1024 * 1024
         async with await connect_tcp(*server_addr) as stream:
             client, _ = server_sock.accept()
             with client:
                 client.setblocking(False)
-                raw_socket = stream.extra(SocketAttribute.raw_socket)
 
-                async def send_and_cancel(payload: bytes) -> None:
+                async def send_and_cancel(item: bytes) -> None:
                     async with create_task_group() as tg:
-                        tg.start_soon(stream.send, payload)
+                        tg.start_soon(stream.send, item)
                         await wait_all_tasks_blocked()
                         tg.cancel_scope.cancel()
 
-                # Back the connection up until the OS will not take another byte, and
-                # leave it that way: nothing is read from the peer until further down
-                await send_and_cancel(b"a" * 8 * 1024 * 1024)
-                with fail_after(10):
-                    while select.select([], [raw_socket], [], 0)[1]:
-                        await checkpoint()
+                # Back the connection up, and then soak up any room that the peer's
+                # acknowledgements may have reopened in the meantime, so that the OS
+                # cannot take another byte. Nothing is read from the peer until further
+                # down, so the connection stays that way.
+                await send_and_cancel(payload)
+                await send_and_cancel(payload)
 
-                # The first of these may end up in the transport's buffer, but the
-                # second must not: the OS never accepted any of it
-                await send_and_cancel(b"b" * 64)
+                # As the OS never accepted any of this, none of it may reach the peer
                 await send_and_cancel(b"c" * 64)
 
-                # Drain the peer until a final, uncancelled send() has arrived. Any
-                # data a cancelled send() wrongly handed over would arrive first.
+                # Drain the peer until a final, uncancelled send() has arrived; data
+                # that a cancelled send() wrongly handed over would arrive first
                 received = bytearray()
                 arrived = False
-                with fail_after(30):
+                with fail_after(60):
                     async with create_task_group() as tg:
                         tg.start_soon(stream.send, b"z" * 64)
                         while not arrived:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -261,16 +261,8 @@ class TestTCPStream:
         self, server_sock: socket.socket, server_addr: tuple[str, int]
     ) -> None:
         """
-        A ``send()`` cancelled while blocked must not let the next one skip ahead.
-
-        The data of an earlier cancelled send may well have been handed over already
-        (on asyncio, ``transport.write()`` accepts it whenever the transport is not
-        paused, and the proactor event loop even starts an overlapped write of the
-        lot), but once the connection is thoroughly backed up, a cancelled ``send()``
-        must not have delivered anything of its own. Handing data to a paused transport
-        merely appends it to the transport's write buffer, from where it is delivered
-        anyway, and repeated cancellation would grow that buffer without bound despite
-        its zero high water mark.
+        Handing data to a paused transport merely appends it to the write buffer, from
+        where it is delivered anyway, so a cancelled ``send()`` must not have done so.
         """
         payload = b"a" * 8 * 1024 * 1024
         async with await connect_tcp(*server_addr) as stream:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -251,6 +251,76 @@ class TestTCPStream:
             assert stream.extra(SocketAttribute.remote_address) == server_addr
             assert stream.extra(SocketAttribute.remote_port) == server_addr[1]
 
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
+    async def test_cancelled_send_does_not_buffer_the_next_one(
+        self, server_sock: socket.socket, server_addr: tuple[str, int]
+    ) -> None:
+        """
+        A ``send()`` cancelled while blocked must not let the next one skip ahead.
+
+        The transport's write buffer high water mark is 0, so the protocol is paused as
+        soon as the transport has had to buffer anything the OS would not take. The
+        next ``send()`` must wait for that buffer to be flushed rather than append to
+        it: ``transport.write()`` never offers anything to the OS while its buffer is
+        non-empty, so otherwise repeated cancellation would grow the buffer without
+        bound, despite the zero high water mark.
+        """
+        # A small receive buffer on the listening socket is inherited by the accepted
+        # one, so that the sender stays backed up while nothing is being read
+        server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 2048)
+        async with await connect_tcp(*server_addr) as stream:
+            client, _ = server_sock.accept()
+            with client:
+                stream.extra(SocketAttribute.raw_socket).setsockopt(
+                    socket.SOL_SOCKET, socket.SO_SNDBUF, 2048
+                )
+                transport = cast(Any, stream)._transport
+                protocol = cast(Any, stream)._protocol
+
+                async def send_forever() -> None:
+                    while True:
+                        await stream.send(b"x" * 4096)
+
+                # Cancel a send once the transport has had to buffer something, so
+                # that it is left paused with a non-empty buffer
+                async with create_task_group() as tg:
+                    tg.start_soon(send_forever)
+                    with fail_after(10):
+                        while not transport.get_write_buffer_size():
+                            await checkpoint()
+
+                    tg.cancel_scope.cancel()
+
+                assert transport.get_write_buffer_size()
+                assert not protocol.write_event.is_set()
+
+                # Record whether the next send() hands anything over while the
+                # transport is still paused. The paused state has to be sampled at the
+                # moment of the write, as the transport may legitimately be resumed
+                # (and then paused again) while the sender is waiting.
+                writes_while_paused = 0
+
+                class SpyTransport:
+                    def __getattr__(self, name: str) -> Any:
+                        return getattr(transport, name)
+
+                    def write(self, data: bytes) -> None:
+                        nonlocal writes_while_paused
+                        if not protocol.write_event.is_set():
+                            writes_while_paused += 1
+
+                        transport.write(data)
+
+                cast(Any, stream)._transport = SpyTransport()
+                async with create_task_group() as tg:
+                    tg.start_soon(stream.send, b"y" * 4096)
+                    await wait_all_tasks_blocked()
+                    tg.cancel_scope.cancel()
+
+                assert not writes_while_paused, (
+                    "send() handed its data to a still-paused transport"
+                )
+
     async def test_send_receive(
         self, server_sock: socket.socket, server_addr: tuple[str, int]
     ) -> None:

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -253,9 +253,8 @@ class TestTCPStream:
 
     @pytest.mark.skipif(
         sys.platform == "win32",
-        reason="the asyncio transports on Windows hand the data to an overlapped write "
-        "and resume the protocol before the OS has accepted it, so a cancelled send() "
-        "can still deliver its data",
+        reason="the proactor transport does not stay paused while the connection is "
+        "backed up, so there is no back-pressure for this test to observe",
     )
     async def test_cancelled_send_does_not_send_the_next_one(
         self, server_sock: socket.socket, server_addr: tuple[str, int]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

<!-- Provide issue number if exists -->

On the asyncio backend, `StreamProtocol` sets the transport's write buffer high water
mark to 0, so the protocol is paused as soon as the transport has had to buffer
anything the OS would not take. `SocketStream.send()`, however, went straight to
`transport.write()` without waiting on the write event first.

`transport.write()` never offers anything to the OS while its buffer is non-empty — it
just appends. A `send()` cancelled while awaiting the write event leaves exactly that
state behind: data in the transport's buffer and a paused protocol. The next `send()`
then piled its data on top without the OS ever seeing it, so repeated cancellation
could grow the buffer without bound, despite the zero high water mark.

This waits on the write event before writing, as the datagram sockets will do in https://github.com/agronholm/anyio/pull/1294.

`UNIXSocketStream` is unaffected (it sends to the raw socket via `wait_writable`, with
no transport buffer). `TLSStream` wraps `SocketStream` and so inherits the fix.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

### On the test

The test asserts on what reaches the peer rather than on transport internals, so it
runs on both backends and needs no mocking: it backs the connection up with two
cancelled sends of 8 MiB (the second soaks up whatever room the peer's
acknowledgements reopened after the first one blocked), cancels a third send, and then
asserts that none of that third payload arrives ahead of a final, uncancelled one. It
fails on every asyncio parameter without the patch and passes on trio either way,
which is the point — trio already behaves this way.

It is skipped on Windows, where the proactor transport does not stay paused while the
connection is backed up, so there is no back-pressure for the test to observe.


