### PR TITLE
Added a workaround for third party code accessing unimported submodules

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,11 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Implemented a compatibility fix for supporting direct access of ``anyio.*`` submodules
+  from the main package even when those submodules were not directly imported first
+
 **4.15.0**
 
 - Added support for the newer keyword-only arguments on ``anyio.Path`` methods to match

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,6 +7,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 - Implemented a compatibility fix for supporting direct access of ``anyio.*`` submodules
   from the main package even when those submodules were not directly imported first
+  (`#1311 <https://github.com/agronholm/anyio/issues/1311>`)
 
 **4.15.0**
 

--- a/src/anyio/__init__.py
+++ b/src/anyio/__init__.py
@@ -120,6 +120,32 @@ if TYPE_CHECKING or not install_lazy_importer():
     from ._core._typedattr import TypedAttributeSet as TypedAttributeSet
     from ._core._typedattr import typed_attribute as typed_attribute
 
+    # ruff: isort: off
+    from . import (
+        abc as abc,
+    )
+    from . import (
+        from_thread as from_thread,
+    )
+    from . import (
+        functools as functools,
+    )
+    from . import (
+        itertools as itertools,
+    )
+    from . import (
+        lowlevel as lowlevel,
+    )
+    from . import (
+        to_interpreter as to_interpreter,
+    )
+    from . import (
+        to_process as to_process,
+    )
+    from . import (
+        to_thread as to_thread,
+    )
+
     fix_package_names()
     set_deprecated_aliases(
         {

--- a/src/anyio/_lazyimport.py
+++ b/src/anyio/_lazyimport.py
@@ -20,7 +20,7 @@ def install_lazy_importer() -> bool:
     module_name = module_globals["__name__"]
     module_prefix = module_name + "."
     module = sys.modules[module_name]
-    lazy_map, deprecated_aliases = _build_lazy_map(module)
+    lazy_map, deprecated_aliases, submodule_names = _build_lazy_map(module)
     names = sorted(lazy_map)
 
     # Delete symbols that are not part of the API
@@ -34,6 +34,14 @@ def install_lazy_importer() -> bool:
         if new_name := deprecated_aliases.get(name):
             emit_deprecation_warning(module_name, name, new_name)
             target_mod, target_attr = new_name.rsplit(".", 1)
+        elif name in submodule_names:
+            target_mod, target_attr = "." + name, ""
+            warnings.warn(
+                f"You should not access {module_name}.{name} directly without "
+                f"importing it first.",
+                FutureWarning,
+                stacklevel=2,
+            )
         else:
             try:
                 target_mod, target_attr = lazy_map[name]
@@ -43,7 +51,7 @@ def install_lazy_importer() -> bool:
                 ) from None
 
         imported = import_module(target_mod, module_name)
-        value = getattr(imported, target_attr)
+        value = getattr(imported, target_attr) if target_attr else imported
 
         # patch the module name to match
         if (
@@ -109,16 +117,17 @@ def set_deprecated_aliases(aliases: dict[str, str]) -> None:
 
 def _build_lazy_map(
     module: ModuleType,
-) -> tuple[dict[str, tuple[str, str]], dict[str, str]]:
+) -> tuple[dict[str, tuple[str, str]], dict[str, str], list[str]]:
     try:
         source = inspect.getsource(module)
     except OSError:
-        return {}, {}
+        return {}, {}, []
 
     tree = compile(source, module.__file__ or "", "exec", ast.PyCF_ONLY_AST)
     assert isinstance(tree, ast.Module)
     out: dict[str, tuple[str, str]] = {}
     deprecated_aliases: dict[str, str] = {}
+    submodule_names: list[str] = []
 
     for node in tree.body:
         if not isinstance(node, ast.If) or not _is_type_checking_block(node.test):
@@ -127,13 +136,16 @@ def _build_lazy_map(
         for stmt in node.body:
             match stmt:
                 case ast.ImportFrom():
-                    base = "." * stmt.level + (stmt.module or "")
-                    for alias in stmt.names:
-                        if alias.name == "*":
-                            raise RuntimeError("star imports not supported")
+                    if stmt.module is None:
+                        submodule_names.extend(alias.name for alias in stmt.names)
+                    else:
+                        base = "." * stmt.level + (stmt.module or "")
+                        for alias in stmt.names:
+                            if alias.name == "*":
+                                raise RuntimeError("star imports not supported")
 
-                        exported = alias.asname or alias.name
-                        out[exported] = (base, alias.name)
+                            exported = alias.asname or alias.name
+                            out[exported] = (base, alias.name)
                 case ast.Expr() if isinstance(stmt.value, ast.Call):
                     call = stmt.value
                     if (
@@ -149,7 +161,7 @@ def _build_lazy_map(
                             assert isinstance(value.value, str)
                             deprecated_aliases[key.value] = value.value
 
-    return out, deprecated_aliases
+    return out, deprecated_aliases, submodule_names
 
 
 def _is_type_checking_block(test: ast.AST) -> bool:

--- a/src/anyio/_lazyimport.py
+++ b/src/anyio/_lazyimport.py
@@ -36,12 +36,6 @@ def install_lazy_importer() -> bool:
             target_mod, target_attr = new_name.rsplit(".", 1)
         elif name in submodule_names:
             target_mod, target_attr = "." + name, ""
-            warnings.warn(
-                f"You should not access {module_name}.{name} directly without "
-                f"importing it first.",
-                FutureWarning,
-                stacklevel=2,
-            )
         else:
             try:
                 target_mod, target_attr = lazy_map[name]

--- a/tests/test_lazyimport.py
+++ b/tests/test_lazyimport.py
@@ -134,30 +134,23 @@ def test_sourceless_install(tmp_path: Path) -> None:
     assert result["deprecations"] == DEPRECATIONS
 
 
-def test_futurewarning_on_access_without_direct_import() -> None:
+def test_submodule_access_without_direct_import() -> None:
     """
     Test that accessing an anyio submodule via attribute access, without having imported
-    it directly, emits a FutureWarning advising the user to import the submodule first.
+    it directly, imports the submodule.
     """
     script = dedent(f"""\
     import json
     import sys
-    import warnings
+    import types
 
     import anyio
 
     submodules = {SUBMODULES!r}
     result = {{}}
     for name in submodules:
-        with warnings.catch_warnings(record=True) as records:
-            warnings.simplefilter("always")
-            getattr(anyio, name)
-
-        result[name] = any(
-            f"anyio.{{name}} directly without importing it first" in str(record.message)
-            for record in records
-            if issubclass(record.category, FutureWarning)
-        )
+        value = getattr(anyio, name)
+        result[name] = isinstance(value, types.ModuleType)
 
     json.dump(result, sys.stdout)
     """)

--- a/tests/test_lazyimport.py
+++ b/tests/test_lazyimport.py
@@ -20,10 +20,6 @@ DEPRECATIONS = {
     "anyio.abc.Lock": "anyio.Lock",
     "anyio.abc.Semaphore": "anyio.Semaphore",
 }
-
-# Submodules tracked by the lazy importer. Order matters: a submodule that imports
-# another tracked submodule must come after the ones it imports, so that its import does
-# not pre-set their attributes on the package and mask the expected warning.
 SUBMODULES = (
     "abc",
     "to_thread",

--- a/tests/test_lazyimport.py
+++ b/tests/test_lazyimport.py
@@ -21,6 +21,20 @@ DEPRECATIONS = {
     "anyio.abc.Semaphore": "anyio.Semaphore",
 }
 
+# Submodules tracked by the lazy importer. Order matters: a submodule that imports
+# another tracked submodule must come after the ones it imports, so that its import does
+# not pre-set their attributes on the package and mask the expected warning.
+SUBMODULES = (
+    "abc",
+    "to_thread",
+    "lowlevel",
+    "from_thread",
+    "functools",
+    "itertools",
+    "to_process",
+    "to_interpreter",
+)
+
 
 @pytest.mark.timeout(60)
 def test_sourceless_install(tmp_path: Path) -> None:
@@ -118,6 +132,43 @@ def test_sourceless_install(tmp_path: Path) -> None:
         "anyio.abc.UDPSocket": "anyio.abc",
     }
     assert result["deprecations"] == DEPRECATIONS
+
+
+def test_futurewarning_on_access_without_direct_import() -> None:
+    """
+    Test that accessing an anyio submodule via attribute access, without having imported
+    it directly, emits a FutureWarning advising the user to import the submodule first.
+    """
+    script = dedent(f"""\
+    import json
+    import sys
+    import warnings
+
+    import anyio
+
+    submodules = {SUBMODULES!r}
+    result = {{}}
+    for name in submodules:
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            getattr(anyio, name)
+
+        result[name] = any(
+            f"anyio.{{name}} directly without importing it first" in str(record.message)
+            for record in records
+            if issubclass(record.category, FutureWarning)
+        )
+
+    json.dump(result, sys.stdout)
+    """)
+
+    process = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        check=True,
+    )
+    result = json.loads(process.stdout.decode("utf-8"))
+    assert result == dict.fromkeys(SUBMODULES, True)
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

This fixes the practical issue where third party code incorrectly accessed AnyIO submodules directly from the package without importing them first. This happened to work before due to said modules being eagerly imported as a side effect.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
