### PR TITLE
Fix AnyIO imports with loaders that omit __file__

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -15,6 +15,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   local host name was given
 - Fixed ``AsyncFile`` not shielding against cancellation while closing
   (`#1314 <https://github.com/agronholm/anyio/pull/1314>`_)
+- Fixed importing AnyIO with loaders that do not provide ``__file__``, such as
+  PyOxidizer, raising ``TypeError`` instead of falling back to eager imports
+  (`#1322 <https://github.com/agronholm/anyio/issues/1322>`_; PR by @skulitom)
 
 **4.15.1**
 

--- a/src/anyio/_lazyimport.py
+++ b/src/anyio/_lazyimport.py
@@ -114,7 +114,7 @@ def _build_lazy_map(
 ) -> tuple[dict[str, tuple[str, str]], dict[str, str], list[str]]:
     try:
         source = inspect.getsource(module)
-    except OSError:
+    except (OSError, TypeError):
         return {}, {}, []
 
     tree = compile(source, module.__file__ or "", "exec", ast.PyCF_ONLY_AST)

--- a/tests/test_lazyimport.py
+++ b/tests/test_lazyimport.py
@@ -130,6 +130,45 @@ def test_sourceless_install(tmp_path: Path) -> None:
     assert result["deprecations"] == DEPRECATIONS
 
 
+def test_import_without_module_file() -> None:
+    """Test the eager fallback for loaders that do not set module.__file__."""
+    script = dedent("""\
+    import sys
+    import warnings
+    from importlib.machinery import PathFinder, SourceFileLoader
+
+    class FilelessLoader(SourceFileLoader):
+        def exec_module(self, module):
+            del module.__file__
+            super().exec_module(module)
+
+    class FilelessFinder:
+        @staticmethod
+        def find_spec(fullname, path=None, target=None):
+            if fullname in ("anyio", "anyio.abc"):
+                spec = PathFinder.find_spec(fullname, path)
+                spec.loader = FilelessLoader(fullname, spec.origin)
+                return spec
+
+    sys.meta_path.insert(0, FilelessFinder)
+    import anyio.abc
+
+    assert "__file__" not in vars(anyio)
+    assert "__file__" not in vars(anyio.abc)
+    assert anyio.sleep.__module__ == "anyio"
+    assert anyio.abc.UDPSocket.__module__ == "anyio.abc"
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always", DeprecationWarning)
+        assert anyio.abc.Condition is anyio.Condition
+
+    assert len(records) == 1
+    assert records[0].category is DeprecationWarning
+    anyio.run(anyio.sleep, 0)
+    """)
+
+    subprocess.run([sys.executable, "-c", script], check=True)
+
+
 def test_submodule_access_without_direct_import() -> None:
     """
     Test that accessing an anyio submodule via attribute access, without having imported

--- a/tests/test_lazyimport.py
+++ b/tests/test_lazyimport.py
@@ -7,10 +7,12 @@ import subprocess
 import sys
 from pathlib import Path
 from textwrap import dedent
+from types import ModuleType
 
 import pytest
 
 import anyio.abc
+from anyio._lazyimport import _build_lazy_map
 
 DEPRECATIONS = {
     "anyio.BrokenWorkerIntepreter": "anyio.BrokenWorkerInterpreter",
@@ -130,43 +132,10 @@ def test_sourceless_install(tmp_path: Path) -> None:
     assert result["deprecations"] == DEPRECATIONS
 
 
-def test_import_without_module_file() -> None:
-    """Test the eager fallback for loaders that do not set module.__file__."""
-    script = dedent("""\
-    import sys
-    import warnings
-    from importlib.machinery import PathFinder, SourceFileLoader
-
-    class FilelessLoader(SourceFileLoader):
-        def exec_module(self, module):
-            del module.__file__
-            super().exec_module(module)
-
-    class FilelessFinder:
-        @staticmethod
-        def find_spec(fullname, path=None, target=None):
-            if fullname in ("anyio", "anyio.abc"):
-                spec = PathFinder.find_spec(fullname, path)
-                spec.loader = FilelessLoader(fullname, spec.origin)
-                return spec
-
-    sys.meta_path.insert(0, FilelessFinder)
-    import anyio.abc
-
-    assert "__file__" not in vars(anyio)
-    assert "__file__" not in vars(anyio.abc)
-    assert anyio.sleep.__module__ == "anyio"
-    assert anyio.abc.UDPSocket.__module__ == "anyio.abc"
-    with warnings.catch_warnings(record=True) as records:
-        warnings.simplefilter("always", DeprecationWarning)
-        assert anyio.abc.Condition is anyio.Condition
-
-    assert len(records) == 1
-    assert records[0].category is DeprecationWarning
-    anyio.run(anyio.sleep, 0)
-    """)
-
-    subprocess.run([sys.executable, "-c", script], check=True)
+def test_build_lazy_map_without_module_file() -> None:
+    """Test the eager fallback when a module has no __file__ attribute."""
+    module = ModuleType("fileless_module")
+    assert _build_lazy_map(module) == ({}, {}, [])
 
 
 def test_submodule_access_without_direct_import() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**NOTE** Erasing or replacing the contents of this template will result in your pull
request being summarily closed without consideration!

## Changes

Fixes #1322. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

Handle `TypeError` from `inspect.getsource()` with the existing eager-import fallback, alongside `OSError`. This lets loaders that omit `__file__` import AnyIO instead of crashing.

The regression is a small in-process test: a `ModuleType` without `__file__` naturally raises `TypeError` in `inspect.getsource()`, and the test asserts that `_build_lazy_map()` returns the empty maps used by the eager fallback. It adds no subprocess or custom loader. The existing sourceless-install test covers eager imports, public module names, and deprecated aliases.

Validation of the updated test on Windows:

- The new regression fails with the reported `TypeError` when the exception-handler change is removed.
- `pytest tests/test_lazyimport.py -q`: **6 passed** on Python 3.10.16 and **6 passed** on Python 3.13.2.
- Pre-commit checks for the changed file pass, with mypy run separately using the hook's version and arguments plus `--platform linux`: **78 source files pass**. Native Windows mypy previously showed platform-specific errors also present on unchanged upstream.
- `git diff --check` passes.

Prepared and self-reviewed with Codex. No PyOxidizer executable was built. No public API or usage-documentation change is needed; the changelog records the fallback fix.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) which would fail without your patch
- [ ] You've updated the documentation (in `docs/`), in case of behavior changes or new
features
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue <span>#</span>123, the entry should look like this:

```
- Fix big bad boo-boo in task groups
  (`#123 <https://github.com/agronholm/anyio/issues/123>`_; PR by @yourgithubaccount)
```

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
