### PR TITLE
fix: clamp negative sleep delays to zero (Fixes #1306)

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,9 +5,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Fixed ``sleep()`` raising ``ValueError`` on Trio for a negative delay (including
-  ``-inf``) while asyncio returned immediately, by clamping negative delays to zero like
-  ``sleep_until()``
+- Fixed ``sleep()`` treating a negative delay (including ``-inf``) inconsistently
+  across backends (asyncio returned immediately; Trio raised ``ValueError``) by
+  raising ``ValueError`` on all backends
   (`#1306 <https://github.com/agronholm/anyio/issues/1306>`_; PR by @BetterAndBetterII)
 
 **4.15.1**

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,13 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed ``sleep()`` raising ``ValueError`` on Trio for a negative delay (including
+  ``-inf``) while asyncio returned immediately, by clamping negative delays to zero like
+  ``sleep_until()``
+  (`#1306 <https://github.com/agronholm/anyio/issues/1306>`_; PR by @BetterAndBetterII)
+
 **4.15.1**
 
 - Implemented a compatibility fix for supporting direct access of ``anyio.*`` submodules

--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -89,9 +89,12 @@ async def sleep(delay: float) -> None:
     """
     Pause the current task for the specified duration.
 
-    :param delay: the duration, in seconds
+    :param delay: the duration, in seconds. Negative values are treated as zero.
 
     """
+    if delay < 0:
+        delay = 0
+
     return await get_async_backend().sleep(delay)
 
 

--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -92,8 +92,7 @@ async def sleep(delay: float) -> None:
     :param delay: the duration, in seconds. Negative values are treated as zero.
 
     """
-    if delay < 0:
-        delay = 0
+    delay = max(delay, 0)
 
     return await get_async_backend().sleep(delay)
 

--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -89,10 +89,13 @@ async def sleep(delay: float) -> None:
     """
     Pause the current task for the specified duration.
 
-    :param delay: the duration, in seconds. Negative values are treated as zero.
+    :param delay: the duration, in seconds. Negative values raise
+        :exc:`ValueError`.
+    :raises ValueError: if ``delay`` is negative (including ``-inf``) or NaN
 
     """
-    delay = max(delay, 0)
+    if not delay >= 0:
+        raise ValueError("delay must be a non-negative number")
 
     return await get_async_backend().sleep(delay)
 

--- a/src/anyio/_core/_eventloop.py
+++ b/src/anyio/_core/_eventloop.py
@@ -89,8 +89,7 @@ async def sleep(delay: float) -> None:
     """
     Pause the current task for the specified duration.
 
-    :param delay: the duration, in seconds. Negative values raise
-        :exc:`ValueError`.
+    :param delay: the duration, in seconds
     :raises ValueError: if ``delay`` is negative (including ``-inf``) or NaN
 
     """

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -47,12 +47,13 @@ async def test_sleep_forever(fake_sleep: AsyncMock) -> None:
     fake_sleep.assert_called_once_with(math.inf)
 
 
-@pytest.mark.parametrize("delay", [-1.0, -math.inf])
-async def test_sleep_negative_delay(delay: float) -> None:
-    """Negative delays return immediately on all backends, matching sleep(0)."""
-    start = current_time()
-    await sleep(delay)
-    assert current_time() - start < 0.1
+@pytest.mark.parametrize(
+    "delay", [-1.0, -math.inf, math.nan], ids=["negative", "neg_inf", "nan"]
+)
+async def test_sleep_invalid_delay(delay: float) -> None:
+    """Invalid delays raise ValueError on all backends."""
+    with pytest.raises(ValueError, match="delay must be a non-negative number"):
+        await sleep(delay)
 
 
 def test_run_task() -> None:

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -47,6 +47,14 @@ async def test_sleep_forever(fake_sleep: AsyncMock) -> None:
     fake_sleep.assert_called_once_with(math.inf)
 
 
+@pytest.mark.parametrize("delay", [-1.0, -math.inf])
+async def test_sleep_negative_delay(delay: float) -> None:
+    """Negative delays return immediately on all backends, matching sleep(0)."""
+    start = current_time()
+    await sleep(delay)
+    assert current_time() - start < 0.1
+
+
 def test_run_task() -> None:
     """Test that anyio.run() on asyncio will work with a callable returning a Future."""
 

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -52,8 +52,8 @@ async def test_sleep_forever(fake_sleep: AsyncMock) -> None:
     [
         pytest.param(-1.0, id="negative"),
         pytest.param(-math.inf, "neg_inf"),
-        pytest.param(math.nan, id="nan")
-    ]
+        pytest.param(math.nan, id="nan"),
+    ],
 )
 async def test_sleep_invalid_delay(delay: float) -> None:
     """Invalid delays raise ValueError on all backends."""

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -51,7 +51,7 @@ async def test_sleep_forever(fake_sleep: AsyncMock) -> None:
     "delay",
     [
         pytest.param(-1.0, id="negative"),
-        pytest.param(-math.inf, "neg_inf"),
+        pytest.param(-math.inf, id="neg_inf"),
         pytest.param(math.nan, id="nan"),
     ],
 )

--- a/tests/test_eventloop.py
+++ b/tests/test_eventloop.py
@@ -48,7 +48,12 @@ async def test_sleep_forever(fake_sleep: AsyncMock) -> None:
 
 
 @pytest.mark.parametrize(
-    "delay", [-1.0, -math.inf, math.nan], ids=["negative", "neg_inf", "nan"]
+    "delay",
+    [
+        pytest.param(-1.0, id="negative"),
+        pytest.param(-math.inf, "neg_inf"),
+        pytest.param(math.nan, id="nan")
+    ]
 )
 async def test_sleep_invalid_delay(delay: float) -> None:
     """Invalid delays raise ValueError on all backends."""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1306.

`anyio.sleep()` passed negative delays straight through to the backend. asyncio
returns immediately; trio raises `ValueError`. `sleep_until()` already clamps with
`max(..., 0)`, so clamp negative finite delays and `-inf` to zero in `sleep()` for
the same cross-backend behavior. `sleep(nan)` is unchanged (NaN comparisons are
false, so the value is still passed through).

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [x] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.