### PR TITLE
Shield TemporaryDirectory.cleanup() from cancellation

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -15,6 +15,10 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   local host name was given
 - Fixed ``AsyncFile`` not shielding against cancellation while closing
   (`#1314 <https://github.com/agronholm/anyio/pull/1314>`_)
+- Fixed ``TemporaryDirectory.cleanup()`` not cleaning up when the host task was
+  already cancelled, as the cleanup now runs in a shielded cancel scope like
+  ``__aexit__`` does (see `#1304 <https://github.com/agronholm/anyio/pull/1304>`_,
+  which shielded ``__aexit__`` but left ``cleanup()`` unshielded)
 
 **4.15.1**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -17,8 +17,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   (`#1314 <https://github.com/agronholm/anyio/pull/1314>`_)
 - Fixed ``TemporaryDirectory.cleanup()`` not cleaning up when the host task was
   already cancelled, as the cleanup now runs in a shielded cancel scope like
-  ``__aexit__`` does (see `#1304 <https://github.com/agronholm/anyio/pull/1304>`_,
-  which shielded ``__aexit__`` but left ``cleanup()`` unshielded)
+  ``__aexit__`` does
+  (`#1316 <https://github.com/agronholm/anyio/pull/1316>`_; PR by @Yasser-Ameur)
 
 **4.15.1**
 

--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -513,7 +513,8 @@ class TemporaryDirectory(Generic[AnyStr]):
 
     async def cleanup(self) -> None:
         if self._tempdir is not None:
-            await to_thread.run_sync(self._tempdir.cleanup)
+            with CancelScope(shield=True):
+                await to_thread.run_sync(self._tempdir.cleanup)
 
 
 @overload

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -177,6 +177,28 @@ class TestTemporaryDirectory:
 
         assert not td_path.exists()
 
+    async def test_cleanup_method_with_cancellation(self) -> None:
+        """
+        Test that the ``cleanup()`` method removes the directory even if the host
+        task is already cancelled when it is called.
+
+        ``cleanup()`` runs the synchronous cleanup in a worker thread via
+        ``to_thread.run_sync``, which performs a cancellation checkpoint on entry.
+        Wrapping that call in a shielded cancel scope ensures that a pending
+        cancellation does not prevent the cleanup from running, matching
+        ``__aexit__``.
+        """
+        td = TemporaryDirectory()
+        td_str = await td.__aenter__()
+        td_path = pathlib.Path(td_str)
+        assert td_path.exists() and td_path.is_dir()
+
+        with CancelScope() as outer_scope:
+            outer_scope.cancel()
+            await td.cleanup()
+
+        assert not td_path.exists()
+
 
 @pytest.mark.parametrize(
     "suffix, prefix, text, content",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #. <!-- no linked issue -->

`TemporaryDirectory.cleanup()` runs its cleanup through `to_thread.run_sync`, which
checkpoints on entry. When the host task is already cancelled, and it usually is,
because `cleanup()` gets awaited from a `finally:` block during unwind, the checkpoint
aborts before the worker thread runs and the directory is left on disk.

#1304 fixed exactly this for `__aexit__` with a shielded `CancelScope`. `cleanup()`, a
few lines below, kept the unshielded call. This gives it the same shield. The other
`to_thread.run_sync` teardown in the module, `AsyncFile.aclose()`, was already shielded
by #1314, so this was the last one.

`test_cleanup_method_with_cancellation` mirrors the test #1304 added for `__aexit__`.
It fails on the unmodified tree on all four backend variants and passes with the fix.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
