### PR TITLE
Shield file stream cleanup from cancellation

### DIFF
--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -219,6 +219,10 @@ File streams read from or write to files on the file system. They can be useful 
 substituting a file for another source of data, or writing output to a file for logging
 or debugging purposes.
 
+Closing a file stream, including when leaving its asynchronous context manager, waits
+for the file to close even if the calling task has been cancelled. For write streams,
+this also flushes buffered output before closing the file.
+
 Example::
 
     from anyio import run

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -219,10 +219,6 @@ File streams read from or write to files on the file system. They can be useful 
 substituting a file for another source of data, or writing output to a file for logging
 or debugging purposes.
 
-Closing a file stream, including when leaving its asynchronous context manager, waits
-for the file to close even if the calling task has been cancelled. For write streams,
-this also flushes buffered output before closing the file.
-
 Example::
 
     from anyio import run

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -15,6 +15,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   local host name was given
 - Fixed ``AsyncFile`` not shielding against cancellation while closing
   (`#1314 <https://github.com/agronholm/anyio/pull/1314>`_)
+- Fixed ``FileReadStream`` and ``FileWriteStream`` leaving files open when cancelled
+  during context manager exit, including unflushed writes (PR by @Kuang-xianxin)
 
 **4.15.1**
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -16,7 +16,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Fixed ``AsyncFile`` not shielding against cancellation while closing
   (`#1314 <https://github.com/agronholm/anyio/pull/1314>`_)
 - Fixed ``FileReadStream`` and ``FileWriteStream`` leaving files open when cancelled
-  during context manager exit, including unflushed writes (PR by @Kuang-xianxin)
+  during context manager exit, including unflushed writes
+  (`#1318 <https://github.com/agronholm/anyio/pull/1318>`_; PR by @Kuang-xianxin)
 
 **4.15.1**
 

--- a/src/anyio/streams/file.py
+++ b/src/anyio/streams/file.py
@@ -14,6 +14,7 @@ from typing import IO, Any
 
 from .. import (
     BrokenResourceError,
+    CancelScope,
     ClosedResourceError,
     EndOfStream,
     TypedAttributeSet,
@@ -37,7 +38,8 @@ class _BaseFileStream:
         self._file = file
 
     async def aclose(self) -> None:
-        await to_thread.run_sync(self._file.close)
+        with CancelScope(shield=True):
+            await to_thread.run_sync(self._file.close)
 
     @property
     def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:

--- a/src/anyio/streams/file.py
+++ b/src/anyio/streams/file.py
@@ -22,6 +22,7 @@ from .. import (
     typed_attribute,
 )
 from ..abc import ByteReceiveStream, ByteSendStream
+from ..lowlevel import checkpoint_if_cancelled
 
 
 class FileStreamAttribute(TypedAttributeSet):
@@ -40,6 +41,8 @@ class _BaseFileStream:
     async def aclose(self) -> None:
         with CancelScope(shield=True):
             await to_thread.run_sync(self._file.close)
+
+        await checkpoint_if_cancelled()
 
     @property
     def extra_attributes(self) -> Mapping[Any, Callable[[], Any]]:

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -7,7 +7,7 @@ import pytest
 from _pytest.fixtures import SubRequest
 from _pytest.tmpdir import TempPathFactory
 
-from anyio import CancelScope, ClosedResourceError, EndOfStream
+from anyio import CancelScope, ClosedResourceError, EndOfStream, get_cancelled_exc_class
 from anyio.streams.file import FileReadStream, FileStreamAttribute, FileWriteStream
 
 if TYPE_CHECKING:
@@ -53,8 +53,9 @@ class TestFileReadStream:
         file = stream.extra(FileStreamAttribute.file)
         try:
             with CancelScope() as scope:
-                async with stream:
-                    scope.cancel()
+                with pytest.raises(get_cancelled_exc_class()):
+                    async with stream:
+                        scope.cancel()
 
             assert file.closed
         finally:
@@ -122,8 +123,9 @@ class TestFileWriteStream:
         file = stream.extra(FileStreamAttribute.file)
         try:
             with CancelScope() as scope:
-                async with stream:
-                    scope.cancel()
+                with pytest.raises(get_cancelled_exc_class()):
+                    async with stream:
+                        scope.cancel()
 
             assert file.closed
         finally:

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -7,7 +7,8 @@ import pytest
 from _pytest.fixtures import SubRequest
 from _pytest.tmpdir import TempPathFactory
 
-from anyio import ClosedResourceError, EndOfStream
+import anyio.lowlevel
+from anyio import CancelScope, ClosedResourceError, EndOfStream
 from anyio.streams.file import FileReadStream, FileStreamAttribute, FileWriteStream
 
 if TYPE_CHECKING:
@@ -47,6 +48,22 @@ class TestFileReadStream:
 
         with pytest.raises(ClosedResourceError):
             await stream.receive()
+
+    async def test_close_on_cancel(self, file_path: Path) -> None:
+        stream = await FileReadStream.from_path(file_path)
+        file = stream.extra(FileStreamAttribute.file)
+        try:
+            with CancelScope() as scope:
+                async with stream:
+                    scope.cancel()
+
+                await anyio.lowlevel.checkpoint()
+                pytest.fail("Cancellation was not propagated")
+
+            assert scope.cancelled_caught
+            assert file.closed
+        finally:
+            file.close()
 
     @pytest.mark.parametrize("max_bytes", [0, -1])
     async def test_receive_invalid_max_bytes(
@@ -104,6 +121,24 @@ class TestFileWriteStream:
 
         with pytest.raises(ClosedResourceError):
             await stream.send(b"foo")
+
+    async def test_close_on_cancel(self, file_path: Path) -> None:
+        stream = await FileWriteStream.from_path(file_path)
+        file = stream.extra(FileStreamAttribute.file)
+        try:
+            with CancelScope() as scope:
+                async with stream:
+                    await stream.send(b"Hello")
+                    scope.cancel()
+
+                await anyio.lowlevel.checkpoint()
+                pytest.fail("Cancellation was not propagated")
+
+            assert scope.cancelled_caught
+            assert file.closed
+            assert file_path.read_bytes() == b"Hello"
+        finally:
+            file.close()
 
     async def test_extra_attributes(self, file_path: Path) -> None:
         async with await FileWriteStream.from_path(file_path) as stream:

--- a/tests/streams/test_file.py
+++ b/tests/streams/test_file.py
@@ -7,7 +7,6 @@ import pytest
 from _pytest.fixtures import SubRequest
 from _pytest.tmpdir import TempPathFactory
 
-import anyio.lowlevel
 from anyio import CancelScope, ClosedResourceError, EndOfStream
 from anyio.streams.file import FileReadStream, FileStreamAttribute, FileWriteStream
 
@@ -57,10 +56,6 @@ class TestFileReadStream:
                 async with stream:
                     scope.cancel()
 
-                await anyio.lowlevel.checkpoint()
-                pytest.fail("Cancellation was not propagated")
-
-            assert scope.cancelled_caught
             assert file.closed
         finally:
             file.close()
@@ -128,15 +123,9 @@ class TestFileWriteStream:
         try:
             with CancelScope() as scope:
                 async with stream:
-                    await stream.send(b"Hello")
                     scope.cancel()
 
-                await anyio.lowlevel.checkpoint()
-                pytest.fail("Cancellation was not propagated")
-
-            assert scope.cancelled_caught
             assert file.closed
-            assert file_path.read_bytes() == b"Hello"
         finally:
             file.close()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->



**NOTE** Erasing or replacing the contents of this template will result in your pull

request being summarily closed without consideration!



## Changes

Related to #1314. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

When a cancelled task exits a `FileReadStream` or `FileWriteStream` context,
`to_thread.run_sync()` can raise before dispatching `file.close()`, leaving the
file open. Shield the shared close operation, then call
`checkpoint_if_cancelled()` after the file is closed so cancellation is delivered
by the close operation itself.

The regressions use public `from_path()` contexts and assert that closing both
releases the real file and propagates cancellation. They have no independent
checkpoint, scope-state or ordinary write/read-back assertions.

Validation on Python 3.13.14 / Windows:
- Both regressions fail on the original implementation because files remain open,
  and on the shield-only version because close does not raise cancellation.
  Each comparison has 8 failures across asyncio, winloop, eager asyncio and Trio.
- Final file-stream, AsyncFile and stapled-stream tests: 131 passed.
- Non-mypy pre-commit checks and focused source/test mypy pass.
- The full configured mypy hook has known Windows baseline diagnostics. The
  earlier wider file/path run had 372 passes, 96 skips and 76 Windows symlink
  failures/setup errors; all 76 also reproduced on the unchanged base. These
  platform-dependent checks are not claimed as passing.

The changelog records the fix; no user-guide addition is needed for expected
cleanup behavior.

## Checklist



If this is a user-facing code change, like a bugfix or a new feature, please ensure that

you've fulfilled the following conditions (where applicable):



- [x] You've added tests (in `tests/`) which would fail without your patch

- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new

features

- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).



If this is a trivial change, like a typo fix or a code reformatting, then you can ignore

these instructions.



### Updating the changelog



If there are no entries after the last release, use `**UNRELEASED**` as the version.

If, say, your patch fixes issue <span>#</span>123, the entry should look like this:



```

- Fix big bad boo-boo in task groups

  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)

```



If there's no issue linked, just link to your pull request instead by updating the

changelog after you've created the PR.

