### PR TITLE
Shield TemporaryDirectory cleanup from cancellation

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -46,6 +46,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   building a lookup table from the ``if TYPE_CHECKING:`` block. A fallback mode has been
   provided for installations where the source code is unavailable (e.g. PyInstaller).
   (`#1169 <https://github.com/agronholm/anyio/pull/1169>`_)
+- Fixed ``TemporaryDirectory`` not cleaning up when the host task was cancelled while
+  exiting the context manager, as the cleanup now runs in a shielded cancel scope
+  (`#1304 <https://github.com/agronholm/anyio/pull/1304>`_; PR by @smurfix)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,
   causing AnyIO to behave erroneously in relation to ``start_blocking_portal()`` and

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -46,9 +46,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   building a lookup table from the ``if TYPE_CHECKING:`` block. A fallback mode has been
   provided for installations where the source code is unavailable (e.g. PyInstaller).
   (`#1169 <https://github.com/agronholm/anyio/pull/1169>`_)
-- Fixed ``TemporaryDirectory`` not cleaning up when the host task was cancelled while
-  exiting the context manager, as the cleanup now runs in a shielded cancel scope
-  (`#1304 <https://github.com/agronholm/anyio/pull/1304>`_; PR by @smurfix)
 - Fixed free-threading compatibility issues arising from the fact that on Python 3.14
   free-threading builds, newly created threads inherit the current context by default,
   causing AnyIO to behave erroneously in relation to ``start_blocking_portal()`` and
@@ -98,6 +95,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
     task.
 
   (`#1197 <https://github.com/agronholm/anyio/issues/1197>`_; PR by @tapetersen)
+- Fixed ``TemporaryDirectory`` not cleaning up when the host task was cancelled while
+  exiting the context manager, as the cleanup now runs in a shielded cancel scope
+  (`#1304 <https://github.com/agronholm/anyio/pull/1304>`_; PR by @smurfix)
 
 **4.14.2**
 

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -17,6 +17,7 @@ from typing import (
 from .. import to_thread
 from .._core._fileio import AsyncFile
 from ..lowlevel import checkpoint_if_cancelled
+from ._tasks import CancelScope
 
 if TYPE_CHECKING:
     from _typeshed import OpenBinaryMode, OpenTextMode, ReadableBuffer, WriteableBuffer
@@ -505,9 +506,10 @@ class TemporaryDirectory(Generic[AnyStr]):
         traceback: TracebackType | None,
     ) -> None:
         if self._tempdir is not None:
-            await to_thread.run_sync(
-                self._tempdir.__exit__, exc_type, exc_value, traceback
-            )
+            with CancelScope(shield=True):
+                await to_thread.run_sync(
+                    self._tempdir.__exit__, exc_type, exc_value, traceback
+                )
 
     async def cleanup(self) -> None:
         if self._tempdir is not None:

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from anyio import (
+    CancelScope,
     NamedTemporaryFile,
     SpooledTemporaryFile,
     TemporaryDirectory,
@@ -157,6 +158,24 @@ class TestTemporaryDirectory:
 
         with pytest.raises(FileNotFoundError):
             (td_path / "nonexistent.txt").write_text("should fail", encoding="utf-8")
+
+    async def test_exit_with_cancellation(self) -> None:
+        """
+        Test that the directory is cleaned up even if the host task is cancelled
+        while exiting the context manager.
+
+        ``__aexit__`` runs the synchronous cleanup in a worker thread via
+        ``to_thread.run_sync``, which performs a cancellation checkpoint on entry.
+        Wrapping that call in a shielded cancel scope ensures that a pending
+        cancellation does not prevent the cleanup from running.
+        """
+        with CancelScope() as outer_scope:
+            async with TemporaryDirectory() as td:
+                td_path = pathlib.Path(td)
+                assert td_path.exists() and td_path.is_dir()
+                outer_scope.cancel()
+
+        assert not td_path.exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #. <!-- no linked issue -->

`TemporaryDirectory.__aexit__` ran the synchronous cleanup via `to_thread.run_sync`,
which performs a cancellation checkpoint on entry. If the host task was already
cancelled when exiting the context manager, that checkpoint aborted the cleanup before
the worker thread was even dispatched, leaking the temporary directory.

This wraps the cleanup call in a shielded `CancelScope` so that a pending cancellation
cannot prevent the cleanup from running.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
