### PR TITLE
Fixed RuntimeError in worker thread when the event loop closes during result reporting

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -49,7 +49,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   a ``RuntimeError`` if the event loop was closed after the worker had checked whether
   the loop was closed but before it could deliver the result of
   ``to_thread.run_sync()``
-  (`#1245 <https://github.com/agronholm/anyio/pull/1245>`_; PR by @shleder)
+  (`#1303 <https://github.com/agronholm/anyio/pull/1303>`_; PR by @shleder)
 
 **4.14.2**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,11 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed a race condition where a worker thread on the asyncio backend would crash with
+  a ``RuntimeError`` if the event loop was closed after the worker had checked whether
+  the loop was closed but before it could deliver the result of
+  ``to_thread.run_sync()``
+  (`#1245 <https://github.com/agronholm/anyio/pull/1245>`_; PR by @shleder)
 - Added ``StapledObjectStream.send_nowait()`` that delegates to the underlying
   ``ObjectSendStream``, if it implements it
   (`#1241 <https://github.com/agronholm/anyio/pull/1241>`_; PR by @davidbrochart)

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1045,9 +1045,15 @@ class WorkerThread(Thread):
                         del threadlocals.current_cancel_scope
 
                     if not self.loop.is_closed():
-                        self.loop.call_soon_threadsafe(
-                            self._report_result, future, result, exception
-                        )
+                        try:
+                            self.loop.call_soon_threadsafe(
+                                self._report_result, future, result, exception
+                            )
+                        except RuntimeError:
+                            # The loop was closed after the is_closed() check
+                            # above (a race with event loop shutdown). The
+                            # result can no longer be delivered, so drop it.
+                            pass
 
                     del result, exception
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -1044,16 +1044,13 @@ class WorkerThread(Thread):
                     finally:
                         del threadlocals.current_cancel_scope
 
-                    if not self.loop.is_closed():
-                        try:
-                            self.loop.call_soon_threadsafe(
-                                self._report_result, future, result, exception
-                            )
-                        except RuntimeError:
-                            # The loop was closed after the is_closed() check
-                            # above (a race with event loop shutdown). The
-                            # result can no longer be delivered, so drop it.
-                            pass
+                    try:
+                        self.loop.call_soon_threadsafe(
+                            self._report_result, future, result, exception
+                        )
+                    except RuntimeError:
+                        if not self.loop.is_closed():
+                            raise
 
                     del result, exception
 

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -6,13 +6,11 @@ import sys
 import threading
 import time
 import weakref
-from collections import deque
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
-from contextvars import Context, ContextVar
+from contextvars import ContextVar
 from functools import partial
-from queue import Queue
-from typing import Any, NoReturn, cast
+from typing import Any, NoReturn
 
 import pytest
 
@@ -21,12 +19,13 @@ from anyio import (
     CapacityLimiter,
     Event,
     create_task_group,
+    fail_after,
     from_thread,
     sleep,
     to_thread,
     wait_all_tasks_blocked,
 )
-from anyio._backends._asyncio import AsyncIOBackend, WorkerThread
+from anyio._backends._asyncio import WorkerThread
 from anyio._core._eventloop import current_async_library
 from anyio.from_thread import BlockingPortalProvider
 from anyio.lowlevel import checkpoint
@@ -421,92 +420,48 @@ def test_asyncio_run_does_not_leak_event_loop() -> None:
     assert loop_ref() is None
 
 
-class _FakeWorkerThreadLoop:
-    """
-    Minimal stand-in for an event loop, used to deterministically exercise the result
-    delivery path of ``WorkerThread.run()`` without running an actual event loop.
-    """
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_to_thread_run_sync_loop_closed_delivery_race(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the loop-close delivery race through ``to_thread.run_sync()``."""
+    assert await to_thread.run_sync(lambda: "foo") == "foo"
 
-    def __init__(self, call_soon_threadsafe_error: RuntimeError | None = None) -> None:
-        self.call_soon_threadsafe_error = call_soon_threadsafe_error
-        self.call_soon_threadsafe_calls: list[
-            tuple[Callable[..., Any], tuple[Any, ...]]
-        ] = []
+    loop = asyncio.get_running_loop()
+    real_call_soon_threadsafe = loop.call_soon_threadsafe
+    delivery_attempted = Event()
+    thread_waiting = Event()
+    finish_thread = threading.Event()
 
-    def is_closed(self) -> bool:
-        return False
+    def call_soon_threadsafe(
+        callback: Callable[..., Any], *args: Any
+    ) -> asyncio.Handle:
+        if not delivery_attempted.is_set() and (
+            getattr(callback, "__self__", None).__class__ is WorkerThread
+            and getattr(callback, "__func__", None) is WorkerThread._report_result
+        ):
+            real_call_soon_threadsafe(delivery_attempted.set)
+            raise RuntimeError("Event loop is closed")
 
-    def call_soon_threadsafe(self, callback: Callable[..., Any], *args: Any) -> None:
-        self.call_soon_threadsafe_calls.append((callback, args))
-        if self.call_soon_threadsafe_error is not None:
-            raise self.call_soon_threadsafe_error
+        return real_call_soon_threadsafe(callback, *args)
 
-        callback(*args)
+    def thread_worker() -> None:
+        real_call_soon_threadsafe(thread_waiting.set)
+        finish_thread.wait(5)
 
+    monkeypatch.setattr(loop, "call_soon_threadsafe", call_soon_threadsafe)
 
-def _make_worker_thread(
-    loop: _FakeWorkerThreadLoop, future: Future[str]
-) -> WorkerThread:
-    """
-    Create a ``WorkerThread`` instance without starting it, with a preloaded work queue
-    containing a single work item followed by the shutdown sentinel (``None``).
-    """
-    worker = cast(Any, WorkerThread.__new__(WorkerThread))
-    worker.loop = loop
-    worker.queue = Queue()
-    worker.idle_workers = deque()
-    worker.stopping = False
-    worker.queue.put((Context(), lambda: "foo", (), future, None))
-    worker.queue.put(None)
-    return worker
+    with fail_after(5):
+        async with create_task_group() as tg:
+            tg.start_soon(
+                partial(to_thread.run_sync, abandon_on_cancel=True), thread_worker
+            )
+            await thread_waiting.wait()
+            tg.cancel_scope.cancel()
 
+        finish_thread.set()
+        await delivery_attempted.wait()
 
-def test_worker_thread_run_loop_closed_race() -> None:
-    """
-    Regression test for #1245.
-
-    If the event loop gets closed after the ``is_closed()`` check but before
-    ``call_soon_threadsafe()`` runs, the resulting ``RuntimeError`` must be
-    suppressed and the result dropped instead of crashing the worker thread. The
-    future is left unresolved since the result can no longer be delivered.
-    """
-    future: Future[str] = Future()
-    loop = _FakeWorkerThreadLoop(RuntimeError("Event loop is closed"))
-    worker = _make_worker_thread(loop, future)
-
-    worker.run()
-
-    assert len(loop.call_soon_threadsafe_calls) == 1
-    assert not future.done()
-
-
-def test_worker_thread_run_unrelated_runtime_error_suppressed() -> None:
-    """
-    Verify that even an unrelated ``RuntimeError`` raised by
-    ``call_soon_threadsafe()`` is suppressed, consistent with the selector thread
-    precedent, and that the future is left unresolved.
-    """
-    future: Future[str] = Future()
-    loop = _FakeWorkerThreadLoop(RuntimeError("unrelated error"))
-    worker = _make_worker_thread(loop, future)
-
-    worker.run()
-
-    assert len(loop.call_soon_threadsafe_calls) == 1
-    assert not future.done()
-
-
-def test_worker_thread_run_reports_result(monkeypatch: pytest.MonkeyPatch) -> None:
-    """
-    Verify that when ``call_soon_threadsafe()`` succeeds, the scheduled callback is
-    invoked and the work item's return value is delivered to the future normally.
-    """
-    monkeypatch.setattr(AsyncIOBackend, "current_time", classmethod(lambda cls: 0.0))
-    future: Future[str] = Future()
-    loop = _FakeWorkerThreadLoop()
-    worker = _make_worker_thread(loop, future)
-
-    worker.run()
-
-    assert len(loop.call_soon_threadsafe_calls) == 1
-    assert future.result(timeout=5) == "foo"
+    assert not loop.is_closed()
+    assert await to_thread.run_sync(lambda: "bar") == "bar"
+    assert not loop.is_closed()

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -6,10 +6,13 @@ import sys
 import threading
 import time
 import weakref
+from collections import deque
+from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
-from contextvars import ContextVar
+from contextvars import Context, ContextVar
 from functools import partial
-from typing import Any, NoReturn
+from queue import Queue
+from typing import Any, NoReturn, cast
 
 import pytest
 
@@ -23,6 +26,7 @@ from anyio import (
     to_thread,
     wait_all_tasks_blocked,
 )
+from anyio._backends._asyncio import AsyncIOBackend, WorkerThread
 from anyio._core._eventloop import current_async_library
 from anyio.from_thread import BlockingPortalProvider
 from anyio.lowlevel import checkpoint
@@ -415,3 +419,94 @@ def test_asyncio_run_does_not_leak_event_loop() -> None:
 
     gc.collect()
     assert loop_ref() is None
+
+
+class _FakeWorkerThreadLoop:
+    """
+    Minimal stand-in for an event loop, used to deterministically exercise the result
+    delivery path of ``WorkerThread.run()`` without running an actual event loop.
+    """
+
+    def __init__(self, call_soon_threadsafe_error: RuntimeError | None = None) -> None:
+        self.call_soon_threadsafe_error = call_soon_threadsafe_error
+        self.call_soon_threadsafe_calls: list[
+            tuple[Callable[..., Any], tuple[Any, ...]]
+        ] = []
+
+    def is_closed(self) -> bool:
+        return False
+
+    def call_soon_threadsafe(self, callback: Callable[..., Any], *args: Any) -> None:
+        self.call_soon_threadsafe_calls.append((callback, args))
+        if self.call_soon_threadsafe_error is not None:
+            raise self.call_soon_threadsafe_error
+
+        callback(*args)
+
+
+def _make_worker_thread(
+    loop: _FakeWorkerThreadLoop, future: Future[str]
+) -> WorkerThread:
+    """
+    Create a ``WorkerThread`` instance without starting it, with a preloaded work queue
+    containing a single work item followed by the shutdown sentinel (``None``).
+    """
+    worker = cast(Any, WorkerThread.__new__(WorkerThread))
+    worker.loop = loop
+    worker.queue = Queue()
+    worker.idle_workers = deque()
+    worker.stopping = False
+    worker.queue.put((Context(), lambda: "foo", (), future, None))
+    worker.queue.put(None)
+    return worker
+
+
+def test_worker_thread_run_loop_closed_race() -> None:
+    """
+    Regression test for #1245.
+
+    If the event loop gets closed after the ``is_closed()`` check but before
+    ``call_soon_threadsafe()`` runs, the resulting ``RuntimeError`` must be
+    suppressed and the result dropped instead of crashing the worker thread. The
+    future is left unresolved since the result can no longer be delivered.
+    """
+    future: Future[str] = Future()
+    loop = _FakeWorkerThreadLoop(RuntimeError("Event loop is closed"))
+    worker = _make_worker_thread(loop, future)
+
+    worker.run()
+
+    assert len(loop.call_soon_threadsafe_calls) == 1
+    assert not future.done()
+
+
+def test_worker_thread_run_unrelated_runtime_error_suppressed() -> None:
+    """
+    Verify that even an unrelated ``RuntimeError`` raised by
+    ``call_soon_threadsafe()`` is suppressed, consistent with the selector thread
+    precedent, and that the future is left unresolved.
+    """
+    future: Future[str] = Future()
+    loop = _FakeWorkerThreadLoop(RuntimeError("unrelated error"))
+    worker = _make_worker_thread(loop, future)
+
+    worker.run()
+
+    assert len(loop.call_soon_threadsafe_calls) == 1
+    assert not future.done()
+
+
+def test_worker_thread_run_reports_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Verify that when ``call_soon_threadsafe()`` succeeds, the scheduled callback is
+    invoked and the work item's return value is delivered to the future normally.
+    """
+    monkeypatch.setattr(AsyncIOBackend, "current_time", classmethod(lambda cls: 0.0))
+    future: Future[str] = Future()
+    loop = _FakeWorkerThreadLoop()
+    worker = _make_worker_thread(loop, future)
+
+    worker.run()
+
+    assert len(loop.call_soon_threadsafe_calls) == 1
+    assert future.result(timeout=5) == "foo"

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -421,9 +421,9 @@ def test_asyncio_run_does_not_leak_event_loop() -> None:
 
 
 def test_to_thread_run_sync_loop_closed_delivery_race() -> None:
-    """Drop a result that cannot be delivered after its event loop has closed."""
+    """Attempt delivery once even when the event loop has already closed."""
 
-    class ClosingRaceLoop(asyncio.SelectorEventLoop):
+    class RecordingLoop(asyncio.SelectorEventLoop):
         delivery_attempted = False
 
         def call_soon_threadsafe(
@@ -440,26 +440,18 @@ def test_to_thread_run_sync_loop_closed_delivery_race() -> None:
 
             return super().call_soon_threadsafe(callback, *args, context=context)
 
-        def is_closed(self) -> bool:
-            closed = super().is_closed()
-            if closed and not self.delivery_attempted:
-                return False
-
-            return closed
-
-    worker_started = Event()
     finish_worker = threading.Event()
     worker_thread: threading.Thread | None = None
-    worker_exception: BaseException | None = None
-    runner_exception: BaseException | None = None
-
-    def thread_worker() -> None:
-        nonlocal worker_thread
-        worker_thread = threading.current_thread()
-        from_thread.run_sync(worker_started.set)
-        finish_worker.wait(5)
 
     async def main() -> None:
+        worker_started = Event()
+
+        def thread_worker() -> None:
+            nonlocal worker_thread
+            worker_thread = threading.current_thread()
+            from_thread.run_sync(worker_started.set)
+            finish_worker.wait(5)
+
         async with create_task_group() as tg:
             tg.start_soon(
                 partial(to_thread.run_sync, abandon_on_cancel=True), thread_worker
@@ -469,40 +461,23 @@ def test_to_thread_run_sync_loop_closed_delivery_race() -> None:
 
             tg.cancel_scope.cancel()
 
-    def run_anyio() -> None:
-        nonlocal runner_exception
-        try:
-            anyio.run(
-                main,
-                backend="asyncio",
-                backend_options={"loop_factory": ClosingRaceLoop},
-            )
-        except BaseException as exc:
-            runner_exception = exc
-
-    def excepthook(args: threading.ExceptHookArgs) -> None:
-        nonlocal worker_exception
-        worker_exception = args.exc_value
-
-    original_excepthook = threading.excepthook
-    threading.excepthook = excepthook
-    runner = threading.Thread(target=run_anyio)
+    loop = RecordingLoop()
     try:
-        runner.start()
-        runner.join(5)
-        assert not runner.is_alive()
+        loop.run_until_complete(main())
+        loop.close()
         finish_worker.set()
         assert worker_thread is not None
         worker_thread.join(5)
     finally:
         finish_worker.set()
-        runner.join(5)
-        threading.excepthook = original_excepthook
+        if not loop.is_closed():
+            loop.close()
+        if worker_thread is not None:
+            worker_thread.join(5)
 
-    assert runner_exception is None
     assert worker_thread is not None
     assert not worker_thread.is_alive()
-    assert worker_exception is None
+    assert loop.delivery_attempted
 
 
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
@@ -513,8 +488,8 @@ async def test_to_thread_run_sync_unrelated_runtime_error_reraised(
     loop = asyncio.get_running_loop()
     real_call_soon_threadsafe = loop.call_soon_threadsafe
     worker_started = Event()
-    finish_worker = threading.Event()
     exception_received = Event()
+    finish_worker = threading.Event()
     worker_exception: BaseException | None = None
     raise_on_delivery = True
 
@@ -543,9 +518,8 @@ async def test_to_thread_run_sync_unrelated_runtime_error_reraised(
         finish_worker.wait(5)
 
     monkeypatch.setattr(loop, "call_soon_threadsafe", call_soon_threadsafe)
+    monkeypatch.setattr(threading, "excepthook", excepthook)
 
-    original_excepthook = threading.excepthook
-    threading.excepthook = excepthook
     try:
         with fail_after(5):
             async with create_task_group() as tg:
@@ -559,7 +533,6 @@ async def test_to_thread_run_sync_unrelated_runtime_error_reraised(
             await exception_received.wait()
     finally:
         finish_worker.set()
-        threading.excepthook = original_excepthook
 
     assert isinstance(worker_exception, RuntimeError)
     assert str(worker_exception) == "Unrelated error"

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -6,8 +6,9 @@ import sys
 import threading
 import time
 import weakref
+from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
-from contextvars import ContextVar
+from contextvars import Context, ContextVar
 from functools import partial
 from typing import Any, NoReturn
 
@@ -421,20 +422,42 @@ def test_asyncio_run_does_not_leak_event_loop() -> None:
 
 def test_to_thread_run_sync_loop_closed_delivery_race() -> None:
     """Drop a result that cannot be delivered after its event loop has closed."""
-    worker_started = threading.Event()
+
+    class ClosingRaceLoop(asyncio.SelectorEventLoop):
+        delivery_attempted = False
+
+        def call_soon_threadsafe(
+            self,
+            callback: Callable[..., Any],
+            *args: Any,
+            context: Context | None = None,
+        ) -> asyncio.Handle:
+            if (
+                isinstance(getattr(callback, "__self__", None), WorkerThread)
+                and getattr(callback, "__func__", None) is WorkerThread._report_result
+            ):
+                self.delivery_attempted = True
+
+            return super().call_soon_threadsafe(callback, *args, context=context)
+
+        def is_closed(self) -> bool:
+            closed = super().is_closed()
+            if closed and not self.delivery_attempted:
+                return False
+
+            return closed
+
+    worker_started = Event()
     finish_worker = threading.Event()
     worker_thread: threading.Thread | None = None
-    caught_exception: BaseException | None = None
+    worker_exception: BaseException | None = None
+    runner_exception: BaseException | None = None
 
     def thread_worker() -> None:
         nonlocal worker_thread
         worker_thread = threading.current_thread()
-        worker_started.set()
+        from_thread.run_sync(worker_started.set)
         finish_worker.wait(5)
-
-    def excepthook(args: Any) -> None:
-        nonlocal caught_exception
-        caught_exception = args.exc_value
 
     async def main() -> None:
         async with create_task_group() as tg:
@@ -442,58 +465,81 @@ def test_to_thread_run_sync_loop_closed_delivery_race() -> None:
                 partial(to_thread.run_sync, abandon_on_cancel=True), thread_worker
             )
             with fail_after(5):
-                while not worker_started.is_set():
-                    await checkpoint()
+                await worker_started.wait()
 
             tg.cancel_scope.cancel()
 
+    def run_anyio() -> None:
+        nonlocal runner_exception
+        try:
+            anyio.run(
+                main,
+                backend="asyncio",
+                backend_options={"loop_factory": ClosingRaceLoop},
+            )
+        except BaseException as exc:
+            runner_exception = exc
+
+    def excepthook(args: threading.ExceptHookArgs) -> None:
+        nonlocal worker_exception
+        worker_exception = args.exc_value
+
     original_excepthook = threading.excepthook
     threading.excepthook = excepthook
+    runner = threading.Thread(target=run_anyio)
     try:
-        anyio.run(main, backend="asyncio")
+        runner.start()
+        runner.join(5)
+        assert not runner.is_alive()
         finish_worker.set()
         assert worker_thread is not None
         worker_thread.join(5)
     finally:
         finish_worker.set()
+        runner.join(5)
         threading.excepthook = original_excepthook
 
+    assert runner_exception is None
     assert worker_thread is not None
     assert not worker_thread.is_alive()
-    assert caught_exception is None
+    assert worker_exception is None
 
 
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_to_thread_run_sync_unrelated_runtime_error_reraised(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, anyio_backend: str
 ) -> None:
     """Re-raise a result-delivery RuntimeError while the event loop remains open."""
     loop = asyncio.get_running_loop()
     real_call_soon_threadsafe = loop.call_soon_threadsafe
-    worker_started = threading.Event()
+    worker_started = Event()
     finish_worker = threading.Event()
-    exception_received = threading.Event()
-    caught_exception: BaseException | None = None
+    exception_received = Event()
+    worker_exception: BaseException | None = None
     raise_on_delivery = True
 
-    def excepthook(args: Any) -> None:
-        nonlocal caught_exception
-        caught_exception = args.exc_value
-        exception_received.set()
+    def excepthook(args: threading.ExceptHookArgs) -> None:
+        nonlocal worker_exception
+        worker_exception = args.exc_value
+        real_call_soon_threadsafe(exception_received.set)
 
-    def call_soon_threadsafe(callback: Any, *args: Any) -> asyncio.Handle:
+    def call_soon_threadsafe(
+        callback: Callable[..., Any],
+        *args: Any,
+        context: Context | None = None,
+    ) -> asyncio.Handle:
         nonlocal raise_on_delivery
         if raise_on_delivery and (
-            getattr(callback, "__self__", None).__class__ is WorkerThread
+            isinstance(getattr(callback, "__self__", None), WorkerThread)
             and getattr(callback, "__func__", None) is WorkerThread._report_result
         ):
             raise_on_delivery = False
             raise RuntimeError("Unrelated error")
 
-        return real_call_soon_threadsafe(callback, *args)
+        return real_call_soon_threadsafe(callback, *args, context=context)
 
     def thread_worker() -> None:
-        worker_started.set()
+        from_thread.run_sync(worker_started.set)
         finish_worker.wait(5)
 
     monkeypatch.setattr(loop, "call_soon_threadsafe", call_soon_threadsafe)
@@ -506,17 +552,15 @@ async def test_to_thread_run_sync_unrelated_runtime_error_reraised(
                 tg.start_soon(
                     partial(to_thread.run_sync, abandon_on_cancel=True), thread_worker
                 )
-                while not worker_started.is_set():
-                    await checkpoint()
-
+                await worker_started.wait()
                 tg.cancel_scope.cancel()
 
             finish_worker.set()
-            while not exception_received.is_set():
-                await checkpoint()
+            await exception_received.wait()
     finally:
         finish_worker.set()
         threading.excepthook = original_excepthook
 
-    assert isinstance(caught_exception, RuntimeError)
-    assert str(caught_exception) == "Unrelated error"
+    assert isinstance(worker_exception, RuntimeError)
+    assert str(worker_exception) == "Unrelated error"
+    assert await to_thread.run_sync(lambda: "ok") == "ok"

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -32,6 +32,13 @@ from anyio.lowlevel import checkpoint
 
 from .conftest import asyncio_params, no_other_refs
 
+if sys.version_info >= (3, 11):
+    from typing import TypeVarTuple, Unpack
+else:
+    from typing_extensions import TypeVarTuple, Unpack
+
+PosArgsT = TypeVarTuple("PosArgsT")
+
 
 async def test_run_in_thread_cancelled() -> None:
     state = 0
@@ -428,8 +435,8 @@ def test_to_thread_run_sync_loop_closed_delivery_race() -> None:
 
         def call_soon_threadsafe(
             self,
-            callback: Callable[..., Any],
-            *args: Any,
+            callback: Callable[[Unpack[PosArgsT]], object],
+            *args: Unpack[PosArgsT],
             context: Context | None = None,
         ) -> asyncio.Handle:
             if (

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -6,7 +6,6 @@ import sys
 import threading
 import time
 import weakref
-from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextvars import ContextVar
 from functools import partial
@@ -420,102 +419,86 @@ def test_asyncio_run_does_not_leak_event_loop() -> None:
     assert loop_ref() is None
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
-async def test_to_thread_run_sync_loop_closed_delivery_race(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Exercise the loop-close delivery race through ``to_thread.run_sync()``."""
-    assert await to_thread.run_sync(lambda: "foo") == "foo"
-
-    loop = asyncio.get_running_loop()
-    real_call_soon_threadsafe = loop.call_soon_threadsafe
-    delivery_attempted = Event()
-    thread_waiting = Event()
-    finish_thread = threading.Event()
-
-    is_closed_returnValue = False
-
-    def is_closed() -> bool:
-        return is_closed_returnValue
-
-    def call_soon_threadsafe(
-        callback: Callable[..., Any], *args: Any
-    ) -> asyncio.Handle:
-        if not delivery_attempted.is_set() and (
-            getattr(callback, "__self__", None).__class__ is WorkerThread
-            and getattr(callback, "__func__", None) is WorkerThread._report_result
-        ):
-            nonlocal is_closed_returnValue
-            is_closed_returnValue = True
-            real_call_soon_threadsafe(delivery_attempted.set)
-            raise RuntimeError("Event loop is closed")
-
-        return real_call_soon_threadsafe(callback, *args)
+def test_to_thread_run_sync_loop_closed_delivery_race() -> None:
+    """Drop a result that cannot be delivered after its event loop has closed."""
+    worker_started = threading.Event()
+    finish_worker = threading.Event()
+    worker_thread: threading.Thread | None = None
+    caught_exception: BaseException | None = None
 
     def thread_worker() -> None:
-        real_call_soon_threadsafe(thread_waiting.set)
-        finish_thread.wait(5)
+        nonlocal worker_thread
+        worker_thread = threading.current_thread()
+        worker_started.set()
+        finish_worker.wait(5)
 
-    monkeypatch.setattr(loop, "call_soon_threadsafe", call_soon_threadsafe)
-    monkeypatch.setattr(loop, "is_closed", is_closed)
+    def excepthook(args: Any) -> None:
+        nonlocal caught_exception
+        caught_exception = args.exc_value
 
-    with fail_after(5):
+    async def main() -> None:
         async with create_task_group() as tg:
             tg.start_soon(
                 partial(to_thread.run_sync, abandon_on_cancel=True), thread_worker
             )
-            await thread_waiting.wait()
+            with fail_after(5):
+                while not worker_started.is_set():
+                    await checkpoint()
+
             tg.cancel_scope.cancel()
 
-        finish_thread.set()
-        await delivery_attempted.wait()
+    original_excepthook = threading.excepthook
+    threading.excepthook = excepthook
+    try:
+        anyio.run(main, backend="asyncio")
+        finish_worker.set()
+        assert worker_thread is not None
+        worker_thread.join(5)
+    finally:
+        finish_worker.set()
+        threading.excepthook = original_excepthook
 
-    monkeypatch.undo()
-    assert not loop.is_closed()
-    assert await to_thread.run_sync(lambda: "bar") == "bar"
-    assert not loop.is_closed()
+    assert worker_thread is not None
+    assert not worker_thread.is_alive()
+    assert caught_exception is None
 
 
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])
 async def test_to_thread_run_sync_unrelated_runtime_error_reraised(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Exercise that an unrelated RuntimeError during result delivery is reraised."""
-    assert await to_thread.run_sync(lambda: "foo") == "foo"
-
+    """Re-raise a result-delivery RuntimeError while the event loop remains open."""
     loop = asyncio.get_running_loop()
     real_call_soon_threadsafe = loop.call_soon_threadsafe
-    delivery_attempted = Event()
-    thread_waiting = Event()
-    finish_thread = threading.Event()
-
-    caught_exception: BaseException | None = None
+    worker_started = threading.Event()
+    finish_worker = threading.Event()
     exception_received = threading.Event()
+    caught_exception: BaseException | None = None
+    raise_on_delivery = True
 
     def excepthook(args: Any) -> None:
         nonlocal caught_exception
         caught_exception = args.exc_value
         exception_received.set()
 
-    def call_soon_threadsafe(
-        callback: Callable[..., Any], *args: Any
-    ) -> asyncio.Handle:
-        if not delivery_attempted.is_set() and (
+    def call_soon_threadsafe(callback: Any, *args: Any) -> asyncio.Handle:
+        nonlocal raise_on_delivery
+        if raise_on_delivery and (
             getattr(callback, "__self__", None).__class__ is WorkerThread
             and getattr(callback, "__func__", None) is WorkerThread._report_result
         ):
-            real_call_soon_threadsafe(delivery_attempted.set)
+            raise_on_delivery = False
             raise RuntimeError("Unrelated error")
 
         return real_call_soon_threadsafe(callback, *args)
 
     def thread_worker() -> None:
-        real_call_soon_threadsafe(thread_waiting.set)
-        finish_thread.wait(5)
+        worker_started.set()
+        finish_worker.wait(5)
 
     monkeypatch.setattr(loop, "call_soon_threadsafe", call_soon_threadsafe)
 
-    orig_excepthook = threading.excepthook
+    original_excepthook = threading.excepthook
     threading.excepthook = excepthook
     try:
         with fail_after(5):
@@ -523,18 +506,17 @@ async def test_to_thread_run_sync_unrelated_runtime_error_reraised(
                 tg.start_soon(
                     partial(to_thread.run_sync, abandon_on_cancel=True), thread_worker
                 )
-                await thread_waiting.wait()
+                while not worker_started.is_set():
+                    await checkpoint()
+
                 tg.cancel_scope.cancel()
 
-            finish_thread.set()
-            await delivery_attempted.wait()
-            await to_thread.run_sync(exception_received.wait, 5)
+            finish_worker.set()
+            while not exception_received.is_set():
+                await checkpoint()
     finally:
-        threading.excepthook = orig_excepthook
+        finish_worker.set()
+        threading.excepthook = original_excepthook
 
-    monkeypatch.undo()
-    assert caught_exception is not None
     assert isinstance(caught_exception, RuntimeError)
     assert str(caught_exception) == "Unrelated error"
-
-    assert await to_thread.run_sync(lambda: "bar") == "bar"

--- a/tests/test_to_thread.py
+++ b/tests/test_to_thread.py
@@ -433,6 +433,11 @@ async def test_to_thread_run_sync_loop_closed_delivery_race(
     thread_waiting = Event()
     finish_thread = threading.Event()
 
+    is_closed_returnValue = False
+
+    def is_closed() -> bool:
+        return is_closed_returnValue
+
     def call_soon_threadsafe(
         callback: Callable[..., Any], *args: Any
     ) -> asyncio.Handle:
@@ -440,6 +445,8 @@ async def test_to_thread_run_sync_loop_closed_delivery_race(
             getattr(callback, "__self__", None).__class__ is WorkerThread
             and getattr(callback, "__func__", None) is WorkerThread._report_result
         ):
+            nonlocal is_closed_returnValue
+            is_closed_returnValue = True
             real_call_soon_threadsafe(delivery_attempted.set)
             raise RuntimeError("Event loop is closed")
 
@@ -450,6 +457,7 @@ async def test_to_thread_run_sync_loop_closed_delivery_race(
         finish_thread.wait(5)
 
     monkeypatch.setattr(loop, "call_soon_threadsafe", call_soon_threadsafe)
+    monkeypatch.setattr(loop, "is_closed", is_closed)
 
     with fail_after(5):
         async with create_task_group() as tg:
@@ -462,6 +470,71 @@ async def test_to_thread_run_sync_loop_closed_delivery_race(
         finish_thread.set()
         await delivery_attempted.wait()
 
+    monkeypatch.undo()
     assert not loop.is_closed()
     assert await to_thread.run_sync(lambda: "bar") == "bar"
     assert not loop.is_closed()
+
+
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_to_thread_run_sync_unrelated_runtime_error_reraised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise that an unrelated RuntimeError during result delivery is reraised."""
+    assert await to_thread.run_sync(lambda: "foo") == "foo"
+
+    loop = asyncio.get_running_loop()
+    real_call_soon_threadsafe = loop.call_soon_threadsafe
+    delivery_attempted = Event()
+    thread_waiting = Event()
+    finish_thread = threading.Event()
+
+    caught_exception: BaseException | None = None
+    exception_received = threading.Event()
+
+    def excepthook(args: Any) -> None:
+        nonlocal caught_exception
+        caught_exception = args.exc_value
+        exception_received.set()
+
+    def call_soon_threadsafe(
+        callback: Callable[..., Any], *args: Any
+    ) -> asyncio.Handle:
+        if not delivery_attempted.is_set() and (
+            getattr(callback, "__self__", None).__class__ is WorkerThread
+            and getattr(callback, "__func__", None) is WorkerThread._report_result
+        ):
+            real_call_soon_threadsafe(delivery_attempted.set)
+            raise RuntimeError("Unrelated error")
+
+        return real_call_soon_threadsafe(callback, *args)
+
+    def thread_worker() -> None:
+        real_call_soon_threadsafe(thread_waiting.set)
+        finish_thread.wait(5)
+
+    monkeypatch.setattr(loop, "call_soon_threadsafe", call_soon_threadsafe)
+
+    orig_excepthook = threading.excepthook
+    threading.excepthook = excepthook
+    try:
+        with fail_after(5):
+            async with create_task_group() as tg:
+                tg.start_soon(
+                    partial(to_thread.run_sync, abandon_on_cancel=True), thread_worker
+                )
+                await thread_waiting.wait()
+                tg.cancel_scope.cancel()
+
+            finish_thread.set()
+            await delivery_attempted.wait()
+            await to_thread.run_sync(exception_received.wait, 5)
+    finally:
+        threading.excepthook = orig_excepthook
+
+    monkeypatch.undo()
+    assert caught_exception is not None
+    assert isinstance(caught_exception, RuntimeError)
+    assert str(caught_exception) == "Unrelated error"
+
+    assert await to_thread.run_sync(lambda: "bar") == "bar"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

No dedicated upstream issue for this failure mode; the earlier review history lives in #1245.

Fix the asyncio worker-thread shutdown race where the loop can close after
`is_closed()` returns false but before `call_soon_threadsafe()` delivers the result.
The undeliverable result is dropped, matching the selector-thread precedent.
Deterministic regressions cover the closed-loop race, unrelated `RuntimeError`
suppression at that call site, no undeliverable future publication, and normal result
delivery.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
