### PR TITLE
Added cancel shielding to AsyncFile.aclose()

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -13,6 +13,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   ``Could not create 2 listeners with a consistent port`` when an ephemeral port is
   requested and IPv6 is enabled and the dual-stack path is not available or a specific
   local host name was given
+- Fixed ``AsyncFile`` not shielding against cancellation while closing
+  (`#1314 <https://github.com/agronholm/anyio/pull/1314>`_)
 
 **4.15.1**
 

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -25,7 +25,7 @@ from typing import (
     overload,
 )
 
-from .. import to_thread
+from .. import CancelScope, to_thread
 from ..abc import AsyncResource
 from ._synchronization import CapacityLimiter
 
@@ -114,7 +114,8 @@ class AsyncFile(AsyncResource, Generic[AnyStr]):
                 break
 
     async def aclose(self) -> None:
-        return await to_thread.run_sync(self._fp.close, limiter=self._limiter)
+        with CancelScope(shield=True):
+            await to_thread.run_sync(self._fp.close, limiter=self._limiter)
 
     async def read(self, size: int = -1) -> AnyStr:
         return await to_thread.run_sync(self._fp.read, size, limiter=self._limiter)

--- a/src/anyio/_core/_fileio.py
+++ b/src/anyio/_core/_fileio.py
@@ -25,9 +25,10 @@ from typing import (
     overload,
 )
 
-from .. import CancelScope, to_thread
+from .. import to_thread
 from ..abc import AsyncResource
 from ._synchronization import CapacityLimiter
+from ._tasks import CancelScope
 
 if sys.version_info >= (3, 11):
     from typing import Self

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -93,7 +93,7 @@ class TestAsyncFile:
 
         assert path.read_text() == "dummydata"
 
-    async def test_shieled_aclose(self, tmp_path: pathlib.Path) -> None:
+    async def test_shielded_aclose(self, tmp_path: pathlib.Path) -> None:
         async with await open_file(tmp_path / "foo", "wb") as f:
             with CancelScope() as scope:
                 scope.cancel()

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -12,7 +12,14 @@ import pytest
 from _pytest.fixtures import FixtureRequest
 from _pytest.tmpdir import TempPathFactory
 
-from anyio import AsyncFile, CapacityLimiter, Path, open_file, wrap_file
+from anyio import (
+    AsyncFile,
+    CancelScope,
+    CapacityLimiter,
+    Path,
+    open_file,
+    wrap_file,
+)
 
 
 @pytest.fixture(params=[False, True])
@@ -85,6 +92,14 @@ class TestAsyncFile:
             await wrapped.write("dummydata")
 
         assert path.read_text() == "dummydata"
+
+    async def test_shieled_aclose(self, tmp_path: pathlib.Path) -> None:
+        async with await open_file(tmp_path / "foo", "wb") as f:
+            with CancelScope() as scope:
+                scope.cancel()
+                await f.aclose()
+
+            assert f.closed
 
 
 class TestPath:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

This is a follow-up to https://github.com/agronholm/anyio/pull/1304 which fixes the same problem for ``AsyncFile``.

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
