### PR TITLE
Fixed occasional bind failures with IPv6 and ephemeral ports

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,13 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Fixed ``create_tcp_listener()`` occasionally failing with a message like
+  ``Could not create 2 listeners with a consistent port`` when an ephemeral port is
+  requested and IPv6 is enabled and the dual-stack path is not available or a specific
+  local host name was given
+
 **4.15.1**
 
 - Implemented a compatibility fix for supporting direct access of ``anyio.*`` submodules

--- a/src/anyio/_core/_sockets.py
+++ b/src/anyio/_core/_sockets.py
@@ -393,7 +393,7 @@ async def create_tcp_listener(
 
     errors: list[OSError] = []
     try:
-        for _ in range(len(sockaddrs)):
+        for _ in range(10):  # enough to absorb ephemeral port collisions
             listeners: list[SocketListener] = []
             bound_ephemeral_port = local_port
             try:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

This adds more retries for ephemeral ports, reducing the chances of random failure to a negligible number.

These failures were the number 1 cause of test suite flakiness.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
