### PR TITLE
Allow Condition.notify() when underlying lock is held directly

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,6 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
+- Fixed ``Condition.notify()`` and ``Condition.notify_all()`` failing when the underlying lock was acquired directly rather than through the condition
+  (`#1319 <https://github.com/agronholm/anyio/issues/1319>`_; PR by @GruffElixir)
 - Fixed ``sleep()`` treating a negative delay (including ``-inf``) inconsistently
   across backends (asyncio returned immediately; Trio raised ``ValueError``) by
   raising ``ValueError`` on all backends

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,8 +5,6 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
 
-- Fixed ``Condition.notify()`` and ``Condition.notify_all()`` failing when the underlying lock was acquired directly rather than through the condition
-  (`#1319 <https://github.com/agronholm/anyio/issues/1319>`_; PR by @GruffElixir)
 - Fixed ``sleep()`` treating a negative delay (including ``-inf``) inconsistently
   across backends (asyncio returned immediately; Trio raised ``ValueError``) by
   raising ``ValueError`` on all backends
@@ -17,6 +15,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   local host name was given
 - Fixed ``AsyncFile`` not shielding against cancellation while closing
   (`#1314 <https://github.com/agronholm/anyio/pull/1314>`_)
+- Fixed ``Condition.notify()`` and ``Condition.notify_all()`` failing when the underlying lock was acquired directly rather than through the condition
+  (`#1319 <https://github.com/agronholm/anyio/issues/1319>`_; PR by @GruffElixir)
 
 **4.15.1**
 

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -274,10 +274,9 @@ class LockAdapter(Lock):
 
 
 class Condition:
-    __slots__ = "__weakref__", "_lock", "_owner_task", "_waiters"
+    __slots__ = "__weakref__", "_lock", "_waiters"
 
     def __init__(self, lock: Lock | None = None):
-        self._owner_task: TaskInfo | None = None
         self._lock = lock or Lock()
         self._waiters: deque[Event] = deque()
 
@@ -292,6 +291,10 @@ class Condition:
     ) -> None:
         self.release()
 
+    @property
+    def _owner_task(self) -> TaskInfo | None:
+        return self._lock.statistics().owner
+
     def _check_acquired(self) -> None:
         if self._owner_task != get_current_task():
             raise RuntimeError("The current task is not holding the underlying lock")
@@ -299,7 +302,6 @@ class Condition:
     async def acquire(self) -> None:
         """Acquire the underlying lock."""
         await self._lock.acquire()
-        self._owner_task = get_current_task()
 
     def acquire_nowait(self) -> None:
         """
@@ -309,7 +311,6 @@ class Condition:
 
         """
         self._lock.acquire_nowait()
-        self._owner_task = get_current_task()
 
     def release(self) -> None:
         """Release the underlying lock."""

--- a/src/anyio/_core/_synchronization.py
+++ b/src/anyio/_core/_synchronization.py
@@ -291,12 +291,8 @@ class Condition:
     ) -> None:
         self.release()
 
-    @property
-    def _owner_task(self) -> TaskInfo | None:
-        return self._lock.statistics().owner
-
     def _check_acquired(self) -> None:
-        if self._owner_task != get_current_task():
+        if self._lock.statistics().owner != get_current_task():
             raise RuntimeError("The current task is not holding the underlying lock")
 
     async def acquire(self) -> None:

--- a/tests/test_synchronization.py
+++ b/tests/test_synchronization.py
@@ -439,6 +439,34 @@ class TestCondition:
         ):
             await condition.wait()
 
+    async def test_notify_with_shared_lock(self) -> None:
+        lock = Lock()
+        condition = Condition(lock)
+        async with lock:
+            condition.notify()
+            condition.notify_all()
+
+    async def test_notify_no_lock(self) -> None:
+        condition = Condition()
+        with pytest.raises(
+            RuntimeError, match="The current task is not holding the underlying lock"
+        ):
+            condition.notify()
+
+        with pytest.raises(
+            RuntimeError, match="The current task is not holding the underlying lock"
+        ):
+            condition.notify_all()
+
+    async def test_notify_after_release(self) -> None:
+        condition = Condition()
+        await condition.acquire()
+        condition.release()
+        with pytest.raises(
+            RuntimeError, match="The current task is not holding the underlying lock"
+        ):
+            condition.notify()
+
     async def test_statistics(self) -> None:
         async def waiter() -> None:
             async with condition:


### PR DESCRIPTION
## Changes

Fixes #1319.

Update `Condition` to determine the owner task dynamically from the underlying lock's statistics (`self._lock.statistics().owner`) instead of storing `_owner_task` separately only within `Condition.acquire()` and `Condition.acquire_nowait()`.

This resolves two issues:
1. `Condition.notify()` and `Condition.notify_all()` can now be called when the underlying lock is acquired directly (such as when multiple conditions share the same lock).
2. `Condition.notify()` now raises `RuntimeError` if called after the lock has been released (previously `_owner_task` was retained on the condition instance after release).

## Checklist

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
