### PR TITLE
Fixed get_current_task() crashing with no current task on asyncio

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -98,6 +98,12 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``TemporaryDirectory`` not cleaning up when the host task was cancelled while
   exiting the context manager, as the cleanup now runs in a shielded cancel scope
   (`#1304 <https://github.com/agronholm/anyio/pull/1304>`_; PR by @smurfix)
+- Fixed ``get_current_task()`` on the asyncio backend raising an opaque
+  ``TypeError: cannot create weak reference to 'NoneType' object`` instead of a clear
+  error when called from a callback scheduled via ``loop.call_soon_threadsafe()`` (e.g.
+  from within ``from_thread.run_sync()``), where ``asyncio.current_task()`` is
+  legitimately ``None``
+  (`#773 <https://github.com/agronholm/anyio/issues/773>`_; PR by @AmirF194)
 
 **4.14.2**
 

--- a/src/anyio/_backends/_asyncio.py
+++ b/src/anyio/_backends/_asyncio.py
@@ -3171,7 +3171,11 @@ class AsyncIOBackend(AsyncBackend):
 
     @classmethod
     def get_current_task(cls) -> TaskInfo:
-        return AsyncIOTaskInfo(current_task())  # type: ignore[arg-type]
+        task = current_task()
+        if task is None:
+            raise RuntimeError("There is no task currently running")
+
+        return AsyncIOTaskInfo(task)
 
     @classmethod
     def get_running_tasks(cls) -> Sequence[TaskInfo]:

--- a/tests/test_from_thread.py
+++ b/tests/test_from_thread.py
@@ -332,6 +332,21 @@ class TestRunSyncFromThread:
 
         assert await to_thread.run_sync(worker) == anyio_backend_name
 
+    @pytest.mark.parametrize("anyio_backend", asyncio_params)
+    async def test_get_current_task(self) -> None:
+        """
+        Regression test for #773: get_current_task() must raise a clear
+        RuntimeError, not an opaque weakref TypeError, when called from a
+        callback scheduled via loop.call_soon_threadsafe() (as from_thread.run_sync
+        does), where asyncio.current_task() is legitimately None.
+        """
+
+        def worker() -> None:
+            from_thread.run_sync(get_current_task)
+
+        with pytest.raises(RuntimeError, match="There is no task currently running"):
+            await to_thread.run_sync(worker)
+
 
 class TestBlockingPortal:
     class AsyncCM:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #773.

`run_sync_from_thread()` schedules its callback via `loop.call_soon_threadsafe()`, which runs outside of any `asyncio.Task`, so `current_task()` is `None` in there. `get_current_task()` builds `AsyncIOTaskInfo(current_task())` regardless, and `AsyncIOTaskInfo.__init__` does `_task_states.get(task)` on a `WeakKeyDictionary`, which can't weak-reference `None` and blows up with the opaque `TypeError` from the issue.

Same "no current task" case #1163 already guards for `CancelScope.__enter__` and `cancel_shielded_checkpoint()`, just a call site it doesn't touch. This raises a clear `RuntimeError` instead, matching that shape.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
