### PR TITLE
Fixed wrong parameter name in SpooledTemporaryFile.write() docstring

### DIFF
--- a/src/anyio/_core/_tempfile.py
+++ b/src/anyio/_core/_tempfile.py
@@ -410,7 +410,7 @@ class SpooledTemporaryFile(AsyncFile[AnyStr]):
         If the file has not yet been rolled over, the data is written synchronously,
         and a rollover is triggered if the size exceeds the maximum size.
 
-        :param s: The data to write.
+        :param b: The data to write.
         :return: The number of bytes written.
         :raises RuntimeError: If the underlying file is not initialized.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

No issue filed; found by comparing `:param` names against real signatures across the source tree.

`SpooledTemporaryFile.write()` documents `:param s:`, but the parameter is named `b`:

```python
async def write(self, b: ReadableBuffer | str) -> int:
    ...
    :param s: The data to write.
```

`docs/api.rst:99` renders the class with `.. autoclass:: anyio.SpooledTemporaryFile`, and `docs/conf.py:30` sets `autodoc_default_options = {"members": True, ...}`, so the wrong name is what readers of the published API docs see. Following it fails:

```
documented :param names : ['s']
actual parameter names  : ['b']

write(s=...) -> TypeError: SpooledTemporaryFile.write() got an unexpected keyword argument 's'
write(b=...) -> wrote 5 bytes
```

(run against `master` @ `bd0d696`, before the change)

`writelines()` directly below already documents its real parameter name (`:param lines:`), and every other `:param` in `_tempfile.py` matches its signature — `write()` is the only one that does not. This is the whole change: one character in one docstring, no behaviour change.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [ ] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

I've treated this as a trivial change per that last line, so the three boxes are left unticked: there is no behaviour to test, no `docs/` page to update beyond the docstring itself, and a changelog line for a one-character docstring correction seemed like noise. Say the word if you'd rather have a `versionhistory.rst` entry and I'll add one.

I did still run the suite for the touched module: `pytest tests/test_tempfile.py` gives **72 passed** with both backends present (trio installed), and `ruff format --check` / `ruff check` are clean on the file. macOS arm64, Python 3.14 — CI will need to confirm the rest of the matrix.

One thing I deliberately left alone: the two `@overload` stubs above `write()` also name the parameter `b`, so they already agree with the implementation and needed no change.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.

---

Disclosure, per `AGENTS.md`: this was prepared with AI assistance (Claude). I checked the open PR list first — #1316 and #1216 are the only open PRs touching `_tempfile.py` and neither goes near this docstring, so this is not a duplicate.
