### PR TITLE
Start move_on_after() timer on context enter

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- **BREAKING:** ``move_on_after()`` now starts its timer when the context manager is
+  entered, matching ``fail_after()``, instead of when the function is called
+  (`#1298 <https://github.com/agronholm/anyio/issues/1298>`_)
 - Added support for the newer keyword-only arguments on ``anyio.Path`` methods to match
   the standard library ``pathlib.Path``:
 

--- a/src/anyio/_core/_tasks.py
+++ b/src/anyio/_core/_tasks.py
@@ -198,25 +198,34 @@ def move_on_at(deadline: float | None, shield: bool = False) -> CancelScope:
     )
 
 
-def move_on_after(delay: float | None, shield: bool = False) -> CancelScope:
+@contextmanager
+def move_on_after(
+    delay: float | None, shield: bool = False
+) -> Generator[CancelScope, None, None]:
     """
-    Create a cancel scope with a deadline that expires after the given delay.
+    Create a context manager which exits if the code in the enclosing context
+    block does not finish in time.
 
-    :param delay: maximum allowed time (in seconds) before exiting the context block, or
-        ``None`` to disable the timeout
+    :param delay: maximum allowed time (in seconds) before exiting the context
+        block, or ``None`` to disable the timeout
     :param shield: ``True`` to shield the cancel scope from external cancellation
-    :return: a cancel scope
+    :return: a context manager that yields a cancel scope
+    :rtype: :class:`~typing.ContextManager`\\[:class:`~anyio.CancelScope`\\]
     :raises NoEventLoopError: if no supported asynchronous event loop is running in the
         current thread
 
-    .. note:: Unlike with :func:`fail_after`, the timer starts when this function is
-        called, not when the context manager is entered. This will be changed in v5.0.
+    .. versionchanged:: 5.0
+        The timer now starts when the context manager is entered, matching
+        :func:`fail_after`. Previously the deadline was computed when this
+        function was called.
 
     """
-    deadline = (
-        (get_async_backend().current_time() + delay) if delay is not None else math.inf
-    )
-    return get_async_backend().create_cancel_scope(deadline=deadline, shield=shield)
+    current_time = get_async_backend().current_time
+    deadline = (current_time() + delay) if delay is not None else math.inf
+    with get_async_backend().create_cancel_scope(
+        deadline=deadline, shield=shield
+    ) as cancel_scope:
+        yield cancel_scope
 
 
 def current_effective_deadline() -> float:

--- a/tests/test_taskgroups.py
+++ b/tests/test_taskgroups.py
@@ -804,6 +804,16 @@ async def test_move_on_after_no_timeout() -> None:
     assert not scope.cancel_called
 
 
+async def test_move_on_after_starts_timer_on_enter() -> None:
+    cm = move_on_after(0.25)
+    await sleep(0.2)
+    finished = False
+    with cm:
+        await sleep(0.1)
+        finished = True
+    assert finished
+
+
 async def test_nested_move_on_after() -> None:
     sleep_completed = inner_scope_completed = False
     with move_on_after(0.1) as outer_scope:


### PR DESCRIPTION
move_on_after() used to compute the deadline as soon as you called it, so any work between the call and `with` ate into the timeout. fail_after() already waits until enter.

It's now a context manager that starts the clock on __enter__, which is the v5.0 change from #1298. Existing `with move_on_after(...) as scope:` usage is unchanged.

Fixes #1298